### PR TITLE
Add Wikispecies presence

### DIFF
--- a/websites/W/Wikispecies/dist/metadata.json
+++ b/websites/W/Wikispecies/dist/metadata.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.1",
+  "author": {
+    "name": "Hans5958",
+    "id": "279855717203050496"
+  },
+  "service": "Wikispecies",
+  "description": {
+    "en": "Wikispecies is a species database for taxonomy that covers living and fossil representatives of Animalia, Plantae, Fungi, Bacteria, Archaea, Protista and all other forms of life.",
+    "zh_CN": "維基物種是分類學物種數據庫，涵蓋動物界，植物界，真菌，細菌，古細菌，原生生物和所有其他形式的生命的生活和化石形態。",
+    "fr": "Wikispecies est une base de données taxonomiques pour les espèces vivantes et fossiles d’Animalia, Plantae, Fungi, Bacteria, Archaea, Protista et toute autre forme de vie.",
+    "es": "Wikiespecies el la base de datos de especies por taxonomía que incluye representantes vivos y fósiles de Animalia, Plantae, Fungi, Bacteria, Archaea, Protista y otras formas de vida."
+  },
+  "url": "species.wikimedia.org",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/9f1XxZE.png",
+  "thumbnail": "https://i.imgur.com/5SnUKIH.png",
+  "color": "#f9f9f9",
+  "tags": ["information", "wiki", "wikimedia-foundation", "wikimedia", "wmf"],
+  "category": "other"
+}

