### PR TITLE
Update TrackMania Exchange presence (1.0.1)

### DIFF
--- a/websites/T/TrackMania Exchange/dist/metadata.json
+++ b/websites/T/TrackMania Exchange/dist/metadata.json
@@ -1,10 +1,11 @@
 {
-  "$schema": "https://schemas.premid.app/metadata/1.0",
+  "$schema": "https://schemas.premid.app/metadata/1.1",
   "author": {
     "name": "Hans5958",
     "id": "279855717203050496"
   },
   "service": "TrackMania Exchange",
+  "altnames": ["TM-Exchange"],
   "url": [
     "tm-exchange.com",
     "www.tm-exchange.com",
@@ -15,7 +16,7 @@
     "original.tm-exchange.com",
     "blog.tm-exchange.com"
   ],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/9OFSS6T.png",
   "thumbnail": "https://i.imgur.com/CKJ2Wqm.png",
   "color": "#c8c8c8",
@@ -25,6 +26,7 @@
     "tm",
     "tmnf",
     "tmuf",
+    "tmx",
     "trackmania-nations-eswc",
     "trackmania-nations-forever",
     "trackmania-nations",
@@ -34,7 +36,7 @@
     "trackmania"
   ],
   "description": {
-    "en": "TrackMania Exchange (TMX) is the biggest and best TrackMania track-swapping website in the world."
+    "en": "TrackMania Exchange (TMX) is the biggest and best TrackMania track-swapping website in the world. This one is not for the newer, TrackmaniaExchange, which is for the 2020 Trackmania. Use the ManiaExchange presence for that."
   },
   "category": "games"
 }


### PR DESCRIPTION
*See also: Hans5958/PreMiD-Presences-Personal#4*

## Preword

Here's an update for the TrackMania Exchange presence, which is done to avoid confusion for the new [TrackmaniaExchange](https://trackmania.exchange), as well to introduce new supported pages and bug fixes.

## Changelog

- Update base script
  - Fix `currentPath` by also removing the last slash if required so it is consistent
  - Update how `resetData()` works so the fields that have been changed before are also included
  - Update metadata schema from 1.1
- Add alternative name for TMX (`TM-Exchange`)
- Edit description to avoid confusion for both TMX
- Add support for more pages

## Notes

- Regarding altnames, am I doing it right?
- Are newlines work on the description?

## Images

| Image | Link visited |
| ----- | ------------ |
| ![](https://user-images.githubusercontent.com/11584103/87421075-91677e80-c600-11ea-99e5-28b6ba361d6e.png) | https://tmnforever.tm-exchange.com/ |
| ![](https://user-images.githubusercontent.com/11584103/87421079-9298ab80-c600-11ea-949b-c76c60b0174b.png) | https://tmnforever.tm-exchange.com/main.aspx?action=trackshow&id=8238264#auto |