### PR TITLE
Fix error output

### DIFF
--- a/schemaValidator.ts
+++ b/schemaValidator.ts
@@ -15,7 +15,7 @@ const stats = {
 
 const validated = (service: string): void => { console.log(green(`✔ ${service}`)); stats.validated++ };
 const validatedWithWarnings = (service: string, warning: string): void => { console.log(yellow(`✔ ${service} (${warning})`)); stats.validatedWithWarnings++ };
-const failedToValidate = (service: string, errors: string[]): void => { console.log(red(`✘ ${service} ${errors.map(e => `  -> ${e}`).join('\n')}`)); stats.failedToValidate++ };
+const failedToValidate = (service: string, errors: string[]): void => { console.log(red(`✘ ${service}\n${errors.map(e => `  -> ${e}`).join('\n')}`)); stats.failedToValidate++ };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const loadMetadata = (path: string): any => JSON.parse(fs.readFileSync(path, 'utf-8'));


### PR DESCRIPTION
Prevents first error from being on the same line as the presence name.