### PR TITLE
Add Wikidata presence

### DIFF
--- a/websites/W/Wikidata/dist/metadata.json
+++ b/websites/W/Wikidata/dist/metadata.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.1",
+  "author": {
+    "name": "Hans5958",
+    "id": "279855717203050496"
+  },
+  "service": "Wikidata",
+  "description": {
+    "en": "Wikidata acts as central storage of structured data for Wikimedia projects. Structuring data into a machine-readable format makes it easier to view, search, edit, curate, use and re-use files.",
+    "ar": "تعمل ويكي داتا كمخزن مركزي للبيانات المنظمة لمشاريع ويكيميديا. يسهل تنظيم البيانات إلى تنسيق قابل للقراءة آليًا عرض الملفات والبحث عنها وتعديلها وتنظيمها وإعادة استخدامها.",
+    "zh_CN": "維基數據充當維基媒體項目結構化數據的中央存儲。將數據結構化為機器可讀格式，可以更輕鬆地查看，搜索，編輯，策劃，使用和重用文件。",
+    "fr": "Wikidata sert de stockage central de données structurées pour les projets Wikimédia. Structurer les données en un format lisible par les machines facilite la consultation, la recherche, la modification, la conservation, l’utilisation et la réutilisation des fichiers.",
+    "es": "Wikidata actúa como el almacenamiento central de información estructurada para los proyectos Wikimedia. Estructurando datos en un formato legible para máquinas los hace más sencillos de visualizar, buscar, editar, curar, usar y reusar archivos."
+  },
+  "url": ["www.wikidata.org", "test.wikidata.org"],
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/lxJ9vQI.png",
+  "thumbnail": "https://i.imgur.com/iDhgTZS.png",
+  "color": "#f9f9f9",
+  "tags": [
+    "abstract",
+    "data",
+    "information",
+    "wiki",
+    "wikimedia-foundation",
+    "wikimedia",
+    "wmf"
+  ],
+  "category": "other"
+}

