### PR TITLE
Add Fandom Presence

### DIFF
--- a/Fandom/dist/metadata.json
+++ b/Fandom/dist/metadata.json
@@ -1,0 +1,22 @@
+{
+   "author": {
+      "name": "Hans5958",
+      "id": "279855717203050496"
+   },
+   "service": "Fandom",
+   "url": "fandom.com",
+   "version": "1.0.0",
+   "logo": "https://i.imgur.com/sko4P3c.png",
+   "thumbnail": "https://i.imgur.com/VrVSD2b.png",
+   "color": "#002A32",
+   "tags": [
+      "encyclopedia",
+      "popular",
+      "informations"
+   ],
+   "description": {
+      "en": "The entertainment site where fans come first. Your daily source for all things TV, movies, and games, including Star Wars, Fallout, Marvel, DC and more."
+   },
+   "category": "others",
+   "regExp": "[a-zA-Z-]+\\.fandom\\.com"
+}

--- a/Fandom/dist/presence.js
+++ b/Fandom/dist/presence.js
@@ -1,0 +1,160 @@
+let presence = new Presence({
+	clientId: "644400074008297512",
+	mediaKeys: false
+});
+
+let browsingStamp = Math.floor(Date.now() / 1000);
+let title, sitename;
+let href = new URL(document.location.href);
+
+presence.on("UpdateData", async () => {
+
+	let presenceData = {
+		details: "In construction",
+		state: "-",
+		largeImageKey: "lg"
+	};
+
+	if (href.pathname.includes("/wiki/")) {
+
+		let actionResult = href.searchParams.get("action") || href.searchParams.get("veaction");
+		let titleFromURL = () => {
+			if (href.pathname.startsWith("/wiki/")) {
+				raw = href.pathname.slice(6);
+			} else {
+				lang = href.pathname.split("/")[0];
+				raw = href.pathname.slice(7 + lang.length);
+			}
+			if (raw.includes("_")) return raw.replace(/_/g, " ");
+			else return raw;
+		};
+
+		try {
+			title = document.querySelector('.page-header__title').innerText;
+		} catch (e) {
+			title = null;
+		}
+
+		try {
+			sitename = document.querySelector("meta[property='og:site_name']").content;
+		} catch (e) {
+			sitename = null;
+		}
+
+		if (title === "Home") {
+			sitename = document.querySelector("meta[property='og:title']").content;
+			presenceData.state = "Home";
+			delete presenceData.details;
+		} else if (actionResult == "history" && titleFromURL) {
+			presenceData.details = "Viewing revision history";
+			presenceData.state = titleFromURL();
+		} else if (actionResult == "edit" && titleFromURL) {
+			if (href.searchParams.has("action")) title = document.querySelector("#EditPageHeader").children[2].innerText;
+			presenceData.details = "Editing a wiki page";
+			presenceData.state = titleFromURL();
+		} else if (href.pathname.includes("User:")) {
+			presenceData.details = "Reading a user page";
+			presenceData.state = titleFromURL();
+		} else if (href.pathname.includes("User_talk:")) {
+			presenceData.details = "Reading a user talk page";
+			presenceData.state = titleFromURL();
+		} else if (href.pathname.includes("User_blog:")) {
+			if (title) {
+				presenceData.details = "Reading a user blog post";
+				presenceData.state = title + " by " + document.querySelector(".page-header__blog-post-details").firstElementChild.innerText;
+			} else {
+				presenceData.details = "Reading a user blog";
+				presenceData.state = titleFromURL();
+			}
+		} else {
+			if (href.pathname.includes("Thread:")) presenceData.details = "Reading a forum thread";
+			else if (href.pathname.includes("Board:")) presenceData.details = "Looking at a forum board";
+			else if (href.pathname.includes("Special:")) presenceData.details = "Reading a special page";
+			else if (href.pathname.includes("Talk:")) presenceData.details = "Reading a talk page";
+			else if (href.pathname.includes("Category:")) presenceData.details = "Looking at a category";
+			else if (href.pathname.includes("File:")) presenceData.details = "Looking at a file";
+			else presenceData.details = "Reading a wiki page";
+			presenceData.state = title || titleFromURL();
+		}
+
+		presenceData.startTimestamp = browsingStamp;
+		presenceData.state += " | " + sitename;
+
+	} else if (href.host === "www.fandom.com") {
+
+		if (href.pathname === "/") {
+			presenceData.state = "Index";
+			presenceData.startTimestamp = browsingStamp;
+			delete presenceData.details;
+		} else if (href.pathname.includes("/signin")) {
+			presenceData.details = "Signing in";
+			presenceData.startTimestamp = browsingStamp;
+			delete presenceData.state;
+		} else if (href.pathname.includes("/register")) {
+			presenceData.details = "Registering an account";
+			presenceData.startTimestamp = browsingStamp;
+			delete presenceData.details;
+		} else if (href.pathname.includes("/articles/")) {
+			presenceData.details = "Reading an article";
+			presenceData.state = document.querySelector(".article-header__title").innerText;
+			presenceData.startTimestamp = browsingStamp;
+		} else if (href.pathname.includes("/topics/")) {
+			presenceData.details = "Looking at a topic";
+			presenceData.state = document.querySelector(".topic-header__title").firstElementChild.innerHTML;
+			presenceData.startTimestamp = browsingStamp;
+		} else if (href.pathname.includes("/video")) {
+			presenceData.details = "Watching a video";
+			presenceData.state = document.querySelector(".video-page-featured-player__title").innerText;
+			try {
+				if (document.querySelector(".jw-icon-playback").getAttribute("aria-label") === "Pause") {
+					video = document.querySelector(".jw-video");
+					let timestamps = getTimestamps(Math.floor(video.currentTime), Math.floor(video.duration));
+					presenceData.startTimestamp = timestamps[0];
+					presenceData.endTimestamp = timestamps[1];
+				}
+			} catch (err) {
+				presenceData.startTimestamp = browsingStamp;
+			}
+		} else if (href.pathname.includes("/curated/")) {
+			presenceData.details = "Looking at a curation";
+			presenceData.state = document.querySelector(".card__title").innerText;
+			presenceData.startTimestamp = browsingStamp;
+		} else {
+			presenceData.details = "Reading a page";
+			if (href.pathname.includes("/explore")) presenceData.state = "Explore";
+			else if (href.pathname.includes("/about")) presenceData.state = "About";
+			else if (href.pathname.includes("/carriers")) presenceData.state = "Carriers";
+			else if (href.pathname.includes("/terms-of-use")) presenceData.state = "Terms of Use";
+			else if (href.pathname.includes("/privacy-policy")) presenceData.state = "Privacy Policy";
+			else if (href.pathname.includes("/mediakit")) presenceData.state = "Media Kit";
+			else if (href.pathname.includes("/local-sitemap")) presenceData.state = "Local Sitemap";
+			presenceData.startTimestamp = browsingStamp;
+		}
+
+	} else if (href.pathname === "/f" || href.pathname.includes("/f/")) {
+
+		href = new URL(document.location.href);
+
+		if (href.pathname === "/f") {
+			presenceData.details = "Looking at the discussion page";
+			delete presenceData.state;
+		} else if (href.pathname.includes("/p/")) {
+			presenceData.details = "Reading an discussion post";
+			presenceData.state = document.querySelector(".post__title").innerText;
+		} else if (href.pathname.includes("/u/")) {
+			presenceData.details = "Looking at a discussion user page";
+			presenceData.state = document.querySelector(".user-overview__username").innerText;
+		}
+		
+		presenceData.startTimestamp = browsingStamp;
+
+	}
+
+	presence.setActivity(presenceData);
+});
+
+function getTimestamps(videoTime, videoDuration) {
+	let startTime = Date.now();
+	let endTime = Math.floor(startTime / 1000) - videoTime + videoDuration;
+	return [Math.floor(startTime / 1000), endTime];
+}


