### PR TITLE
Add Wikimedia Commons presence

### DIFF
--- a/websites/W/Wikimedia Commons/dist/metadata.json
+++ b/websites/W/Wikimedia Commons/dist/metadata.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.1",
+  "author": {
+    "name": "Hans5958",
+    "id": "279855717203050496"
+  },
+  "service": "Wikimedia Commons",
+  "description": {
+    "en": "Wikimedia Commons is the world’s largest free-to-use library of illustrations, photos, drawings, videos, and music.",
+    "ar": "ويكيميديا كومنز هي أكبر مكتبة مجانية في العالم من الرسوم التوضيحية والصور والرسومات والفيديو والموسيقى.",
+    "zh_CN": "維基共享資源是世界上最大的免費圖庫，照片，圖畫，視頻和音樂庫。",
+    "fr": "Wikimedia Commons est la plus grande médiathèque d’illustrations, photographies, dessins, vidéos et musiques libres de droits.",
+    "es": "Wikimedia Commons, la biblioteca de ilustraciones, fotografías, dibujos videos y música más grande del mundo."
+  },
+  "url": ["commons.wikimedia.org", "test-commons.wikimedia.org"],
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/5Ko07gf.png",
+  "thumbnail": "https://i.imgur.com/SRU3R9d.png",
+  "color": "#f9f9f9",
+  "tags": [
+    "creative-commons",
+    "images",
+    "information",
+    "media",
+    "pictures",
+    "wiki",
+    "wikimedia-foundation",
+    "wikimedia",
+    "wmf"
+  ],
+  "category": "other"
+}

