### PR TITLE
Toradora Wikia Presence

### DIFF
--- a/ToradorAPI/dist/metadata.json
+++ b/ToradorAPI/dist/metadata.json
@@ -17,5 +17,5 @@
     "logo": "https://crugg.de/premid/tapilogo.png",
     "thumbnail": "https://crugg.de/premid/tapibanner.png",
     "color": "#F9304B",
-    "tags": [ "anime", "manga", "images", "random" ]
+    "tags": [ "anime", "manga", "images", "random", "toradora" ]
 }

--- a/Toradora Wikia/dist/metadata.json
+++ b/Toradora Wikia/dist/metadata.json
@@ -1,0 +1,17 @@
+{
+  "author": {
+    "name": "CRUGG",
+    "id": "228965621478588416"
+  },
+  "service": "Toradora Wikia",
+  "description": {
+    "en": "Presence for the english & german wikias of the anime Toradora!",
+    "de": "Präsenz für die englischen & deutschen Wikias über den Anime Toradora!"
+  },
+  "url": ["tora-dora.fandom.com", "toradora.fandom.com"],
+  "version": "2.0",
+  "logo": "https://crugg.de/premid/tapilogo.png",
+  "thumbnail": "https://crugg.de/premid/tapibanner.png",
+  "color": "#F9304B",
+  "tags": ["anime", "toradora"]
+}

--- a/Toradora Wikia/dist/presence.js
+++ b/Toradora Wikia/dist/presence.js
@@ -1,0 +1,56 @@
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var englishPresence = new Presence({
+    clientId: "613417749489778689",
+    mediaKeys: false
+});
+var germanPresence = new Presence({
+    clientId: "613418400042975329",
+    mediaKeys: false
+});
+englishPresence.on("UpdateData", () => __awaiter(this, void 0, void 0, function* () {
+    if (document.location.href.includes("tora-dora.fandom.com")) {
+        if (document.location.pathname.startsWith("/wiki/")) {
+            let page = "N/A";
+            try {
+                page = document.getElementsByClassName("page-header__title")[0].textContent;
+            }
+            catch (err) {
+                let errCode = "TWIKI_WIKIEN_GETPAGETITLE";
+                console.log("An error occured in the PreMiD Presence, please send this to CRUGG#0001   :::   " + errCode + "   :::   " + err);
+            }
+            let presenceData = {
+                details: "Viewing a page...",
+                state: page,
+                largeImageKey: "lg-twiki"
+            };
+            englishPresence.setActivity(presenceData);
+        }
+    }
+    germanPresence.on("UpdateData", () => __awaiter(this, void 0, void 0, function* () {
+        if (document.location.href.includes("toradora.fandom.com")) {
+            if (document.location.pathname.startsWith("/de/wiki/")) {
+                let page = "N/A";
+                try {
+                    page = document.getElementsByClassName("page-header__title")[0].textContent;
+                }
+                catch (err) {
+                    let errCode = "TWIKI_WIKIDE_GETPAGETITLE";
+                    console.log("An error occured in the PreMiD Presence, please send this to CRUGG#0001   :::   " + errCode + "   :::   " + err);
+                }
+                let presenceData = {
+                    details: "Schaut eine Seite an...",
+                    state: page,
+                    largeImageKey: "lg-twiki"
+                };
+                germanPresence.setActivity(presenceData);
+            }
+        }
+    }));
+}));

--- a/Toradora Wikia/presence.ts
+++ b/Toradora Wikia/presence.ts
@@ -1,0 +1,54 @@
+/*
+  There is currently a bug, where sometimes the presence flickers (at least for the german wiki, not occured with the english one yet)
+  This is probably caused by the two presences. If anyone has an idea how to fix, be happy to do a pull request or tell me on Discord CRUGG#0001
+*/
+
+var englishPresence = new Presence({
+  clientId: "613417749489778689",
+  mediaKeys: false
+});
+var germanPresence = new Presence({
+  clientId: "613418400042975329",
+  mediaKeys: false
+});
+
+englishPresence.on("UpdateData", async () => {
+  if(document.location.href.includes("tora-dora.fandom.com")) {
+    // English Wiki
+    if(document.location.pathname.startsWith("/wiki/")) { // Making 100% sure it's the english wiki
+      let page = "N/A";
+      try {
+        page = document.getElementsByClassName("page-header__title")[0].textContent;
+      } catch (err) {
+        let errCode = "TWIKI_WIKIEN_GETPAGETITLE"
+        console.log("An error occured in the PreMiD Presence, please send this to CRUGG#0001   :::   " + errCode + "   :::   " + err);
+      }
+      let presenceData: presenceData = {
+        details: "Viewing a page...",
+        state: page,
+        largeImageKey: "lg-twiki"
+       };
+       englishPresence.setActivity(presenceData);
+    }
+  }
+  germanPresence.on("UpdateData", async () => {
+    if(document.location.href.includes("toradora.fandom.com")) {
+      // German Wiki
+      if(document.location.pathname.startsWith("/de/wiki/")) { // Making 100% sure it's the german wiki
+      let page = "N/A";
+      try {
+        page = document.getElementsByClassName("page-header__title")[0].textContent;
+      } catch (err) {
+        let errCode = "TWIKI_WIKIDE_GETPAGETITLE"
+        console.log("An error occured in the PreMiD Presence, please send this to CRUGG#0001   :::   " + errCode + "   :::   " + err);
+      }
+      let presenceData: presenceData = {
+        details: "Schaut eine Seite an...",
+        state: page,
+        largeImageKey: "lg-twiki"
+       };
+       germanPresence.setActivity(presenceData);
+    }
+    }
+  })
+});

--- a/Toradora Wikia/tsconfig.json
+++ b/Toradora Wikia/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/"
+  }
+}


### PR DESCRIPTION
Added Toradora Wikia Presence and changed the tags of ToradorAPI to also have the tag "Toradora" as there are now two presences focused around Toradora.