### PR TITLE
Add Wikinews presence

### DIFF
--- a/websites/W/Wikinews/dist/metadata.json
+++ b/websites/W/Wikinews/dist/metadata.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.1",
+  "author": {
+    "name": "Hans5958",
+    "id": "279855717203050496"
+  },
+  "service": "Wikinews",
+  "description": {
+    "en": "Wikinews provides a free content alternative to commercial news sites with articles that are fact-checked and peer reviewed.",
+    "ar": "تقدم ويكي الأخبار محتوى مجانيًا بديلًا لمواقع الأخبار التجارية مع مقالات يتم التحقق منها بشكل حقيقي بمراجعة الزملاء.",
+    "zh_CN": "維基新聞提供商業新聞網站的免費內容替代品。",
+    "fr": "Wikinews est une alternative libre aux sites d’actualités commerciaux, aux articles vérifiés factuellement par les pairs.",
+    "es": "Wikinoticias provee contenido libre y es una alternativa a los sitios comerciales de noticias con artículos verificados y revisados por colegas."
+  },
+  "url": "wikinews.org",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/GVgGEKB.png",
+  "thumbnail": "https://i.imgur.com/r6l2Z7m.png",
+  "color": "#f9f9f9",
+  "tags": [
+    "information",
+    "news",
+    "wiki",
+    "wikimedia-foundation",
+    "wikimedia",
+    "wmf"
+  ],
+  "category": "other",
+  "regExp": "([a-z0-9-]+[.])+wikinews[.]org[/]"
+}

