### PR TITLE
Add Wikisource presence

### DIFF
--- a/websites/W/Wikisource/dist/metadata.json
+++ b/websites/W/Wikisource/dist/metadata.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.1",
+  "author": {
+    "name": "Hans5958",
+    "id": "279855717203050496"
+  },
+  "service": "Wikisource",
+  "description": {
+    "en": "Wikisource is a library of freely-licensed source texts and historical documents, including poetry, government documents, constitutions of many countries, and general literature.",
+    "ar": "ويكي مصدر هي مكتبة لنصوص المصدر المرخص لها بحرية والوثائق التاريخية ، بما في ذلك الشعر والوثائق الحكومية ودساتير العديد من البلدان والأدب العام.",
+    "zh_CN": "維基文庫是一個自由許可的源文本和歷史文檔庫，包括詩歌，政府文檔，許多國家的憲法和一般文獻。",
+    "fr": "Wikisource est une bibliothèque de textes de référence et de documents historiques sous licence libre, qu’il s’agisse de poèmes, de documents officiels, de constitutions de nombreux pays ou de littérature générale.",
+    "es": "Wikisource es una biblioteca de licencias libres, textos y documentos históricos incluyendo poesía, documentos de gobierno, constituciones de muchos países y literatura en general."
+  },
+  "url": "wikisource.org",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/HS37uGx.png",
+  "thumbnail": "https://i.imgur.com/K7f8lKG.png",
+  "color": "#f9f9f9",
+  "tags": [
+    "information",
+    "library",
+    "reading",
+    "wiki",
+    "wikimedia-foundation",
+    "wikimedia",
+    "wmf"
+  ],
+  "category": "other",
+  "regExp": "([a-z0-9-]+[.])*wikisource[.]org[/]"
+}