--- a/websites/W/Wikispecies/presence.ts
+++ b/websites/W/Wikispecies/presence.ts
@@ -1,0 +1,181 @@
+const presence = new Presence({
+  clientId: "733216914951897118"
+});
+
+let currentURL = new URL(document.location.href),
+  currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
+const browsingStamp = Math.floor(Date.now() / 1000);
+let presenceData: PresenceData = {
+  details: "Viewing an unsupported page",
+  largeImageKey: "lg",
+  startTimestamp: browsingStamp
+};
+const updateCallback = {
+  _function: null as Function,
+  get function(): Function {
+    return this._function;
+  },
+  set function(parameter) {
+    this._function = parameter;
+  },
+  get present(): boolean {
+    return this._function !== null;
+  }
+},
+
+/**
+ * Initialize/reset presenceData.
+ */
+ resetData = (
+  defaultData: PresenceData = {
+    details: "Viewing an unsupported page",
+    largeImageKey: "lg",
+    startTimestamp: browsingStamp
+  }
+): void => {
+  currentURL = new URL(document.location.href);
+  currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
+  presenceData = { ...defaultData };
+},
+
+/**
+ * Search for URL parameters.
+ * @param urlParam The parameter that you want to know about the value.
+ */
+ getURLParam = (urlParam: string): string => {
+  return currentURL.searchParams.get(urlParam);
+};
+
+((): void => {
+  let title: string;
+  const actionResult = getURLParam("action") || getURLParam("veaction"),
+
+   titleFromURL = (): string => {
+    const raw =
+      currentPath[1] === "index.php"
+        ? getURLParam("title")
+        : currentPath.slice(1).join("/");
+    return decodeURI(raw.replace(/_/g, " "));
+  };
+
+  try {
+    title = document.querySelector("h1").textContent;
+  } catch (e) {
+    title = titleFromURL();
+  }
+
+  /**
+   * Returns details based on the namespace.
+   * @link https://species.wikimedia.org/wiki/Special:PrefixIndex
+   */
+  const namespaceDetails = (): string => {
+    const details: { [index: string]: string } = {
+      "-2": "Viewing a media",
+      "-1": "Viewing a special page",
+      0: "Reading an article",
+      1: "Viewing a talk page",
+      2: "Viewing a user page",
+      3: "Viewing a user talk page",
+      4: "Viewing a project page",
+      5: "Viewing a project talk page",
+      6: "Viewing a file",
+      7: "Viewing a file talk page",
+      8: "Viewing an interface page",
+      9: "Viewing an interface talk page",
+      10: "Viewing a template",
+      11: "Viewing a template talk page",
+      12: "Viewing a help page",
+      13: "Viewing a help talk page",
+      14: "Viewing a category",
+      15: "Viewing a category talk page",
+      100: "Viewing a portal",
+      101: "Viewing a portal talk page",
+      828: "Viewing a module",
+      829: "Viewing a module talk page",
+      1198: "Viewing a translation",
+      1199: "Viewing a translation talk page",
+      2300: "Viewing a gadget",
+      2301: "Viewing a gadget talk page",
+      2302: "Viewing a gadget definition page",
+      2303: "Viewing a gadget definition talk page",
+      2600: "Viewing a topic"
+    };
+    return (
+      details[
+        [...document.querySelector("body").classList]
+          .filter((v) => /ns--?\d/.test(v))[0]
+          .slice(3)
+      ] || "Viewing a page"
+    );
+  };
+
+  //
+  // Important note:
+  //
+  // When checking for the current location, avoid using the URL.
+  // The URL is going to be different in other languages.
+  // Use the elements on the page instead.
+  //
+
+  if (
+    ((document.querySelector("#n-mainpage a") ||
+      document.querySelector("#p-navigation a") ||
+      document.querySelector(".mw-wiki-logo")) as HTMLAnchorElement).href ===
+    currentURL.href
+  ) {
+    presenceData.details = "On the main page";
+  } else if (document.querySelector("#wpLoginAttempt")) {
+    presenceData.details = "Logging in";
+  } else if (document.querySelector("#wpCreateaccount")) {
+    presenceData.details = "Creating an account";
+  } else if (document.querySelector(".searchresults")) {
+    presenceData.details = "Searching for a page";
+    presenceData.state = (document.querySelector(
+      "input[type=search]"
+    ) as HTMLInputElement).value;
+  } else if (getURLParam("diff")) {
+    presenceData.details = "Viewing difference between revisions";
+    presenceData.state = titleFromURL();
+  } else if (getURLParam("oldid")) {
+    presenceData.details = "Viewing an old revision of a page";
+    presenceData.state = titleFromURL();
+  } else if (document.querySelector("#pt-logout") || getURLParam("veaction")) {
+    presenceData.state = `${
+      title.toLowerCase() === titleFromURL().toLowerCase()
+        ? `${title}`
+        : `${title} (${titleFromURL()})`
+    }`;
+    updateCallback.function = (): void => {
+      if (actionResult == "edit" || actionResult == "editsource") {
+        presenceData.details = "Editing a page";
+      } else {
+        presenceData.details = namespaceDetails();
+      }
+    };
+  } else {
+    if (actionResult == "edit") {
+      presenceData.details = "Editing a page";
+      presenceData.state = titleFromURL();
+    } else {
+      presenceData.details = namespaceDetails();
+      presenceData.state = `${
+        title.toLowerCase() === titleFromURL().toLowerCase()
+          ? `${title}`
+          : `${title} (${titleFromURL()})`
+      }`;
+    }
+  }
+})();
+
+if (updateCallback.present) {
+  const defaultData = { ...presenceData };
+  presence.on("UpdateData", async () => {
+    resetData(defaultData);
+    updateCallback.function();
+    presence.setActivity(presenceData);
+  });
+} else {
+  presence.on("UpdateData", async () => {
+    presence.setActivity(presenceData);
+  });
+}

--- a/websites/W/Wikispecies/tsconfig.json
+++ b/websites/W/Wikispecies/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/"
+  }
+}


### PR DESCRIPTION
*See also: Hans5958/PreMiD-Presences-Personal#3*

## Preword

This is a presence for Wikispecies (species.wikimedia.org), a website from Wikimedia Foundation (the same company that made Wikipedia) that is a directory for species around the world.

## Notes

- It works essentially the same as how the Wikipedia presence works.

## Images

| Image | Link visited |
| ----- | ------------ |
| ![](https://user-images.githubusercontent.com/11584103/90757331-b63dc880-e307-11ea-8d9b-a544a36108a2.png) | https://species.wikimedia.org/wiki/Main_Page |
| ![](https://user-images.githubusercontent.com/11584103/90757338-b76ef580-e307-11ea-8cab-b98e54e020ed.png) | https://species.wikimedia.org/wiki/Rafflesia_arnoldii |