### PR TITLE
Pocket Casts: Fix hours

### DIFF
--- a/Pocket Casts/dist/metadata.json
+++ b/Pocket Casts/dist/metadata.json
@@ -8,7 +8,7 @@
     "en": "All the features you need in a podcasting app without any of the bloat. Podcast listening turned up to 11."
   },
   "url": "play.pocketcasts.com",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/dyQLFDS.png",
   "thumbnail": "https://i.imgur.com/AJS6zcg.png",
   "color": "#F43E37",

--- a/Pocket Casts/dist/presence.js
+++ b/Pocket Casts/dist/presence.js
@@ -48,7 +48,11 @@ presence.on("UpdateData", async () => {
 		presenceData.state = document.getElementsByClassName("podcast-title player_podcast_title")[0].textContent;
 
 		var time = document.getElementsByClassName("time-text current-time")[0].textContent.split(":").map(n => Number(n));
-		presenceData.startTimestamp = Date.now() - ((time[0] * 60 + time[1]) * 1000);
+		if (time.length == 3) {
+			presenceData.startTimestamp = Date.now() - ((time[0] * 3600 + time[1] * 60 + time[2]) * 1000);
+		} else {
+			presenceData.startTimestamp = Date.now() - ((time[0] * 60 + time[1]) * 1000);
+		};
 
 		if (document.getElementsByClassName("pause_button").length == 0) {
 			presenceData.smallImageKey = "pause";


### PR DESCRIPTION
Fixes the timestamp when a podcast is 60 minutes or longer (e.g. 01:02 -> 01:02:03).