### PR TITLE
Fix Trello presence showing private boards

### DIFF
--- a/websites/T/Trello/dist/metadata.json
+++ b/websites/T/Trello/dist/metadata.json
@@ -25,5 +25,13 @@
     "list",
     "management"
   ],
-  "category": "other"
+  "category": "other",
+  "settings": [
+    {
+      "id": "displayPrivateBoards",
+      "title": "Display Private Boards",
+      "icon": "fas fa-lock",
+      "value": false
+    }
+  ]
 }

--- a/websites/T/Trello/dist/metadata.json
+++ b/websites/T/Trello/dist/metadata.json
@@ -14,7 +14,7 @@
     "blog.trello.com",
     "developers.trello.com"
   ],
-  "version": "2.1.7",
+  "version": "2.1.8",
   "logo": "https://i.imgur.com/5IK6wjd.png",
   "thumbnail": "https://i.imgur.com/6V8VR6S.png",
   "color": "#0080cb",

--- a/websites/T/Trello/presence.ts
+++ b/websites/T/Trello/presence.ts
@@ -22,8 +22,8 @@ presence.on("UpdateData", async () => {
       ) {
         if (
           document.querySelector(
-            "#permission-level > span.board-header-btn-text"
-          ).textContent === "Private"
+            "#permission-level > span.board-header-btn-icon"
+          ).classList.contains('icon-private')
         ) {
           presenceData.details = "Viewing private board";
         } else {
@@ -47,8 +47,8 @@ presence.on("UpdateData", async () => {
         presenceData.details = "Viewing board:";
         if (
           document.querySelector(
-            "#permission-level > span.board-header-btn-text"
-          ).textContent === "Private"
+            "#permission-level > span.board-header-btn-icon"
+          ).classList.contains('icon-private')
         ) {
           presenceData.details = "Viewing private board";
         } else {
@@ -60,8 +60,9 @@ presence.on("UpdateData", async () => {
       presenceData.smallImageKey = "reading";
     } else if (document.location.pathname.includes("/c/")) {
       if (
-        document.querySelector("#permission-level > span.board-header-btn-text")
-          .textContent === "Private"
+        document.querySelector(
+          "#permission-level > span.board-header-btn-icon"
+        ).classList.contains('icon-private')
       ) {
         presenceData.details = "Viewing private card";
         presenceData.state = "Private Board";

--- a/websites/T/Trello/presence.ts
+++ b/websites/T/Trello/presence.ts
@@ -11,6 +11,7 @@ presence.on("UpdateData", async () => {
     largeImageKey: "trello"
   };
 
+  const displayPrivateBoards = await presence.getSetting("displayPrivateBoards");
   presenceData.startTimestamp = browsingStamp;
 
   if (document.location.hostname == "trello.com") {
@@ -23,7 +24,7 @@ presence.on("UpdateData", async () => {
         if (
           document.querySelector(
             "#permission-level > span.board-header-btn-icon"
-          ).classList.contains('icon-private')
+          ).classList.contains('icon-private') && !displayPrivateBoards
         ) {
           presenceData.details = "Viewing private board";
         } else {
@@ -48,7 +49,7 @@ presence.on("UpdateData", async () => {
         if (
           document.querySelector(
             "#permission-level > span.board-header-btn-icon"
-          ).classList.contains('icon-private')
+          ).classList.contains('icon-private') && !displayPrivateBoards
         ) {
           presenceData.details = "Viewing private board";
         } else {
@@ -62,7 +63,7 @@ presence.on("UpdateData", async () => {
       if (
         document.querySelector(
           "#permission-level > span.board-header-btn-icon"
-        ).classList.contains('icon-private')
+        ).classList.contains('icon-private') && !displayPrivateBoards
       ) {
         presenceData.details = "Viewing private card";
         presenceData.state = "Private Board";

--- a/websites/T/Trello/presence.ts
+++ b/websites/T/Trello/presence.ts
@@ -9,9 +9,9 @@ var browsingStamp = Math.floor(Date.now() / 1000);
 presence.on("UpdateData", async () => {
   const presenceData: PresenceData = {
     largeImageKey: "trello"
-  };
-
-  const displayPrivateBoards = await presence.getSetting("displayPrivateBoards");
+  },
+  displayPrivateBoards = await presence.getSetting("displayPrivateBoards");
+  
   presenceData.startTimestamp = browsingStamp;
 
   if (document.location.hostname == "trello.com") {


### PR DESCRIPTION
Fixes #2006

#2017 fixed that issue already and it is working but only when the page is set to English

![image](https://user-images.githubusercontent.com/23432278/95649876-38649500-0ae0-11eb-831b-0574332bb6a2.png)

The current solution detects if text on the button is `Private` but my solution detects presence of "lock" icon

![image](https://user-images.githubusercontent.com/23432278/95649927-a01ae000-0ae0-11eb-8b39-3b23e469c8d3.png)

![image](https://user-images.githubusercontent.com/23432278/95649880-431f2a00-0ae0-11eb-9e41-c16a3e1b00c0.png)