--- a/websites/W/Wikinews/presence.ts
+++ b/websites/W/Wikinews/presence.ts
@@ -1,0 +1,194 @@
+const presence = new Presence({
+  clientId: "733216857724682300"
+});
+
+let currentURL = new URL(document.location.href),
+  currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
+const browsingStamp = Math.floor(Date.now() / 1000);
+let presenceData: PresenceData = {
+  details: "Viewing an unsupported page",
+  largeImageKey: "lg",
+  startTimestamp: browsingStamp
+};
+const updateCallback = {
+  _function: null as Function,
+  get function(): Function {
+    return this._function;
+  },
+  set function(parameter) {
+    this._function = parameter;
+  },
+  get present(): boolean {
+    return this._function !== null;
+  }
+},
+
+/**
+ * Initialize/reset presenceData.
+ */
+ resetData = (
+  defaultData: PresenceData = {
+    details: "Viewing an unsupported page",
+    largeImageKey: "lg",
+    startTimestamp: browsingStamp
+  }
+): void => {
+  currentURL = new URL(document.location.href);
+  currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
+  presenceData = { ...defaultData };
+},
+
+/**
+ * Search for URL parameters.
+ * @param urlParam The parameter that you want to know about the value.
+ */
+ getURLParam = (urlParam: string): string => {
+  return currentURL.searchParams.get(urlParam);
+};
+
+((): void => {
+  if (currentURL.hostname === "www.wikinews.org") {
+    presenceData.details = "On the home page";
+  } else {
+    let title: string;
+    const actionResult = getURLParam("action") || getURLParam("veaction"),
+      lang = currentURL.hostname.split(".")[0],
+
+     titleFromURL = (): string => {
+      const raw =
+        currentPath[1] === "index.php"
+          ? getURLParam("title")
+          : currentPath.slice(1).join("/");
+      return decodeURI(raw.replace(/_/g, " "));
+    };
+
+    try {
+      title = document.querySelector("h1").textContent;
+    } catch (e) {
+      title = titleFromURL();
+    }
+
+    /**
+     * Returns details based on the namespace.
+     * @link https://en.wikinews.org/wiki/Special:PrefixIndex
+     */
+    const namespaceDetails = (): string => {
+      const details: { [index: string]: string } = {
+        "-2": "Viewing a media",
+        "-1": "Viewing a special page",
+        0: "Reading a news article",
+        1: "Viewing a talk page",
+        2: "Viewing a user page",
+        3: "Viewing a user talk page",
+        4: "Viewing a project page",
+        5: "Viewing a project talk page",
+        6: "Viewing a file",
+        7: "Viewing a file talk page",
+        8: "Viewing an interface page",
+        9: "Viewing an interface talk page",
+        10: "Viewing a template",
+        11: "Viewing a template talk page",
+        12: "Viewing a help page",
+        13: "Viewing a help talk page",
+        14: "Viewing a category",
+        15: "Viewing a category talk page",
+        100: "Viewing a portal",
+        101: "Viewing a portal talk page",
+        102: "Viewing comments of an article",
+        103: "Viewing a comments talk page",
+        828: "Viewing a module",
+        829: "Viewing a module talk page",
+        2300: "Viewing a gadget",
+        2301: "Viewing a gadget talk page",
+        2302: "Viewing a gadget definition page",
+        2303: "Viewing a gadget definition talk page",
+        2600: "Viewing a topic"
+      };
+      return (
+        details[
+          [...document.querySelector("body").classList]
+            .filter((v) => /ns--?\d/.test(v))[0]
+            .slice(3)
+        ] || "Viewing a page"
+      );
+    };
+
+    //
+    // Important note:
+    //
+    // When checking for the current location, avoid using the URL.
+    // The URL is going to be different in other languages.
+    // Use the elements on the page instead.
+    //
+
+    if (
+      ((document.querySelector("#n-mainpage a") ||
+        document.querySelector("#p-navigation a") ||
+        document.querySelector(".mw-wiki-logo")) as HTMLAnchorElement).href ===
+      currentURL.href
+    ) {
+      presenceData.details = "On the main page";
+    } else if (document.querySelector("#wpLoginAttempt")) {
+      presenceData.details = "Logging in";
+    } else if (document.querySelector("#wpCreateaccount")) {
+      presenceData.details = "Creating an account";
+    } else if (document.querySelector(".searchresults")) {
+      presenceData.details = "Searching for a page";
+      presenceData.state = (document.querySelector(
+        "input[type=search]"
+      ) as HTMLInputElement).value;
+    } else if (getURLParam("diff")) {
+      presenceData.details = "Viewing difference between revisions";
+      presenceData.state = titleFromURL();
+    } else if (getURLParam("oldid")) {
+      presenceData.details = "Viewing an old revision of a page";
+      presenceData.state = titleFromURL();
+    } else if (
+      document.querySelector("#pt-logout") ||
+      getURLParam("veaction")
+    ) {
+      presenceData.state = `${
+        title.toLowerCase() === titleFromURL().toLowerCase()
+          ? `${title}`
+          : `${title} (${titleFromURL()})`
+      }`;
+      updateCallback.function = (): void => {
+        if (actionResult == "edit" || actionResult == "editsource") {
+          presenceData.details = "Editing a page";
+        } else {
+          presenceData.details = namespaceDetails();
+        }
+      };
+    } else {
+      if (actionResult == "edit") {
+        presenceData.details = "Editing a page";
+        presenceData.state = titleFromURL();
+      } else {
+        presenceData.details = namespaceDetails();
+        presenceData.state = `${
+          title.toLowerCase() === titleFromURL().toLowerCase()
+            ? `${title}`
+            : `${title} (${titleFromURL()})`
+        }`;
+      }
+    }
+
+    if (lang !== "en") {
+      if (presenceData.state) presenceData.state += ` (${lang})`;
+      else presenceData.details += ` (${lang})`;
+    }
+  }
+})();
+
+if (updateCallback.present) {
+  const defaultData = { ...presenceData };
+  presence.on("UpdateData", async () => {
+    resetData(defaultData);
+    updateCallback.function();
+    presence.setActivity(presenceData);
+  });
+} else {
+  presence.on("UpdateData", async () => {
+    presence.setActivity(presenceData);
+  });
+}

--- a/websites/W/Wikinews/tsconfig.json
+++ b/websites/W/Wikinews/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/"
+  }
+}


### PR DESCRIPTION
*See also: Hans5958/PreMiD-Presences-Personal#3*

## Preword

This is a presence for Wikinews (www.wikinews.org), a website from Wikimedia Foundation (the same company that made Wikipedia) that contains news about anything.

## Notes

- This presence supports all languages of Wikinews.
- It works essentially the same as how the Wikipedia presence works.

## Images

| Image | Link visited |
| ----- | ------------ |
| ![](https://user-images.githubusercontent.com/11584103/90750892-a6ba8180-e2ff-11ea-94ad-4dba83ee1c21.png) | https://www.wikinews.org |
| ![](https://user-images.githubusercontent.com/11584103/90750894-a7ebae80-e2ff-11ea-8cea-5cf0a4379e2c.png) | https://en.wikinews.org/wiki/Main_Page |
| ![](https://user-images.githubusercontent.com/11584103/90750897-a8844500-e2ff-11ea-94ff-373a4eb152fb.png) | https://en.wikinews.org/wiki/Water_main_bursts_in_White_Plains,_New_York,_US |