### PR TITLE
Add Wikibooks presence

### DIFF
--- a/websites/W/Wikibooks/dist/metadata.json
+++ b/websites/W/Wikibooks/dist/metadata.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.1",
+  "author": {
+    "name": "Hans5958",
+    "id": "279855717203050496"
+  },
+  "service": "Wikibooks",
+  "description": {
+    "en": "Wikibooks aims to build a collection of free e-book resources including textbooks, annotated texts, instructional guides, and manuals.",
+    "ar": "تهدف ويكي الكتب إلى إنشاء مجموعة من موارد الكتب الإلكترونية المجانية بما في ذلك الكتب النصية ، والنصوص المشروحة ، والأدلة الإرشادية ، والأدلة.",
+    "zh_CN": "維基教科書旨在建立一系列免費電子書資源，包括教科書，註釋文本，教學指南和手冊。",
+    "fr": "Wikilivres vise à constituer une bibliothèque de ressources livresques électroniques, composée de manuels scolaires et techniques ainsi que de textes annotés et de guides.",
+    "es": "Wikilibros busca construir una colección de recursos libres en e-book incluyendo libros de texto, versiones comentadas, guías instructivas y manuales."
+  },
+  "url": "wikibooks.org",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/Y6Z6NKa.png",
+  "thumbnail": "https://i.imgur.com/zhJBMJe.png",
+  "color": "#f9f9f9",
+  "tags": [
+    "books",
+    "e-books",
+    "information",
+    "library",
+    "reading",
+    "wiki",
+    "wikimedia-foundation",
+    "wikimedia",
+    "wmf"
+  ],
+  "category": "other",
+  "regExp": "([a-z0-9-]+[.])+wikibooks[.]org[/]"
+}

