### PR TITLE
🔗 Fix Apple Music URL

### DIFF
--- a/Apple Music/dist/metadata.json
+++ b/Apple Music/dist/metadata.json
@@ -9,8 +9,8 @@
     "zh_TW": "Apple Music是蘋果公司推出的一款線上音樂串流媒體服務。",
     "zh_CN": "Apple Music是苹果推出的流行音乐界又一位新成员。"
   },
-  "url": "beta.music.apple.com",
-  "version": "1.2.1",
+  "url": "music.apple.com",
+  "version": "1.2.2",
   "logo": "https://i.gyazo.com/953a27f5dc6ec95ccb792957b699e3de.png",
   "thumbnail": "https://i.gyazo.com/a85cbd963a42138975b16436b3cfb3fe.png",
   "color": "#fff",


### PR DESCRIPTION
Changed URL to music.apple.com as beta.music.apple.com now redirects to music.apple.com and appears to have released.