### PR DESCRIPTION
# Preface

This is a presence for fandom.com/*.fandom.com (also known as FANDOM and FANDOM powered by Wikia). This presence is made so every page on the fandom.com site is detectable, whether is the Fandom part (those articles, videos, etc) and the Wikia part (wikis with MediaWiki)

Due to the nature of different implementations of the pages on the website ([to the point they even acknowledge it](https://community.fandom.com/wiki/User_blog:MisterWoodhouse/Fandom_is_upgrading_to_a_modern_version_of_MediaWiki)), it took a while on making this presence so it supports vast majority of the pages compared on making a Wikipedia presence.

This is my first presence, hope this is get accepted.

# Notes

There are multiple thumbnails that I have prepared for this presence. I tried to make those so it shows the Fandom part and the Wikia part. Although reviewers may override this to show the other per request.
- https://i.imgur.com/VrVSD2b.png (on the pull request, showing both parts)
- https://i.imgur.com/Dpe2sna.png (alternative version of the top)
- https://i.imgur.com/f764pIp.png (Fandom part, as visiting www.fandom.com)
- https://i.imgur.com/TtWWjvF.png (Community Central, core of the Wikia part, on [community.fandom.com](https://community.fandom.com))

This also answered issue #655, and replacing multiple Wikia presences (Love Live! Wikia, Kimi no Na wa Wikia, and Toradora Wikia)

*Addendum 1*: The presence is based on the Wikipedia presence, although it is heavily customized for more coverage. Some presences are also used for references.

# Images
| Image | Link visited |
| -- | -- |
|![2019-12-01_18-35-44](https://user-images.githubusercontent.com/11584103/69913545-8265fe80-146b-11ea-8d27-6c3701377f27.png)|https://www.fandom.com/topics/movies|
|![2019-12-01_18-40-50](https://user-images.githubusercontent.com/11584103/69913531-69f5e400-146b-11ea-9677-fb80e559caf9.png)|https://www.fandom.com/articles/death-stranding-america-cable|
|![2019-12-01_18-43-13](https://user-images.githubusercontent.com/11584103/69913532-69f5e400-146b-11ea-860b-9b8de81e3db5.png)|https://www.fandom.com/video/US7ixl9l/honest-game-trailers-untitled-goose-game|
|![2019-12-01_18-43-41](https://user-images.githubusercontent.com/11584103/69913533-6a8e7a80-146b-11ea-879a-c8939185f326.png)|https://community.fandom.com/wiki/Community_Central|
|![2019-12-01_18-44-36](https://user-images.githubusercontent.com/11584103/69913534-6a8e7a80-146b-11ea-8477-a669bb32c056.png)|https://lego.fandom.com/wiki/Classic|
|![2019-12-01_18-45-24](https://user-images.githubusercontent.com/11584103/69913535-6bbfa780-146b-11ea-91df-e4a1cdd0fadb.png)|https://lego.fandom.com/wiki/Category:Themes|
|![2019-12-01_18-46-35](https://user-images.githubusercontent.com/11584103/69913536-6bbfa780-146b-11ea-8e3e-03e84fce1e77.png)|https://community.fandom.com/wiki/User:Hans5958|
|![2019-12-01_18-46-51](https://user-images.githubusercontent.com/11584103/69913537-6c583e00-146b-11ea-9132-7155f2aaa587.png)|https://community.fandom.com/wiki/Special:Statistics|
|![2019-12-01_18-47-17](https://user-images.githubusercontent.com/11584103/69913538-6c583e00-146b-11ea-9f2a-b9eea2e291a6.png)|https://www.fandom.com/signin|