--- a/websites/W/Wikibooks/presence.ts
+++ b/websites/W/Wikibooks/presence.ts
@@ -1,0 +1,196 @@
+const presence = new Presence({
+  clientId: "733216796991029301"
+});
+
+let currentURL = new URL(document.location.href),
+  currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
+const browsingStamp = Math.floor(Date.now() / 1000);
+let presenceData: PresenceData = {
+  details: "Viewing an unsupported page",
+  largeImageKey: "lg",
+  startTimestamp: browsingStamp
+};
+const updateCallback = {
+  _function: null as Function,
+  get function(): Function {
+    return this._function;
+  },
+  set function(parameter) {
+    this._function = parameter;
+  },
+  get present(): boolean {
+    return this._function !== null;
+  }
+},
+
+/**
+ * Initialize/reset presenceData.
+ */
+ resetData = (
+  defaultData: PresenceData = {
+    details: "Viewing an unsupported page",
+    largeImageKey: "lg",
+    startTimestamp: browsingStamp
+  }
+): void => {
+  currentURL = new URL(document.location.href);
+  currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
+  presenceData = { ...defaultData };
+},
+
+/**
+ * Search for URL parameters.
+ * @param urlParam The parameter that you want to know about the value.
+ */
+ getURLParam = (urlParam: string): string => {
+  return currentURL.searchParams.get(urlParam);
+};
+
+((): void => {
+  if (currentURL.hostname === "www.wikibooks.org") {
+    presenceData.details = "On the home page";
+  } else {
+    let title: string;
+    const actionResult = getURLParam("action") || getURLParam("veaction"),
+      lang = currentURL.hostname.split(".")[0],
+
+     titleFromURL = (): string => {
+      const raw =
+        currentPath[1] === "index.php"
+          ? getURLParam("title")
+          : currentPath.slice(1).join("/");
+      return decodeURI(raw.replace(/_/g, " "));
+    };
+
+    try {
+      title = document.querySelector("h1").textContent;
+    } catch (e) {
+      title = titleFromURL();
+    }
+
+    /**
+     * Returns details based on the namespace.
+     * @link https://en.wikibooks.org/wiki/Help:Pages#Namespaces
+     */
+    const namespaceDetails = (): string => {
+      const details: { [index: string]: string } = {
+        "-2": "Viewing a media",
+        "-1": "Viewing a special page",
+        0: "Reading a book",
+        1: "Viewing a talk page",
+        2: "Viewing a user page",
+        3: "Viewing a user talk page",
+        4: "Viewing a project page",
+        5: "Viewing a project talk page",
+        6: "Viewing a file",
+        7: "Viewing a file talk page",
+        8: "Viewing an interface page",
+        9: "Viewing an interface talk page",
+        10: "Viewing a template",
+        11: "Viewing a template talk page",
+        12: "Viewing a help page",
+        13: "Viewing a help talk page",
+        14: "Viewing a category",
+        15: "Viewing a category talk page",
+        102: "Viewing a cookbook",
+        103: "Viewing a cookbook talk page",
+        108: "Viewing a Transwiki page",
+        109: "Viewing a Transwiki talk page",
+        110: "Reading a Wikijunior book",
+        111: "Viewing a Wikijunior book talk page",
+        112: "Viewing a subject",
+        113: "Viewing a subject talk page",
+        2300: "Viewing a gadget",
+        2301: "Viewing a gadget talk page",
+        2302: "Viewing a gadget definition page",
+        2303: "Viewing a gadget definition talk page",
+        2600: "Viewing a topic"
+      };
+      return (
+        details[
+          [...document.querySelector("body").classList]
+            .filter((v) => /ns--?\d/.test(v))[0]
+            .slice(3)
+        ] || "Viewing a page"
+      );
+    };
+
+    //
+    // Important note:
+    //
+    // When checking for the current location, avoid using the URL.
+    // The URL is going to be different in other languages.
+    // Use the elements on the page instead.
+    //
+
+    if (
+      ((document.querySelector("#n-mainpage a") ||
+        document.querySelector("#p-navigation a") ||
+        document.querySelector(".mw-wiki-logo")) as HTMLAnchorElement).href ===
+      currentURL.href
+    ) {
+      presenceData.details = "On the main page";
+    } else if (document.querySelector("#wpLoginAttempt")) {
+      presenceData.details = "Logging in";
+    } else if (document.querySelector("#wpCreateaccount")) {
+      presenceData.details = "Creating an account";
+    } else if (document.querySelector(".searchresults")) {
+      presenceData.details = "Searching for a page";
+      presenceData.state = (document.querySelector(
+        "input[type=search]"
+      ) as HTMLInputElement).value;
+    } else if (getURLParam("diff")) {
+      presenceData.details = "Viewing difference between revisions";
+      presenceData.state = titleFromURL();
+    } else if (getURLParam("oldid")) {
+      presenceData.details = "Viewing an old revision of a page";
+      presenceData.state = titleFromURL();
+    } else if (
+      document.querySelector("#pt-logout") ||
+      getURLParam("veaction")
+    ) {
+      presenceData.state = `${
+        title.toLowerCase() === titleFromURL().toLowerCase()
+          ? `${title}`
+          : `${title} (${titleFromURL()})`
+      }`;
+      updateCallback.function = (): void => {
+        if (actionResult == "edit" || actionResult == "editsource") {
+          presenceData.details = "Editing a page";
+        } else {
+          presenceData.details = namespaceDetails();
+        }
+      };
+    } else {
+      if (actionResult == "edit") {
+        presenceData.details = "Editing a page";
+        presenceData.state = titleFromURL();
+      } else {
+        presenceData.details = namespaceDetails();
+        presenceData.state = `${
+          title.toLowerCase() === titleFromURL().toLowerCase()
+            ? `${title}`
+            : `${title} (${titleFromURL()})`
+        }`;
+      }
+    }
+
+    if (lang !== "en") {
+      if (presenceData.state) presenceData.state += ` (${lang})`;
+      else presenceData.details += ` (${lang})`;
+    }
+  }
+})();
+
+if (updateCallback.present) {
+  const defaultData = { ...presenceData };
+  presence.on("UpdateData", async () => {
+    resetData(defaultData);
+    updateCallback.function();
+    presence.setActivity(presenceData);
+  });
+} else {
+  presence.on("UpdateData", async () => {
+    presence.setActivity(presenceData);
+  });
+}

--- a/websites/W/Wikibooks/tsconfig.json
+++ b/websites/W/Wikibooks/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/"
+  }
+}


### PR DESCRIPTION
*See also: Hans5958/PreMiD-Presences-Personal#3*

## Preword

This is a presence for Wikibooks (www.wikibooks.org), a website from Wikimedia Foundation (the same company that made Wikipedia) that contains free textbooks.

## Notes

- This presence supports all languages of Wikibooks.
- It works essentially the same as how the Wikipedia presence works.

## Images

| Image | Link visited |
| ----- | ------------ |
| ![](https://user-images.githubusercontent.com/11584103/90745357-6d334780-e2fa-11ea-9f81-7fe1082ad912.png) | https://www.wikibooks.org |
| ![](https://user-images.githubusercontent.com/11584103/90745387-6efd0b00-e2fa-11ea-873c-1943a8192946.png) | https://en.wikibooks.org/wiki/Main_Page |
| ![](https://user-images.githubusercontent.com/11584103/90745397-6f95a180-e2fa-11ea-8f24-d9960b2c7895.png) | https://en.wikibooks.org/wiki/LaTeX |