### PR TITLE
 shortened: query strings // changed: browsing

### DIFF
--- a/Deezer/dist/presence.js
+++ b/Deezer/dist/presence.js
@@ -45,16 +45,16 @@ var strings = presence.getStrings({
 });
 var live, prevLive, elapsed;
 presence.on("UpdateData", function () { return __awaiter(_this, void 0, void 0, function () {
-    var player, player_button, player_button_aria, paused, on_air, title, author, audioTime, audioDuration, timestamps, title, author, timestamps, data, _a, _b, _c, details, state, playlist, album, artist, podcast;
+    var player, player_button, player_button_aria, paused, on_air, title, author, audioTime, audioDuration, timestamps, title, author, timestamps, data, _a, _b, _c, details, state, header, playlist, album, artist, podcast;
     return __generator(this, function (_d) {
         switch (_d.label) {
             case 0:
-                player = document.querySelector("#page_player > div");
+                player = document.querySelector(".page-player");
                 if (!player) return [3 /*break*/, 7];
-                player_button = document.querySelector("#page_player > div > div.player-controls > ul > li:nth-child(3) > button");
+                player_button = document.querySelector(".svg-icon-group-item:nth-child(3)");
                 player_button_aria = player_button.getAttribute("aria-label");
-                paused = player_button_aria === "Play";
-                on_air = document.querySelector("#page_player > div > div.player-track > div > div.track-heading > span");
+                paused = document.querySelector(".svg-icon-group-item:nth-child(3) .svg-icon-pause") === null;
+                on_air = document.querySelector(".track-label");
                 if (on_air && on_air.textContent == "ON AIR") {
                     live = true;
                     if (prevLive !== live) {
@@ -66,14 +66,18 @@ presence.on("UpdateData", function () { return __awaiter(_this, void 0, void 0, 
                     live = false;
                 }
                 if (!live) {
-                    title = document.querySelector("#page_player > div > div.player-track > div > div.track-heading > div.track-title > div > div > div > a:nth-child(1)").textContent;
-                    author = document.querySelector("#page_player > div > div.player-track > div > div.track-heading > div.track-title > div > div > div > a:nth-child(2)").textContent;
-                    audioTime = document.querySelector("#page_player > div > div.player-track > div > div.track-seekbar > div > div.slider-counter.slider-counter-current").textContent;
-                    audioDuration = document.querySelector("#page_player > div > div.player-track > div > div.track-seekbar > div > div.slider-counter.slider-counter-max").textContent;
+                    title = document.querySelector(".track-link:nth-child(1)")
+                        .textContent;
+                    author = document.querySelector(".track-link:nth-child(2)")
+                        .textContent;
+                    audioTime = document.querySelector(".slider-counter-current")
+                        .textContent;
+                    audioDuration = document.querySelector(".slider-counter-max")
+                        .textContent;
                     timestamps = getTimestamps(audioTime, audioDuration);
                 }
                 else {
-                    title = document.querySelector("#page_player > div > div.player-track > div > div.track-heading > div.track-title > div > div > div").textContent;
+                    title = document.querySelector(".marquee-content").textContent;
                     author = "On Air";
                     timestamps = [elapsed, undefined];
                 }
@@ -112,25 +116,25 @@ presence.on("UpdateData", function () { return __awaiter(_this, void 0, void 0, 
                 if (timestamps[0] === timestamps[1]) {
                     details = "Browsing...";
                     state = undefined;
-                    playlist = document.querySelector("#page_naboo_playlist > div.catalog-content > div > div.catalog-header > div.header-info.has-info-list > h1");
+                    header = document.querySelector("div.header-infos.ellipsis > h1");
+                    playlist = document.querySelector("#page_naboo_playlist");
                     if (playlist) {
-                        details = "Viewing " + playlist.textContent;
-                        state = "Playlist";
+                        details = "Viewing Playlist";
                     }
-                    album = document.querySelector("#page_naboo_album > div:nth-child(1) > div > div.catalog-header > div.header-info.has-info-list > h1");
+                    album = document.querySelector("#page_naboo_album");
                     if (album) {
-                        details = "Viewing " + album.textContent;
-                        state = "Album";
+                        details = "Viewing Album";
                     }
-                    artist = document.querySelector("#page_naboo_artist > div.catalog-header > div > div.catalog-header-infos > div.header-infos.ellipsis > h1");
+                    artist = document.querySelector("#page_naboo_artist");
                     if (artist) {
-                        details = "Viewing " + artist.textContent;
-                        state = "Artist";
+                        details = "Viewing Artist";
                     }
-                    podcast = document.querySelector("#page_naboo_show > div.catalog-content > div > div.catalog-header > div.header-info > h1");
+                    podcast = document.querySelector("#page_naboo_podcast");
                     if (podcast) {
-                        details = "Viewing " + podcast.textContent;
-                        state = "Podcast";
+                        details = "Viewing Podcast";
+                    }
+                    if (header) {
+                        state = header.textContent;
                     }
                     presence.setActivity({
                         details: details,
@@ -152,15 +156,15 @@ presence.on("UpdateData", function () { return __awaiter(_this, void 0, void 0, 
 presence.on("MediaKeys", function (key) {
     switch (key) {
         case "pause":
-            var pause_button = document.querySelector("#page_player > div > div.player-controls > ul > li:nth-child(3) > button");
+            var pause_button = document.querySelector(".svg-icon-group-item:nth-child(3)");
             pause_button.click();
             break;
         case "nextTrack":
-            var next_button = document.querySelector("#page_player > div > div.player-controls > ul > li:nth-child(5) > div > button");
+            var next_button = document.querySelector(".svg-icon-group-item:nth-child(5)");
             next_button.click();
             break;
         case "previousTrack":
-            var prev_button = document.querySelector("#page_player > div > div.player-controls > ul > li:nth-child(1) > div > button");
+            var prev_button = document.querySelector(".svg-icon-group-item:nth-child(1)");
             prev_button.click();
             break;
     }

--- a/Deezer/presence.ts
+++ b/Deezer/presence.ts
@@ -11,19 +11,20 @@ var strings = presence.getStrings({
 var live, prevLive, elapsed;
 
 presence.on("UpdateData", async () => {
-  var player = document.querySelector("#page_player > div");
+  var player = document.querySelector(".page-player");
 
   if (player) {
     var player_button = document.querySelector(
-      "#page_player > div > div.player-controls > ul > li:nth-child(3) > button"
+      ".svg-icon-group-item:nth-child(3)"
     );
     var player_button_aria = player_button.getAttribute("aria-label");
 
-    var paused = player_button_aria === "Play";
+    var paused =
+      document.querySelector(
+        ".svg-icon-group-item:nth-child(3) .svg-icon-pause"
+      ) === null;
 
-    var on_air = document.querySelector(
-      "#page_player > div > div.player-track > div > div.track-heading > span"
-    );
+    var on_air = document.querySelector(".track-label");
 
     if (on_air && on_air.textContent == "ON AIR") {
       live = true;
@@ -36,23 +37,17 @@ presence.on("UpdateData", async () => {
     }
 
     if (!live) {
-      var title = document.querySelector(
-        "#page_player > div > div.player-track > div > div.track-heading > div.track-title > div > div > div > a:nth-child(1)"
-      ).textContent;
-      var author = document.querySelector(
-        "#page_player > div > div.player-track > div > div.track-heading > div.track-title > div > div > div > a:nth-child(2)"
-      ).textContent;
-      var audioTime = document.querySelector(
-        "#page_player > div > div.player-track > div > div.track-seekbar > div > div.slider-counter.slider-counter-current"
-      ).textContent;
-      var audioDuration = document.querySelector(
-        "#page_player > div > div.player-track > div > div.track-seekbar > div > div.slider-counter.slider-counter-max"
-      ).textContent;
+      var title = document.querySelector(".track-link:nth-child(1)")
+        .textContent;
+      var author = document.querySelector(".track-link:nth-child(2)")
+        .textContent;
+      var audioTime = document.querySelector(".slider-counter-current")
+        .textContent;
+      var audioDuration = document.querySelector(".slider-counter-max")
+        .textContent;
       var timestamps = getTimestamps(audioTime, audioDuration);
     } else {
-      var title = document.querySelector(
-        "#page_player > div > div.player-track > div > div.track-heading > div.track-title > div > div > div"
-      ).textContent;
+      var title = document.querySelector(".marquee-content").textContent;
       var author = "On Air";
       var timestamps: number[] = [elapsed, undefined];
     }
@@ -81,36 +76,30 @@ presence.on("UpdateData", async () => {
       var details = "Browsing...";
       var state = undefined;
 
-      var playlist = document.querySelector(
-        "#page_naboo_playlist > div.catalog-content > div > div.catalog-header > div.header-info.has-info-list > h1"
-      );
+      var header = document.querySelector("div.header-infos.ellipsis > h1");
+
+      var playlist = document.querySelector("#page_naboo_playlist");
       if (playlist) {
-        details = "Viewing " + playlist.textContent;
-        state = "Playlist";
+        details = "Viewing Playlist";
       }
 
-      var album = document.querySelector(
-        "#page_naboo_album > div:nth-child(1) > div > div.catalog-header > div.header-info.has-info-list > h1"
-      );
+      var album = document.querySelector("#page_naboo_album");
       if (album) {
-        details = "Viewing " + album.textContent;
-        state = "Album";
+        details = "Viewing Album";
       }
 
-      var artist = document.querySelector(
-        "#page_naboo_artist > div.catalog-header > div > div.catalog-header-infos > div.header-infos.ellipsis > h1"
-      );
+      var artist = document.querySelector("#page_naboo_artist");
       if (artist) {
-        details = "Viewing " + artist.textContent;
-        state = "Artist";
+        details = "Viewing Artist";
       }
 
-      var podcast = document.querySelector(
-        "#page_naboo_show > div.catalog-content > div > div.catalog-header > div.header-info > h1"
-      );
+      var podcast = document.querySelector("#page_naboo_podcast");
       if (podcast) {
-        details = "Viewing " + podcast.textContent;
-        state = "Podcast";
+        details = "Viewing Podcast";
+      }
+
+      if (header) {
+        state = header.textContent;
       }
 
       presence.setActivity(
@@ -133,19 +122,19 @@ presence.on("MediaKeys", (key: string) => {
   switch (key) {
     case "pause":
       var pause_button = document.querySelector(
-        "#page_player > div > div.player-controls > ul > li:nth-child(3) > button"
+        ".svg-icon-group-item:nth-child(3)"
       );
       pause_button.click();
       break;
     case "nextTrack":
       var next_button = document.querySelector(
-        "#page_player > div > div.player-controls > ul > li:nth-child(5) > div > button"
+        ".svg-icon-group-item:nth-child(5)"
       );
       next_button.click();
       break;
     case "previousTrack":
       var prev_button = document.querySelector(
-        "#page_player > div > div.player-controls > ul > li:nth-child(1) > div > button"
+        ".svg-icon-group-item:nth-child(1)"
       );
       prev_button.click();
       break;

--- a/Deezer/presence.ts
+++ b/Deezer/presence.ts
@@ -14,11 +14,6 @@ presence.on("UpdateData", async () => {
   var player = document.querySelector(".page-player");
 
   if (player) {
-    var player_button = document.querySelector(
-      ".svg-icon-group-item:nth-child(3)"
-    );
-    var player_button_aria = player_button.getAttribute("aria-label");
-
     var paused =
       document.querySelector(
         ".svg-icon-group-item:nth-child(3) .svg-icon-pause"

--- a/SoundCloud/dist/metadata.json
+++ b/SoundCloud/dist/metadata.json
@@ -10,5 +10,5 @@
   "logo": "https://i.imgur.com/KgOkfIz.png",
   "thumbnail": "https://i.imgur.com/eZyrvbS.jpg",
   "color": "#FF7E30",
-  "tags": ["SoundCloud", "music"]
+  "tags": ["soundcloud", "music"]
 }

--- a/SoundCloud/dist/presence.js
+++ b/SoundCloud/dist/presence.js
@@ -43,19 +43,18 @@ var strings = presence.getStrings({
     pause: "presence.playback.paused"
 });
 presence.on("UpdateData", function () { return __awaiter(_this, void 0, void 0, function () {
-    var player, player_button, player_button_aria, paused, title, author, audioTime, audioDuration, timestamps, data, _a, _b;
+    var player, player_button, paused, title, author, audioTime, audioDuration, timestamps, data, _a, _b;
     return __generator(this, function (_c) {
         switch (_c.label) {
             case 0:
-                player = document.querySelector("#app > div.playControls.g-z-index-control-bar.m-visible.m-googleCastActive > section");
+                player = document.querySelector(".playControls__elements");
                 if (!player) return [3 /*break*/, 5];
-                player_button = document.querySelector("#app > div.playControls.g-z-index-control-bar.m-visible.m-googleCastActive > section > div > div.playControls__elements > button.playControl.sc-ir.playControls__control.playControls__play");
-                player_button_aria = player_button.getAttribute("aria-label");
-                paused = player_button_aria === "Play current";
-                title = document.querySelector("#app > div.playControls.g-z-index-control-bar.m-visible.m-googleCastActive > section > div > div.playControls__elements > div.playControls__soundBadge > div > div.playbackSoundBadge__titleContextContainer > div > a > span:nth-child(2)").textContent;
-                author = document.querySelector("#app > div.playControls.g-z-index-control-bar.m-visible.m-googleCastActive > section > div > div.playControls__elements > div.playControls__soundBadge > div > div.playbackSoundBadge__titleContextContainer > a").textContent;
-                audioTime = document.querySelector("#app > div.playControls.g-z-index-control-bar.m-visible.m-googleCastActive > section > div > div.playControls__elements > div.playControls__timeline > div > div.playbackTimeline__timePassed > span:nth-child(2)").textContent;
-                audioDuration = document.querySelector("#app > div.playControls.g-z-index-control-bar.m-visible.m-googleCastActive > section > div > div.playControls__elements > div.playControls__timeline > div > div.playbackTimeline__duration > span:nth-child(2)").textContent;
+                player_button = document.querySelector(".playControls__play");
+                paused = player_button.classList.contains("playing") === false;
+                title = document.querySelector(".playbackSoundBadge__titleContextContainer > div span:nth-child(2)").textContent;
+                author = document.querySelector(".playbackSoundBadge__titleContextContainer > a").textContent;
+                audioTime = document.querySelector(".playbackTimeline__timePassed span:nth-child(2)").textContent;
+                audioDuration = document.querySelector(".playbackTimeline__duration span:nth-child(2)").textContent;
                 timestamps = getTimestamps(audioTime, audioDuration);
                 _a = {
                     details: title,
@@ -95,15 +94,15 @@ presence.on("UpdateData", function () { return __awaiter(_this, void 0, void 0, 
 presence.on("MediaKeys", function (key) {
     switch (key) {
         case "pause":
-            var pause_button = document.querySelector("#app > div.playControls.g-z-index-control-bar.m-visible.m-googleCastActive > section > div > div.playControls__elements > button.playControl.sc-ir.playControls__control.playControls__play");
+            var pause_button = document.querySelector(".playControls__play");
             pause_button.click();
             break;
         case "nextTrack":
-            var next_button = document.querySelector("#app > div.playControls.g-z-index-control-bar.m-visible.m-googleCastActive > section > div > div.playControls__elements > button.skipControl.sc-ir.playControls__control.playControls__next.skipControl__next");
+            var next_button = document.querySelector(".skipControl__next");
             next_button.click();
             break;
         case "previousTrack":
-            var prev_button = document.querySelector("#app > div.playControls.g-z-index-control-bar.m-visible.m-googleCastActive > section > div > div.playControls__elements > button.skipControl.sc-ir.playControls__control.playControls__prev.skipControl__previous");
+            var prev_button = document.querySelector(".skipControl__previous");
             prev_button.click();
             break;
     }

--- a/SoundCloud/presence.ts
+++ b/SoundCloud/presence.ts
@@ -8,29 +8,24 @@ var strings = presence.getStrings({
 });
 
 presence.on("UpdateData", async () => {
-  var player = document.querySelector(
-    "#app > div.playControls.g-z-index-control-bar.m-visible.m-googleCastActive > section"
-  );
+  var player = document.querySelector(".playControls__elements");
 
   if (player) {
-    var player_button = document.querySelector(
-      "#app > div.playControls.g-z-index-control-bar.m-visible.m-googleCastActive > section > div > div.playControls__elements > button.playControl.sc-ir.playControls__control.playControls__play"
-    );
-    var player_button_aria = player_button.getAttribute("aria-label");
+    var player_button = document.querySelector(".playControls__play");
 
-    var paused = player_button_aria === "Play current";
+    var paused = player_button.classList.contains("playing") === false;
 
     var title = document.querySelector(
-      "#app > div.playControls.g-z-index-control-bar.m-visible.m-googleCastActive > section > div > div.playControls__elements > div.playControls__soundBadge > div > div.playbackSoundBadge__titleContextContainer > div > a > span:nth-child(2)"
+      ".playbackSoundBadge__titleContextContainer > div span:nth-child(2)"
     ).textContent;
     var author = document.querySelector(
-      "#app > div.playControls.g-z-index-control-bar.m-visible.m-googleCastActive > section > div > div.playControls__elements > div.playControls__soundBadge > div > div.playbackSoundBadge__titleContextContainer > a"
+      ".playbackSoundBadge__titleContextContainer > a"
     ).textContent;
     var audioTime = document.querySelector(
-      "#app > div.playControls.g-z-index-control-bar.m-visible.m-googleCastActive > section > div > div.playControls__elements > div.playControls__timeline > div > div.playbackTimeline__timePassed > span:nth-child(2)"
+      ".playbackTimeline__timePassed span:nth-child(2)"
     ).textContent;
     var audioDuration = document.querySelector(
-      "#app > div.playControls.g-z-index-control-bar.m-visible.m-googleCastActive > section > div > div.playControls__elements > div.playControls__timeline > div > div.playbackTimeline__duration > span:nth-child(2)"
+      ".playbackTimeline__duration span:nth-child(2)"
     ).textContent;
     var timestamps = getTimestamps(audioTime, audioDuration);
 
@@ -60,21 +55,15 @@ presence.on("UpdateData", async () => {
 presence.on("MediaKeys", (key: string) => {
   switch (key) {
     case "pause":
-      var pause_button = document.querySelector(
-        "#app > div.playControls.g-z-index-control-bar.m-visible.m-googleCastActive > section > div > div.playControls__elements > button.playControl.sc-ir.playControls__control.playControls__play"
-      );
+      var pause_button = document.querySelector(".playControls__play");
       pause_button.click();
       break;
     case "nextTrack":
-      var next_button = document.querySelector(
-        "#app > div.playControls.g-z-index-control-bar.m-visible.m-googleCastActive > section > div > div.playControls__elements > button.skipControl.sc-ir.playControls__control.playControls__next.skipControl__next"
-      );
+      var next_button = document.querySelector(".skipControl__next");
       next_button.click();
       break;
     case "previousTrack":
-      var prev_button = document.querySelector(
-        "#app > div.playControls.g-z-index-control-bar.m-visible.m-googleCastActive > section > div > div.playControls__elements > button.skipControl.sc-ir.playControls__control.playControls__prev.skipControl__previous"
-      );
+      var prev_button = document.querySelector(".skipControl__previous");
       prev_button.click();
       break;
   }


### PR DESCRIPTION
Query selecting strings are much shorter and should be more accurate. When your control bar, at the bottom, is not playing anything and is at 00:00, it will display the "browsing" message. Along with extra information when the user visits playlists, albums, artists, and podcasts.

Ready to be deployed, mention me on the discord server if there are issues.

This edit applies to both Deezer and SoundCloud.