--- a/websites/W/Wikidata/presence.ts
+++ b/websites/W/Wikidata/presence.ts
@@ -1,0 +1,187 @@
+const presence = new Presence({
+  clientId: "733216821758525460"
+});
+
+let currentURL = new URL(document.location.href),
+  currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
+const browsingStamp = Math.floor(Date.now() / 1000);
+let presenceData: PresenceData = {
+  details: "Viewing an unsupported page",
+  largeImageKey: "lg",
+  startTimestamp: browsingStamp
+};
+const updateCallback = {
+  _function: null as Function,
+  get function(): Function {
+    return this._function;
+  },
+  set function(parameter) {
+    this._function = parameter;
+  },
+  get present(): boolean {
+    return this._function !== null;
+  }
+},
+
+/**
+ * Initialize/reset presenceData.
+ */
+ resetData = (
+  defaultData: PresenceData = {
+    details: "Viewing an unsupported page",
+    largeImageKey: "lg",
+    startTimestamp: browsingStamp
+  }
+): void => {
+  currentURL = new URL(document.location.href);
+  currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
+  presenceData = { ...defaultData };
+},
+
+/**
+ * Search for URL parameters.
+ * @param urlParam The parameter that you want to know about the value.
+ */
+ getURLParam = (urlParam: string): string => {
+  return currentURL.searchParams.get(urlParam);
+};
+
+((): void => {
+  let title: string;
+  const actionResult = getURLParam("action") || getURLParam("veaction"),
+
+   titleFromURL = (): string => {
+    const raw =
+      currentPath[1] === "index.php"
+        ? getURLParam("title")
+        : currentPath.slice(1).join("/");
+    return decodeURI(raw.replace(/_/g, " "));
+  };
+
+  try {
+    title = document.querySelector(".wikibase-title")
+      ? document.querySelector(".wikibase-title-label").textContent.trim()
+      : document.querySelector("h1").textContent;
+  } catch (e) {
+    title = titleFromURL();
+  }
+
+  /**
+   * Returns details based on the namespace.
+   * @link https://www.wikidata.org/wiki/Help:Namespaces
+   */
+  const namespaceDetails = (): string => {
+    const details: { [index: string]: string } = {
+      "-2": "Viewing a media",
+      "-1": "Viewing a special page",
+      0: "Reading an article",
+      1: "Viewing a talk page",
+      2: "Viewing a user page",
+      3: "Viewing a user talk page",
+      4: "Viewing a project page",
+      5: "Viewing a project talk page",
+      6: "Viewing a file",
+      7: "Viewing a file talk page",
+      8: "Viewing an interface page",
+      9: "Viewing an interface talk page",
+      10: "Viewing a template",
+      11: "Viewing a template talk page",
+      12: "Viewing a help page",
+      13: "Viewing a help talk page",
+      14: "Viewing a category",
+      15: "Viewing a category talk page",
+      120: "Viewing a propery",
+      121: "Viewing a propery talk page",
+      122: "Viewing a query",
+      123: "Viewing a query talk page",
+      146: "Viewing a lexeme",
+      147: "Viewing a lexeme talk page",
+      640: "Viewing a schema",
+      641: "Viewing a schema talk page",
+      828: "Viewing a module",
+      829: "Viewing a module talk page",
+      2300: "Viewing a gadget",
+      2301: "Viewing a gadget talk page",
+      2302: "Viewing a gadget definition page",
+      2303: "Viewing a gadget definition talk page",
+      2600: "Viewing a topic"
+    };
+    return (
+      details[
+        [...document.querySelector("body").classList]
+          .filter((v) => /ns--?\d/.test(v))[0]
+          .slice(3)
+      ] || "Viewing a page"
+    );
+  };
+
+  //
+  // Important note:
+  //
+  // When checking for the current location, avoid using the URL.
+  // The URL is going to be different in other languages.
+  // Use the elements on the page instead.
+  //
+
+  if (
+    ((document.querySelector("#n-mainpage a") ||
+      document.querySelector("#p-navigation a") ||
+      document.querySelector(".mw-wiki-logo")) as HTMLAnchorElement).href ===
+    currentURL.href
+  ) {
+    presenceData.details = "On the main page";
+  } else if (document.querySelector("#wpLoginAttempt")) {
+    presenceData.details = "Logging in";
+  } else if (document.querySelector("#wpCreateaccount")) {
+    presenceData.details = "Creating an account";
+  } else if (document.querySelector(".searchresults")) {
+    presenceData.details = "Searching for a page";
+    presenceData.state = (document.querySelector(
+      "input[type=search]"
+    ) as HTMLInputElement).value;
+  } else if (getURLParam("diff")) {
+    presenceData.details = "Viewing difference between revisions";
+    presenceData.state = titleFromURL();
+  } else if (getURLParam("oldid")) {
+    presenceData.details = "Viewing an old revision of a page";
+    presenceData.state = titleFromURL();
+  } else if (document.querySelector("#pt-logout") || getURLParam("veaction")) {
+    presenceData.state = `${
+      title.toLowerCase() === titleFromURL().toLowerCase()
+        ? `${title}`
+        : `${title} (${titleFromURL()})`
+    }`;
+    updateCallback.function = (): void => {
+      if (actionResult == "edit" || actionResult == "editsource") {
+        presenceData.details = "Editing a page";
+      } else {
+        presenceData.details = namespaceDetails();
+      }
+    };
+  } else {
+    if (actionResult == "edit") {
+      presenceData.details = "Editing a page";
+      presenceData.state = titleFromURL();
+    } else {
+      presenceData.details = namespaceDetails();
+      presenceData.state = `${
+        title.toLowerCase() === titleFromURL().toLowerCase()
+          ? `${title}`
+          : `${title} (${titleFromURL()})`
+      }`;
+    }
+  }
+})();
+
+if (updateCallback.present) {
+  const defaultData = { ...presenceData };
+  presence.on("UpdateData", async () => {
+    resetData(defaultData);
+    updateCallback.function();
+    presence.setActivity(presenceData);
+  });
+} else {
+  presence.on("UpdateData", async () => {
+    presence.setActivity(presenceData);
+  });
+}

--- a/websites/W/Wikidata/tsconfig.json
+++ b/websites/W/Wikidata/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/"
+  }
+}


### PR DESCRIPTION
*See also: Hans5958/PreMiD-Presences-Personal#3*

## Preword

This is a presence for Wikidata (www.wikidata.org), a website from Wikimedia Foundation (the same company that made Wikipedia) that contains abstract, strucuted data of everything on other Wikimedia projects (Wikipedia, Wiktionary, etc).

## Notes

- This presence also supports the test version of Wikimedia Commons (https://test.wikidata.org/).
- It works essentially the same as how the Wikipedia presence works.

## Images

| Image | Link visited |
| ----- | ------------ |
| ![](https://user-images.githubusercontent.com/11584103/90747450-2003a580-e2fb-11ea-84ad-81804599c979.png) | https://www.wikidata.org/wiki/Wikidata:Main_Page |
| ![](https://user-images.githubusercontent.com/11584103/90747564-49bccc80-e2fb-11ea-8451-3e9de6221263.png) | https://www.wikidata.org/wiki/Q2 |