### PR TITLE
Workflow Maintenance

### DIFF
--- a/.github/workflows/SA.yml
+++ b/.github/workflows/SA.yml
@@ -1,0 +1,37 @@
+name: SA
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  review:
+    name: Diff review
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'PreMiD'
+    steps:
+      - uses: actions/checkout@v1
+      - name: eslint
+        uses: reviewdog/action-eslint@v1
+        with:
+          github_token: ${{ secrets.AUTOMERGE }}
+          level: error
+          reporter: github-pr-review
+          filter_mode: diff_context
+          fail_on_error: true
+          eslint_flags: ". --ext .ts"
+  analysis:
+    needs: review
+    name: Files check
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'PreMiD'
+    steps:
+      - uses: actions/checkout@v1
+      - name: eslint
+        uses: reviewdog/action-eslint@v1
+        with:
+          github_token: ${{ secrets.AUTOMERGE }}
+          level: error
+          reporter: github-pr-check
+          filter_mode: file
+          fail_on_error: true
+          eslint_flags: ". --ext .ts"


### PR DESCRIPTION
ESLint's warnings have been removed from DeepScan thanks to its inconsistency regarding a few pull requests and to also make reviewing easier. What the workflow basically does is check the modified/added lines first and If there are any errors it posts a review using the bot pointing at the exact line with the issue (+ links to how it can be fixed), and in case there are no errors in the modified files another job will run, the second job checks by files instead of diff, so it can spot the issues not included in diff (e.g. stuff DeepScan missed before :bruh:), if it does then instead of reviewing like before, it uses code annotations (thanks GitHub for the technical limitations), the code annotations are the same as the reviews except they are in the commits and the workflow's run page, you can see a commit example [here](https://github.com/PreMiD/Presences/pull/1910/commits/11cc704d0b2128a142a7e3c4759c91e0f66c9670).

[TL;DR](https://github.com/PreMiD/Presences/pull/1910)