### PR TITLE
New Presence: Origin

### DIFF
--- a/websites/O/Origin/dist/metadata.json
+++ b/websites/O/Origin/dist/metadata.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.0",
+  "author": {
+    "name": "mmatt",
+    "id": "308000668181069824"
+  },
+  "url": [
+    "www.origin.com",
+    "origin.com"
+  ],
+  "description": {
+    "en": "EA's Webstore for buying EA Games."
+  },
+  "service": "Origin",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/KXWzOsC.png",
+  "thumbnail": "https://i.imgur.com/ouRWcio.jpg",
+  "color": "#f56c2d",
+  "tags": [
+    "ea",
+    "games",
+    "store",
+    "webstore",
+    "eagames"
+  ],
+  "category": "games"
+}

--- a/websites/O/Origin/presence.ts
+++ b/websites/O/Origin/presence.ts
@@ -1,0 +1,33 @@
+const path = window.location.pathname;
+const browsingStamp = Math.floor(Date.now() / 1000),
+  presence = new Presence({
+    clientId: "773080268126683186"
+  });
+let title, timestamp;
+
+presence.on("UpdateData", async () => {
+  const presenceData: PresenceData = {
+    largeImageKey: "origin_logo",
+    smallImageKey: "shop_icon"
+  };
+
+  if (
+    document.location.pathname == "/" ||
+    document.location.pathname == "/usa/en-us/store"
+  ) {
+    presenceData.startTimestamp = browsingStamp;
+    presenceData.details = "Viewing the homepage.";
+  }
+  else{
+    presenceData.startTimestamp = browsingStamp;
+    presenceData.details = "Browsing Games"
+  }
+  // I would like it so that the presenceData.details just has the webpage Title, like what shows in the tab on your browser.
+
+  if (presenceData.details == null) {
+    presence.setTrayTitle();
+    presence.setActivity();
+  } else {
+    presence.setActivity(presenceData);
+  }
+});

--- a/websites/O/Origin/tsconfig.json
+++ b/websites/O/Origin/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/"
+  }
+}


### PR DESCRIPTION
Pretty finished, but not many "features"
I would like it so that the `presenceData.details` just has the webpage Title, like what shows in the tab on your browser, but I'm not sure on how to do that yet.

Visiting the homepage:
![Visiting the homepage](https://user-images.githubusercontent.com/30363562/97959487-14aa0d00-1d75-11eb-9a56-d5601f43233c.png)

Browsing Games:
![Browsing Games](https://user-images.githubusercontent.com/30363562/97959457-0825b480-1d75-11eb-9fbb-bb2dd2593bfd.png)