--- a/websites/W/Wikisource/presence.ts
+++ b/websites/W/Wikisource/presence.ts
@@ -1,0 +1,200 @@
+const presence = new Presence({
+  clientId: "733216897562050570"
+});
+
+let currentURL = new URL(document.location.href),
+  currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
+const browsingStamp = Math.floor(Date.now() / 1000);
+let presenceData: PresenceData = {
+  details: "Viewing an unsupported page",
+  largeImageKey: "lg",
+  startTimestamp: browsingStamp
+};
+const updateCallback = {
+  _function: null as Function,
+  get function(): Function {
+    return this._function;
+  },
+  set function(parameter) {
+    this._function = parameter;
+  },
+  get present(): boolean {
+    return this._function !== null;
+  }
+},
+
+/**
+ * Initialize/reset presenceData.
+ */
+ resetData = (
+  defaultData: PresenceData = {
+    details: "Viewing an unsupported page",
+    largeImageKey: "lg",
+    startTimestamp: browsingStamp
+  }
+): void => {
+  currentURL = new URL(document.location.href);
+  currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
+  presenceData = { ...defaultData };
+},
+
+/**
+ * Search for URL parameters.
+ * @param urlParam The parameter that you want to know about the value.
+ */
+ getURLParam = (urlParam: string): string => {
+  return currentURL.searchParams.get(urlParam);
+};
+
+((): void => {
+  let title: string;
+  const actionResult = getURLParam("action") || getURLParam("veaction"),
+    lang = currentURL.hostname.split(".")[0],
+
+   titleFromURL = (): string => {
+    const raw =
+      currentPath[1] === "index.php"
+        ? getURLParam("title")
+        : currentPath.slice(1).join("/");
+    return decodeURI(raw.replace(/_/g, " "));
+  };
+
+  try {
+    title = document.querySelector("h1").textContent;
+  } catch (e) {
+    title = titleFromURL();
+  }
+
+  /**
+   * Returns details based on the namespace.
+   * @link https://en.wikisource.org/wiki/Help:Namespaces
+   */
+  const namespaceDetails = (): string => {
+    const details: { [index: string]: string } = {
+      "-2": "Viewing a media",
+      "-1": "Viewing a special page",
+      0: "Reading a work",
+      1: "Viewing a talk page",
+      2: "Viewing a user page",
+      3: "Viewing a user talk page",
+      4: "Viewing a project page",
+      5: "Viewing a project talk page",
+      6: "Viewing a file",
+      7: "Viewing a file talk page",
+      8: "Viewing an interface page",
+      9: "Viewing an interface talk page",
+      10: "Viewing a template",
+      11: "Viewing a template talk page",
+      12: "Viewing a help page",
+      13: "Viewing a help talk page",
+      14: "Viewing a category",
+      15: "Viewing a category talk page",
+      100: "Viewing a portal",
+      101: "Viewing a portal talk page",
+      102: "Viewing an author",
+      103: "Viewing an author talk page",
+      104: "Reading a page",
+      105: "Viewing a page talk page",
+      106: "Viewing an index",
+      107: "Viewing an index talk page",
+      114: "Viewing a translation",
+      115: "Viewing a translation talk page",
+      828: "Viewing a module",
+      829: "Viewing a module talk page",
+      2300: "Viewing a gadget",
+      2301: "Viewing a gadget talk page",
+      2302: "Viewing a gadget definition page",
+      2303: "Viewing a gadget definition talk page",
+      2600: "Viewing a topic"
+    };
+    return (
+      details[
+        [...document.querySelector("body").classList]
+          .filter((v) => /ns--?\d/.test(v))[0]
+          .slice(3)
+      ] || "Viewing a page"
+    );
+  };
+
+  //
+  // Important note:
+  //
+  // When checking for the current location, avoid using the URL.
+  // The URL is going to be different in other languages.
+  // Use the elements on the page instead.
+  //
+
+  if (
+    ((document.querySelector("#n-mainpage a") ||
+      document.querySelector("#p-navigation a") ||
+      document.querySelector(".mw-wiki-logo")) as HTMLAnchorElement).href ===
+    currentURL.href
+  ) {
+    presenceData.details = "On the main page";
+  } else if (document.querySelector("#wpLoginAttempt")) {
+    presenceData.details = "Logging in";
+  } else if (document.querySelector("#wpCreateaccount")) {
+    presenceData.details = "Creating an account";
+  } else if (document.querySelector(".searchresults")) {
+    presenceData.details = "Searching for a page";
+    presenceData.state = (document.querySelector(
+      "input[type=search]"
+    ) as HTMLInputElement).value;
+  } else if (getURLParam("diff")) {
+    presenceData.details = "Viewing difference between revisions";
+    presenceData.state = titleFromURL();
+  } else if (getURLParam("oldid")) {
+    presenceData.details = "Viewing an old revision of a page";
+    presenceData.state = titleFromURL();
+  } else if (document.querySelector("#pt-logout") || getURLParam("veaction")) {
+    presenceData.state = `${
+      title.toLowerCase() === titleFromURL().toLowerCase()
+        ? `${title}`
+        : `${title} (${titleFromURL()})`
+    }`;
+    updateCallback.function = (): void => {
+      if (actionResult == "edit" || actionResult == "editsource") {
+        presenceData.details = "Editing a page";
+      } else {
+        presenceData.details = namespaceDetails();
+      }
+    };
+  } else {
+    if (actionResult == "edit") {
+      presenceData.details = "Editing a page";
+      presenceData.state = titleFromURL();
+    } else {
+      presenceData.details = namespaceDetails();
+      presenceData.state = `${
+        title.toLowerCase() === titleFromURL().toLowerCase()
+          ? `${title}`
+          : `${title} (${titleFromURL()})`
+      }`;
+    }
+  }
+
+  if (lang === "wikisource") {
+    if (presenceData.details === "On the main page")
+      presenceData.details = "On the home page";
+    else {
+      if (presenceData.state) presenceData.state += " (multilingual)";
+      else presenceData.details += " (multilingual)";
+    }
+  } else if (lang !== "en") {
+    if (presenceData.state) presenceData.state += ` (${lang})`;
+    else presenceData.details += ` (${lang})`;
+  }
+})();
+
+if (updateCallback.present) {
+  const defaultData = { ...presenceData };
+  presence.on("UpdateData", async () => {
+    resetData(defaultData);
+    updateCallback.function();
+    presence.setActivity(presenceData);
+  });
+} else {
+  presence.on("UpdateData", async () => {
+    presence.setActivity(presenceData);
+  });
+}

--- a/websites/W/Wikisource/tsconfig.json
+++ b/websites/W/Wikisource/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/"
+  }
+}


### PR DESCRIPTION
# Wikisource (1.0.0)

*See also: Hans5958/PreMiD-Presences-Personal#3*

## Preword

This is a presence for Wikisource (www.wikisource.org), a website from Wikimedia Foundation (the same company that made Wikipedia) that contains texts of various stuffs. It's basically a library.

## Notes

- This presence supports all languages of Wikisource, including the multilingual one on wikisource.org.
- It works essentially the same as how the Wikipedia presence works.

## Images

| Image | Link visited |
| ----- | ------------ |
| ![](https://user-images.githubusercontent.com/11584103/90757178-8393d000-e307-11ea-963b-24271e36162b.png) | https://www.wikisource.org |
| ![](https://user-images.githubusercontent.com/11584103/90757198-88588400-e307-11ea-8c60-dfc22b998df7.png) | https://en.wikisource.org/wiki/Main_Page |
| ![](https://user-images.githubusercontent.com/11584103/90757203-8989b100-e307-11ea-8523-be3129e22b12.png) | https://en.wikisource.org/wiki/1911_Encyclop%C3%A6dia_Britannica |