--- a/websites/W/Wikimedia Commons/presence.ts
+++ b/websites/W/Wikimedia Commons/presence.ts
@@ -1,0 +1,193 @@
+const presence = new Presence({
+  clientId: "733216837843812444"
+});
+
+let currentURL = new URL(document.location.href),
+  currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
+const browsingStamp = Math.floor(Date.now() / 1000);
+let presenceData: PresenceData = {
+  details: "Viewing an unsupported page",
+  largeImageKey: "lg",
+  startTimestamp: browsingStamp
+};
+const updateCallback = {
+  _function: null as Function,
+  get function(): Function {
+    return this._function;
+  },
+  set function(parameter) {
+    this._function = parameter;
+  },
+  get present(): boolean {
+    return this._function !== null;
+  }
+},
+
+/**
+ * Initialize/reset presenceData.
+ */
+ resetData = (
+  defaultData: PresenceData = {
+    details: "Viewing an unsupported page",
+    largeImageKey: "lg",
+    startTimestamp: browsingStamp
+  }
+): void => {
+  currentURL = new URL(document.location.href);
+  currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
+  presenceData = { ...defaultData };
+},
+
+/**
+ * Search for URL parameters.
+ * @param urlParam The parameter that you want to know about the value.
+ */
+ getURLParam = (urlParam: string): string => {
+  return currentURL.searchParams.get(urlParam);
+};
+
+((): void => {
+  let title: string;
+  const actionResult = getURLParam("action") || getURLParam("veaction"),
+
+   titleFromURL = (): string => {
+    const raw =
+      currentPath[1] === "index.php"
+        ? getURLParam("title")
+        : currentPath.slice(1).join("/");
+    return decodeURI(raw.replace(/_/g, " "));
+  };
+
+  try {
+    title = document.querySelector("h1").textContent;
+  } catch (e) {
+    title = titleFromURL();
+  }
+
+  /**
+   * Returns details based on the namespace.
+   * @link https://commons.wikimedia.org/wiki/Help:Namespaces
+   */
+  const namespaceDetails = (): string => {
+    const details: { [index: string]: string } = {
+      "-2": "Viewing a media",
+      "-1": "Viewing a special page",
+      0: "Viewing a gallery",
+      1: "Viewing a talk page",
+      2: "Viewing a user page",
+      3: "Viewing a user talk page",
+      4: "Viewing a project page",
+      5: "Viewing a project talk page",
+      6: "Viewing a file",
+      7: "Viewing a file talk page",
+      8: "Viewing an interface page",
+      9: "Viewing an interface talk page",
+      10: "Viewing a template",
+      11: "Viewing a template talk page",
+      12: "Viewing a help page",
+      13: "Viewing a help talk page",
+      14: "Viewing a category",
+      15: "Viewing a category talk page",
+      100: "Viewing a creator template",
+      101: "Viewing a creator template talk page",
+      102: "Viewing a media's subtitles",
+      103: "Viewing a media's subtitles talk page",
+      104: "Viewing a sequence",
+      105: "Viewing a sequence talk page",
+      106: "Viewing a institution template",
+      107: "Viewing a institution template talk page",
+      460: "Viewing a campaign",
+      461: "Viewing a campaign talk page",
+      486: "Viewing a data",
+      487: "Viewing a data talk page",
+      490: "Viewing a GWToolset page",
+      491: "Viewing a GWToolset talk page",
+      828: "Viewing a module",
+      829: "Viewing a module talk page",
+      1198: "Viewing a translation",
+      1199: "Viewing a translation talk page",
+      2300: "Viewing a gadget",
+      2301: "Viewing a gadget talk page",
+      2302: "Viewing a gadget definition page",
+      2303: "Viewing a gadget definition talk page",
+      2600: "Viewing a topic"
+    };
+    return (
+      details[
+        [...document.querySelector("body").classList]
+          .filter((v) => /ns--?\d/.test(v))[0]
+          .slice(3)
+      ] || "Viewing a page"
+    );
+  };
+
+  //
+  // Important note:
+  //
+  // When checking for the current location, avoid using the URL.
+  // The URL is going to be different in other languages.
+  // Use the elements on the page instead.
+  //
+
+  if (
+    ((document.querySelector("#n-mainpage a") ||
+      document.querySelector("#p-navigation a") ||
+      document.querySelector(".mw-wiki-logo")) as HTMLAnchorElement).href ===
+    currentURL.href
+  ) {
+    presenceData.details = "On the main page";
+  } else if (document.querySelector("#wpLoginAttempt")) {
+    presenceData.details = "Logging in";
+  } else if (document.querySelector("#wpCreateaccount")) {
+    presenceData.details = "Creating an account";
+  } else if (document.querySelector(".searchresults")) {
+    presenceData.details = "Searching for a page";
+    presenceData.state = (document.querySelector(
+      "input[type=search]"
+    ) as HTMLInputElement).value;
+  } else if (getURLParam("diff")) {
+    presenceData.details = "Viewing difference between revisions";
+    presenceData.state = titleFromURL();
+  } else if (getURLParam("oldid")) {
+    presenceData.details = "Viewing an old revision of a page";
+    presenceData.state = titleFromURL();
+  } else if (document.querySelector("#pt-logout") || getURLParam("veaction")) {
+    presenceData.state = `${
+      title.toLowerCase() === titleFromURL().toLowerCase()
+        ? `${title}`
+        : `${title} (${titleFromURL()})`
+    }`;
+    updateCallback.function = (): void => {
+      if (actionResult == "edit" || actionResult == "editsource") {
+        presenceData.details = "Editing a page";
+      } else {
+        presenceData.details = namespaceDetails();
+      }
+    };
+  } else {
+    if (actionResult == "edit") {
+      presenceData.details = "Editing a page";
+      presenceData.state = titleFromURL();
+    } else {
+      presenceData.details = namespaceDetails();
+      presenceData.state = `${
+        title.toLowerCase() === titleFromURL().toLowerCase()
+          ? `${title}`
+          : `${title} (${titleFromURL()})`
+      }`;
+    }
+  }
+})();
+
+if (updateCallback.present) {
+  const defaultData = { ...presenceData };
+  presence.on("UpdateData", async () => {
+    resetData(defaultData);
+    updateCallback.function();
+    presence.setActivity(presenceData);
+  });
+} else {
+  presence.on("UpdateData", async () => {
+    presence.setActivity(presenceData);
+  });
+}

--- a/websites/W/Wikimedia Commons/tsconfig.json
+++ b/websites/W/Wikimedia Commons/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/"
+  }
+}


### PR DESCRIPTION
*See also: Hans5958/PreMiD-Presences-Personal#3*

## Preword

This is a presence for Wikimedia Commons (commons.wikimedia.org), a website from Wikimedia Foundation (the same company that made Wikipedia) that contains usable media (photos, videos, etc) that lsi

## Notes

- This presence also supports the test version of Wikimedia Commons (https://test-commons.wikimedia.org/).
- It works essentially the same as how the Wikipedia presence works.

## Images

| Image | Link visited |
| ----- | ------------ |
| ![](https://user-images.githubusercontent.com/11584103/90747877-a6b88280-e2fb-11ea-8d39-e211e36b7e55.png) | https://commons.wikimedia.org/wiki/Main_Page |
| ![](https://user-images.githubusercontent.com/11584103/90747880-a7e9af80-e2fb-11ea-8e2d-01b0beac0c5c.png) | https://commons.wikimedia.org/wiki/File:Freiburg_M%C3%BCnster_Hochaltar_01.jpg |