### PR TITLE
Update to new Wikipedia logo

### DIFF
--- a/websites/W/Wikipedia/dist/metadata.json
+++ b/websites/W/Wikipedia/dist/metadata.json
@@ -21,7 +21,7 @@
     "zh_CN": "维基百科是一种多语言的在线百科全书，包含基于Wiki的内容的协作编辑系统。"
   },
   "url": "wikipedia.org",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "logo": "https://i.imgur.com/JyyHKLB.png",
   "thumbnail": "https://i.imgur.com/vJiuzZy.png",
   "color": "#f9f9f9",

--- a/websites/W/Wikipedia/dist/metadata.json
+++ b/websites/W/Wikipedia/dist/metadata.json
@@ -22,7 +22,7 @@
   },
   "url": "wikipedia.org",
   "version": "2.7.5",
-  "logo": "https://i.imgur.com/zFdTVKT.png",
+  "logo": "https://i.imgur.com/JyyHKLB.png",
   "thumbnail": "https://i.imgur.com/vJiuzZy.png",
   "color": "#f9f9f9",
   "tags": [


### PR DESCRIPTION
Currently using the old logo. Updated to the new one.