### PR TITLE
GitHub Codespaces: Add ext argument

### DIFF
--- a/websites/G/GitHub Codespaces/dist/metadata.json
+++ b/websites/G/GitHub Codespaces/dist/metadata.json
@@ -10,7 +10,7 @@
     "en": "Contribute to projects without complicating your local setup. Spin up dev environments with a click — even for projects you haven't worked on before — and switch between them with ease."
   },
   "service": "GitHub Codespaces",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/JWaYQC8.png",
   "thumbnail": "https://i.imgur.com/fLQ6JLS.png",
   "color": "#000000",
@@ -26,14 +26,14 @@
         "title": "Details Template",
         "icon": "fas fa-info",
         "value": "Editing %file%",
-        "placeholder": "can use %file%, %path%, %workspace%, %folder%, %workspaceOrFolder%"
+        "placeholder": "can use %file%, %path%, %workspace%, %folder%, %workspaceOrFolder%, %ext%"
       },
       {
         "id": "state",
         "title": "State Template",
         "icon": "fas fa-bars",
         "value": "Workspace: %workspace%",
-        "placeholder": "can use %file%, %path%, %workspace%, %folder%, %workspaceOrFolder%"
+        "placeholder": "can use %file%, %path%, %workspace%, %folder%, %workspaceOrFolder%, %ext%"
       }
     ]
 }

--- a/websites/G/GitHub Codespaces/presence.ts
+++ b/websites/G/GitHub Codespaces/presence.ts
@@ -581,12 +581,14 @@ presence.on('UpdateData', async () => {
       .replace(/%file%/g, filename)
       .replace(/%path%/g, filepath)
       .replace(/%folder%/g, filepath.split('/').reverse()[1])
+      .replace(/%ext%/g, (largeImageKey ? largeImageKey.image : 'txt').toUpperCase())
       .replace(/%workspace%/g, scmTab && scmTab.hasAttribute('title') ? scmTab.getAttribute('title').split(' (Git)')[0] : 'N/A')
       .replace(/%workspaceOrFolder%/g, scmTab && scmTab.hasAttribute('title') ? scmTab.getAttribute('title').split(' (Git)')[0] : filepath.split('/').reverse()[1]);
     data.state = (await presence.getSetting('state'))
       .replace(/%file%/g, filename)
       .replace(/%path%/g, filepath)
       .replace(/%folder%/g, filepath.split('/').reverse()[1])
+      .replace(/%ext%/g, (largeImageKey ? largeImageKey.image : 'txt').toUpperCase())
       .replace(/%workspace%/g, scmTab && scmTab.hasAttribute('title') ? scmTab.getAttribute('title').split(' (Git)')[0] : 'N/A')
       .replace(/%workspaceOrFolder%/g, scmTab && scmTab.hasAttribute('title') ? scmTab.getAttribute('title').split(' (Git)')[0] : filepath.split('/').reverse()[1]);
   } else if (!editorMode) {


### PR DESCRIPTION
This PR adds the `%ext%` argument to the `details` and `state` options.
- i.e. `main.ts` has an `%ext` of `"TS"`