### PR TITLE
feat: add presence for skyra.pw

### DIFF
--- a/Skyra/dist/metadata.json
+++ b/Skyra/dist/metadata.json
@@ -1,0 +1,17 @@
+{
+  "author": {
+    "name": "Favna",
+    "id": "268792781713965056"
+  },
+  "url": "skyra.pw",
+  "description": {
+    "en": "A fully customizable server moderation Discord bot for your Discord server that features a simple and intuitive web dashboard. Server management just got a whole lot easier."
+  },
+  "service": "Skyra",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/vUk6eWg.png",
+  "thumbnail": "https://i.imgur.com/4C39tqP.png",
+  "color": "#7087D8",
+  "tags": ["bot", "discord"],
+  "category": "other"
+}

--- a/Skyra/dist/presence.js
+++ b/Skyra/dist/presence.js
@@ -1,0 +1,43 @@
+var presence = new Presence({
+    clientId: "266624760782258186"
+});
+var browsingStamp = Math.floor(Date.now() / 1000);
+var title;
+presence.on("UpdateData", async () => {
+    var presenceData = {
+        largeImageKey: "skyra"
+    };
+    if (document.location.hostname === "skyra.pw") {
+        presenceData.startTimestamp = browsingStamp;
+        if (document.location.pathname.includes("/guilds/")) {
+            presenceData.details = "Managing server settings";
+            title = document.querySelector("[data-premid='server-title']");
+            presenceData.state = "server: " + title.textContent;
+            presenceData.smallImageKey = "writing";
+        }
+        else if (document.location.pathname.includes("/music/")) {
+            presenceData.details = "Spinning the turntables";
+            title = document.querySelector("[data-premid='music-title']");
+            if (title !== null) {
+                presenceData.state = "Currently Playing: " + title.textContent;
+            }
+            presenceData.smallImageKey = "play";
+        }
+        else if (document.location.pathname === "/commands") {
+            presenceData.details = "Browsing Skyra's commands";
+            presenceData.smallImageKey = "reading";
+        }
+        else {
+            presenceData.details = "Checking out Skyra";
+            presenceData.smallImageKey = "reading";
+        }
+    }
+    if (presenceData.details == null) {
+        presence.setTrayTitle();
+        presence.setActivity();
+    }
+    else {
+        presence.setActivity(presenceData);
+    }
+});
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicHJlc2VuY2UuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyIuLi9wcmVzZW5jZS50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxJQUFJLFFBQVEsR0FBRyxJQUFJLFFBQVEsQ0FBQztJQUMxQixRQUFRLEVBQUUsb0JBQW9CO0NBQy9CLENBQUMsQ0FBQztBQUVILElBQUksYUFBYSxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLEdBQUcsRUFBRSxHQUFHLElBQUksQ0FBQyxDQUFDO0FBRWxELElBQUksS0FBYyxDQUFDO0FBRW5CLFFBQVEsQ0FBQyxFQUFFLENBQUMsWUFBWSxFQUFFLEtBQUssSUFBSSxFQUFFO0lBQ25DLElBQUksWUFBWSxHQUFpQjtRQUMvQixhQUFhLEVBQUUsT0FBTztLQUN2QixDQUFDO0lBRUYsSUFBSSxRQUFRLENBQUMsUUFBUSxDQUFDLFFBQVEsS0FBSyxVQUFVLEVBQUU7UUFDN0MsWUFBWSxDQUFDLGNBQWMsR0FBRyxhQUFhLENBQUM7UUFFNUMsSUFBSSxRQUFRLENBQUMsUUFBUSxDQUFDLFFBQVEsQ0FBQyxRQUFRLENBQUMsVUFBVSxDQUFDLEVBQUU7WUFDbkQsWUFBWSxDQUFDLE9BQU8sR0FBRywwQkFBMEIsQ0FBQztZQUNsRCxLQUFLLEdBQUcsUUFBUSxDQUFDLGFBQWEsQ0FBQyw4QkFBOEIsQ0FBQyxDQUFDO1lBQy9ELFlBQVksQ0FBQyxLQUFLLEdBQUcsVUFBVSxHQUFHLEtBQUssQ0FBQyxXQUFXLENBQUM7WUFDcEQsWUFBWSxDQUFDLGFBQWEsR0FBRyxTQUFTLENBQUM7U0FDeEM7YUFBTSxJQUFJLFFBQVEsQ0FBQyxRQUFRLENBQUMsUUFBUSxDQUFDLFFBQVEsQ0FBQyxTQUFTLENBQUMsRUFBRTtZQUN6RCxZQUFZLENBQUMsT0FBTyxHQUFHLHlCQUF5QixDQUFDO1lBQ2pELEtBQUssR0FBRyxRQUFRLENBQUMsYUFBYSxDQUFDLDZCQUE2QixDQUFDLENBQUM7WUFFOUQsSUFBSSxLQUFLLEtBQUssSUFBSSxFQUFFO2dCQUNsQixZQUFZLENBQUMsS0FBSyxHQUFHLHFCQUFxQixHQUFHLEtBQUssQ0FBQyxXQUFXLENBQUM7YUFDaEU7WUFFRCxZQUFZLENBQUMsYUFBYSxHQUFHLE1BQU0sQ0FBQztTQUNyQzthQUFNLElBQUksUUFBUSxDQUFDLFFBQVEsQ0FBQyxRQUFRLEtBQUssV0FBVyxFQUFFO1lBQ3JELFlBQVksQ0FBQyxPQUFPLEdBQUcsMkJBQTJCLENBQUM7WUFDbkQsWUFBWSxDQUFDLGFBQWEsR0FBRyxTQUFTLENBQUM7U0FDeEM7YUFBTTtZQUNMLFlBQVksQ0FBQyxPQUFPLEdBQUcsb0JBQW9CLENBQUM7WUFDNUMsWUFBWSxDQUFDLGFBQWEsR0FBRyxTQUFTLENBQUM7U0FDeEM7S0FDRjtJQUVELElBQUksWUFBWSxDQUFDLE9BQU8sSUFBSSxJQUFJLEVBQUU7UUFDaEMsUUFBUSxDQUFDLFlBQVksRUFBRSxDQUFDO1FBQ3hCLFFBQVEsQ0FBQyxXQUFXLEVBQUUsQ0FBQztLQUN4QjtTQUFNO1FBQ0wsUUFBUSxDQUFDLFdBQVcsQ0FBQyxZQUFZLENBQUMsQ0FBQztLQUNwQztBQUNILENBQUMsQ0FBQyxDQUFDIn0=

