### PR TITLE
Update ManiaExchange presence (1.0.1)

### DIFF
--- a/websites/M/ManiaExchange/dist/metadata.json
+++ b/websites/M/ManiaExchange/dist/metadata.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemas.premid.app/metadata/1.0",
+  "$schema": "https://schemas.premid.app/metadata/1.1",
   "author": {
     "name": "Hans5958",
     "id": "279855717203050496"
@@ -22,27 +22,31 @@
     "tmtube.mania-exchange.com",
     "tmtube.mania.exchange",
     "api.mania-exchange.com",
-    "api.mania.exchange"
+    "api.mania.exchange",
+    "trackmania.exchange"
   ],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/KPcs9y1.png",
   "thumbnail": "https://i.imgur.com/NYitprM.png",
   "color": "#7ad5ff",
   "tags": [
-    "trackmania",
-    "trackmania-2",
-    "shootmania",
-    "questmania",
-    "gaming",
     "cars",
-    "trackmania2",
+    "gaming",
+    "mania-exchange",
     "maniaplanet",
+    "questmania",
+    "shootmania",
     "tm",
     "tm2",
-    "mania-exchange"
+    "tmx",
+    "trackmania-2",
+    "trackmania-exchange",
+    "trackmaniaexchange",
+    "trackmania",
+    "trackmania2"
   ],
   "description": {
-    "en": "The content network for Trackmania and Shootmania - driven by the community."
+    "en": "The content network for Trackmania and Shootmania - driven by the community. This one supports the newer, TrackmaniaExchange, which is for the 2020 Trackmania. For the older one, uses the TrackMania Exchange presence."
   },
   "category": "games"
 }


### PR DESCRIPTION
*See also: Hans5958/PreMiD-Presences-Personal#4*

## Preword

Here's an update for the ManiaExchange presence, which is done to add support for the new [TrackmaniaExchange](https://trackmania.exchange), as well to introduce new supported pages and bug fixes.

## Changelog

- Update base script
  - Fix `currentPath` by also removing the last slash if required so it is consistent
  - Update how `resetData()` works so the fields that have been changed before are also included
  - Update metadata schema from 1.1
- Add support for TrackmaniaExchange (a TMX variation, but for the 2020 Trackmania)
- Edit description to avoid confusion for both TMX
- Swap the small image with the large image for some parts of the website
- Add support for more pages

## Notes

- Are newlines work on the description?

## Images

| Image | Link visited |
| ----- | ------------ |
| ![](https://user-images.githubusercontent.com/11584103/87420673-e5be2e80-c5ff-11ea-8e06-2eac99573d07.png) | https://trackmania.exchange |
| ![](https://user-images.githubusercontent.com/11584103/87420675-e656c500-c5ff-11ea-956f-ba21603409e8.png) | https://trackmania.exchange/maps/1476/zero |
| ![](https://user-images.githubusercontent.com/11584103/87420676-e656c500-c5ff-11ea-9421-97b8b73198dc.png) | https://trackmania.exchange/forums |
| ![](https://user-images.githubusercontent.com/11584103/87420677-e6ef5b80-c5ff-11ea-8913-4b6a7a5ef746.png) | https://item.mania.exchange |
| ![](https://user-images.githubusercontent.com/11584103/87420681-e787f200-c5ff-11ea-9689-1973d159d962.png) | https://tmtube.mania-exchange.com/ |
| ![](https://user-images.githubusercontent.com/11584103/87420682-e8208880-c5ff-11ea-8d27-76d5527d366e.png) | https://mania-exchange.com |