### PR TITLE
[4anime] Fixed typo that broke vjs compatibility

### DIFF
--- a/websites/0-9/4anime/dist/metadata.json
+++ b/websites/0-9/4anime/dist/metadata.json
@@ -17,7 +17,7 @@
     "ga_IE": "Féach ar anime ar líne i gcaighdeán ard 1080p le fotheidil Bhéarla. Suí siar agus scíth a ligean!"
   },
   "url": "4anime.to",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "logo": "https://premid.is-inside.me/0Ki4Cf2i.png",
   "thumbnail": "https://i.imgur.com/Tcf3IMX.png",
   "color": "#ff0808",

--- a/websites/0-9/4anime/presence.ts
+++ b/websites/0-9/4anime/presence.ts
@@ -48,7 +48,7 @@ presence.on("UpdateData", async () => {
     presence.setActivity(presenceData, true);
   }
 
-  var video: HTMLVideoElement =
+  let video: HTMLVideoElement =
     document.querySelector("#videoo1_html5_api") ||
     document.querySelector(".jw-video");
 

--- a/websites/0-9/4anime/presence.ts
+++ b/websites/0-9/4anime/presence.ts
@@ -49,7 +49,7 @@ presence.on("UpdateData", async () => {
   }
 
   var video: HTMLVideoElement =
-    document.querySelector("#video1_html5_api") ||
+    document.querySelector("#videoo1_html5_api") ||
     document.querySelector(".jw-video");
 
   if (video !== null && !isNaN(video.duration)) {

--- a/websites/0-9/4anime/presence.ts
+++ b/websites/0-9/4anime/presence.ts
@@ -48,7 +48,7 @@ presence.on("UpdateData", async () => {
     presence.setActivity(presenceData, true);
   }
 
-  let video: HTMLVideoElement =
+  const video: HTMLVideoElement =
     document.querySelector("#videoo1_html5_api") ||
     document.querySelector(".jw-video");
 


### PR DESCRIPTION
`#video1_html5_api` was supposed to be `#videoo1_html5_api`, so anybody using the default vjs player wouldn't have been detected. 