--- a/Skyra/presence.ts
+++ b/Skyra/presence.ts
@@ -1,0 +1,46 @@
+var presence = new Presence({
+  clientId: "266624760782258186"
+});
+
+var browsingStamp = Math.floor(Date.now() / 1000);
+
+var title: Element;
+
+presence.on("UpdateData", async () => {
+  var presenceData: presenceData = {
+    largeImageKey: "skyra"
+  };
+
+  if (document.location.hostname === "skyra.pw") {
+    presenceData.startTimestamp = browsingStamp;
+
+    if (document.location.pathname.includes("/guilds/")) {
+      presenceData.details = "Managing server settings";
+      title = document.querySelector("[data-premid='server-title']");
+      presenceData.state = "server: " + title.textContent;
+      presenceData.smallImageKey = "writing";
+    } else if (document.location.pathname.includes("/music/")) {
+      presenceData.details = "Spinning the turntables";
+      title = document.querySelector("[data-premid='music-title']");
+
+      if (title !== null) {
+        presenceData.state = "Currently Playing: " + title.textContent;
+      }
+
+      presenceData.smallImageKey = "play";
+    } else if (document.location.pathname === "/commands") {
+      presenceData.details = "Browsing Skyra's commands";
+      presenceData.smallImageKey = "reading";
+    } else {
+      presenceData.details = "Checking out Skyra";
+      presenceData.smallImageKey = "reading";
+    }
+  }
+
+  if (presenceData.details == null) {
+    presence.setTrayTitle();
+    presence.setActivity();
+  } else {
+    presence.setActivity(presenceData);
+  }
+});

