### PR TITLE
Add Wikiwand presence

### DIFF
--- a/websites/W/Wikiwand/dist/metadata.json
+++ b/websites/W/Wikiwand/dist/metadata.json
@@ -10,7 +10,7 @@
   "logo": "https://i.imgur.com/8QkIyOM.png",
   "thumbnail": "https://i.imgur.com/vLXp14J.jpg",
   "color": "#F7F6F5",
-  "tags": ["encyclopedia", "informations", "wiki", "wikipedia"],
+  "tags": ["encyclopedia", "information", "wiki", "wikipedia"],
   "description": {
     "en": "Wikiwand is a modern reader for web and mobile, that optimizes Wikipedia's amazing content for a significantly improved reading experience."
   },

--- a/websites/W/Wikiwand/dist/metadata.json
+++ b/websites/W/Wikiwand/dist/metadata.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.0",
+  "author": {
+    "name": "Hans5958",
+    "id": "279855717203050496"
+  },
+  "service": "Wikiwand",
+  "url": "www.wikiwand.com",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/8QkIyOM.png",
+  "thumbnail": "https://i.imgur.com/vLXp14J.jpg",
+  "color": "#F7F6F5",
+  "tags": ["encyclopedia", "informations", "wiki", "wikipedia"],
+  "description": {
+    "en": "Wikiwand is a modern reader for web and mobile, that optimizes Wikipedia's amazing content for a significantly improved reading experience."
+  },
+  "category": "other"
+}

--- a/websites/W/Wikiwand/presence.ts
+++ b/websites/W/Wikiwand/presence.ts
@@ -70,8 +70,6 @@ const resetData = (): void => {
     presenceData.details = "Reading a wiki page";
     presenceData.state = title;
   }
-
-  console.log(presenceData);
 })();
 
 if (updateCallback.present) {

--- a/websites/W/Wikiwand/presence.ts
+++ b/websites/W/Wikiwand/presence.ts
@@ -1,0 +1,87 @@
+const presence = new Presence({
+  clientId: "731472884337475596"
+});
+
+let currentURL = new URL(document.location.href),
+  currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
+const browsingStamp = Math.floor(Date.now() / 1000);
+let presenceData: PresenceData = {
+  details: "Viewing an unsupported page",
+  largeImageKey: "lg",
+  startTimestamp: browsingStamp
+};
+const updateCallback = {
+  _function: null as Function,
+  get function(): Function {
+    return this._function;
+  },
+  set function(parameter) {
+    this._function = parameter;
+  },
+  get present(): boolean {
+    return this._function !== null;
+  }
+};
+
+/**
+ * Initialize/reset presenceData.
+ */
+const resetData = (): void => {
+  currentURL = new URL(document.location.href);
+  currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
+  presenceData = {
+    details: "Viewing an unsupported page",
+    largeImageKey: "lg",
+    startTimestamp: browsingStamp
+  };
+};
+
+((): void => {
+  let title: string;
+
+  const titleFromURL = (): string => currentPath[1];
+
+  try {
+    title = document.querySelector("h1.firstHeading span").textContent;
+  } catch (e) {
+    title = titleFromURL();
+  }
+
+  if (currentPath[0] === "") {
+    presenceData.details = "On the home page";
+  } else if (document.querySelector(".error_content")) {
+    presenceData.details = "On a non-existent page";
+  } else if (currentPath[0] === "news") {
+    presenceData.details = "Viewing a page";
+    presenceData.state = "Wikiwand Today";
+  } else if (currentPath[0] === "about") {
+    presenceData.details = "Viewing a page";
+    presenceData.state = "About";
+  } else if (currentPath[0] === "press") {
+    presenceData.details = "Viewing a page";
+    presenceData.state = "Press";
+  } else if (currentPath[0] === "terms") {
+    presenceData.details = "Viewing a page";
+    presenceData.state = "Terms of Service";
+  } else if (currentPath[0] === "privacy") {
+    presenceData.details = "Viewing a page";
+    presenceData.state = "Privacy Policy";
+  } else {
+    presenceData.details = "Reading a wiki page";
+    presenceData.state = title;
+  }
+
+  console.log(presenceData);
+})();
+
+if (updateCallback.present) {
+  presence.on("UpdateData", async () => {
+    resetData();
+    updateCallback.function();
+    presence.setActivity(presenceData);
+  });
+} else {
+  presence.on("UpdateData", async () => {
+    presence.setActivity(presenceData);
+  });
+}

--- a/websites/W/Wikiwand/tsconfig.json
+++ b/websites/W/Wikiwand/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/"
+  }
+}


### PR DESCRIPTION
*See also: #1735, Hans5958/PreMiD-Presences-Personal#2*

## Preword

This is the presence for Wikiwand (www.wikiwand.com), a web app for viewing Wikipedia articles/pages better. I think that's it.

This PR resolves #1735.

## Notes

- Images are from the press kit, and the logo is manually upscaled by me.
- On an unrelated note, I actually have rewritten the Wikipedia presence, along with a plan to do all wikis from the Wikimedia Foundation. I'm not sure if the rewritten part is applicable, so I will need a discussion.

## Images

| Image                                                                                                                        | Link visited                                   |
| ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| ![2020-07-11_21-47-33](https://user-images.githubusercontent.com/11584103/87226858-d56c4080-c3c0-11ea-8a92-6070a701b8f2.png) | https://www.wikiwand.com/                      |
| ![2020-07-11_21-47-59](https://user-images.githubusercontent.com/11584103/87226861-d69d6d80-c3c0-11ea-9100-96b41eed3870.png) | https://www.wikiwand.com/en/Discord_(software) |
| ![2020-07-11_21-49-11](https://user-images.githubusercontent.com/11584103/87226864-d7360400-c3c0-11ea-95fb-499d6e5c759b.png) | https://www.wikiwand.com/en/NASA               |
| ![2020-07-11_21-50-28](https://user-images.githubusercontent.com/11584103/87226865-d7ce9a80-c3c0-11ea-8e84-9ca71e594ce4.png) | https://www.wikiwand.com/news                  |