### PR TITLE
GitHub: Detect Codespace browsing

### DIFF
--- a/websites/G/GitHub/dist/metadata.json
+++ b/websites/G/GitHub/dist/metadata.json
@@ -18,7 +18,7 @@
     "pl": "GitHub to system do zarządzania projektami i wersjonowania kodu, a także platforma społecznościowa stworzona dla programistów."
   },
   "url": "github.com",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "logo": "https://i.imgur.com/mGxuWWu.png",
   "thumbnail": "https://i.imgur.com/G816tlo.png",
   "color": "#000000",

--- a/websites/G/GitHub/presence.ts
+++ b/websites/G/GitHub/presence.ts
@@ -160,6 +160,12 @@ presence.on("UpdateData", async () => {
     presenceData.startTimestamp = browsingStamp;
 
     delete presenceData.details;
+  } else if (document.location.pathname.startsWith("/codespaces")) {
+    presenceData.state = "Browsing codespaces...";
+
+    presenceData.startTimestamp = browsingStamp;
+
+    delete presenceData.details;
   } else if (document.location.pathname.indexOf(search)) {
     presenceData.details = "Searching for: ";
 


### PR DESCRIPTION
Adds "Browsing codespaces..." to people that are viewing the [codespaces page](https://github.com/codespaces/) ([image](https://get.snaz.in/8c7uEkh.png))

> At the moment, codespaces are [available to a small group of GitHub users while in limited beta](https://github.com/features/codespaces#faq), so it may or may not be available for you. I can show this off a bit more if needed.

![](https://get.snaz.in/4xhjbxW.png)