--- a/Skyra/tsconfig.json
+++ b/Skyra/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}


### PR DESCRIPTION
Superseding #1253 as requested

---

I'd like to add a Presence for [skyra.pw](https://skyra.pw/), the website and dashboard for [Skyra](https://github.com/skyra-project/skyra)

Before a remark is made about the using of `data-premid` in the query-selectors, I'm a co-owner of Skyra and added those attributes to the sourcecode of the website myself, so it's a perfectly safe selector to use. 

Screenshots in collapsed view:

<details><summary>Click here to view screenshots</summary>

![image](https://user-images.githubusercontent.com/4019718/77864217-a96ceb00-7227-11ea-80d4-96bcb379ab4a.png)
![image](https://user-images.githubusercontent.com/4019718/77864222-b2f65300-7227-11ea-8f1c-f54175b2f26e.png)
![image](https://user-images.githubusercontent.com/4019718/77864320-2c8e4100-7228-11ea-86bb-64d8ee32380f.png)
![image](https://user-images.githubusercontent.com/4019718/77864347-50ea1d80-7228-11ea-8f17-e4da850cce8b.png)

</details

---
---

If I may give you guys some general advice/remarks from 1 software engineer (who does this for a living might I add) to many others. You do not have to take any of these points to heart at all, I'd just like to share them.

- ~~You have a `.prettierrc.json` config, trailing commas in there are configured as `es5` but in the review you gave me you said no trailing commas. So change the this in prettierrc to `none` so prettier removes the trailing commas~~
- On a related note, use [`lint-staged`](https://github.com/okonet/lint-staged) and [`husky`](https://github.com/typicode/husky) to automatically run the prettier autoformatter with the `pre-commit` Git hook (yes this also works for Git GUI clients, it does NOT need the CLI!!). That way whenever people commit code (to their forks or you guys to this repo) styling is adjusted to the way you want it automatically and you don't have to nitpick through code checking styling ever again. You can have all code always follow 2 (or 4) spaces (or tabs) and no trailing commas without ever having to look at it. 
  - On a subrelated note, automate what you can automate and don't give yourself meaningless tasks that drain your time. At least that's what I very strongly believe when developing.
  - Also if you want a hand with configuring this kind of stuff you can let me know and I'd be glad to open a PR for it. We can talk further on the Discord server (Favna#0001, dragonite GIF profile picture)
- ~~In the referenced closed PR I was told to compile with `tsc --noFallthroughCasesInSwitch --noUnusedLocals --noUnusedParameters -t "ES2020"`, however following the proper guidelines the `tsconfig.json` in my folder properly extends the tsconfig from root (which is a MUST requirement anyway) and all these CLI options are already specified in the root TSConfig. There is no need to specify them *again* as CLI flags.~~
- ~~Aside from the commas I had to remove the previous PR was perfectly up2date because I rebased it on top of the master branch after #1258 was merged. I also discussed this on the Discord and I have a feeling some here may not entirely know what it means to rebase. Anyway from snippets on Discord I have a feeling some of you don't know what it means to "rebase on top of master" and I had hoped that [the screenshot I shared on Discord](https://cdn.discordapp.com/attachments/607524579874832446/694530214683738232/unknown.png) would show it. Rebasing on top of master means to pull in all changes from master and completely re-apply your own changes on top of that as if you never made them in the past. I already had the latest Deepscan config files and Deepscan would not block my PR, nor did it ever, as you can clearly see from this log on Deepscan that is from *after* I rebased on top of master: https://deepscan.io/dashboard/#view=project&tid=6792&pid=8925&bid=113944&subview=pull-request&prid=302990~~
