### PR TITLE
Fix excess [Edit] parts for Chinese wikipedia

### DIFF
--- a/websites/W/Wikipedia/presence.ts
+++ b/websites/W/Wikipedia/presence.ts
@@ -3,7 +3,7 @@ var presence = new Presence({
 });
 
 var browsingStamp = Math.floor(Date.now() / 1000);
-var title: any;
+var title: any, editsection: any;
 var actionURL = new URL(document.location.href);
 var title2URL = new URL(document.location.href);
 
@@ -13,6 +13,7 @@ presence.on("UpdateData", async () => {
     largeImageKey: "lg"
   };
 
+  editsection = document.querySelector("#firstHeading > span");
   title = document.querySelector("h1#firstHeading");
 
   var actionResult = actionURL.searchParams.get("action");
@@ -27,8 +28,11 @@ presence.on("UpdateData", async () => {
   } else if (title && document.location.pathname.includes("/wiki/")) {
     presenceData.details = "Reading about:";
 
-    presenceData.state = title.innerText;
-
+    if (editsection == null) {
+      presenceData.state = title.innerText;
+    } else {
+      presenceData.state = title.innerText.replace(editsection.innerText, "");
+    }
     presenceData.startTimestamp = browsingStamp;
   } else if (
     actionResult == "history" &&


### PR DESCRIPTION
Before:
![](https://cdn.discordapp.com/attachments/715453185845624842/733469681075355698/unknown.png)
After:
![](https://cdn.discordapp.com/attachments/715453185845624842/733472518064701510/unknown.png)
Current website:
![](https://cdn.discordapp.com/attachments/715453185845624842/733472557591822346/unknown.png)
The `h1` title source:
![image](https://user-images.githubusercontent.com/35394151/87734773-30a99300-c806-11ea-9c69-1a6ae5afa98b.png)
Example Link:
[zh.Wikipedia: Australia](https://zh.wikipedia.org/wiki/%E6%BE%B3%E5%A4%A7%E5%88%A9%E4%BA%9A)

Note:
I slightly checked some popular languages. I think that [Edit] only appears in Chinese and its localism sub-site.