### PR TITLE
top.gg - added Presence-settings and fixed voting presence

### DIFF
--- a/websites/T/top.gg/dist/metadata.json
+++ b/websites/T/top.gg/dist/metadata.json
@@ -7,6 +7,10 @@
     {
       "name": "Eren",
       "id": "478937019758673931"
+    },
+    {
+      "name": "Aurel",
+      "id": "669452973755072524"
     }
   ],
   "service": "top.gg",
@@ -16,7 +20,7 @@
     "de": "Rich Presence für top.gg - Die größte Discord Bot Liste und mehr"
   },
   "url": "top.gg",
-  "version": "1.3.9",
+  "version": "1.4.1",
   "logo": "https://i.imgur.com/fu207UB.png",
   "thumbnail": "https://i.imgur.com/6RKANLa.png",
   "color": "#7289DA",
@@ -25,5 +29,64 @@
     "bot",
     "gaming"
   ],
-  "category": "other"
+  "category": "other",
+  "settings": [
+    {
+      "id": "privacy",
+      "title": "Privacy",
+      "icon": "fas fa-user-secret",
+      "value": false
+    },
+    {
+      "id": "server",
+      "if": {
+        "privacy": true
+      },
+      "title": "Show server",
+      "icon": "fas fa-server",
+      "value": true
+    },
+    {
+      "id": "bots",
+      "if": {
+        "privacy": true
+      },
+      "title": "Show bot",
+      "icon": "fas fa-robot",
+      "value": true
+    },
+    {
+      "id": "profiles",
+      "if": {
+        "privacy": true
+      },
+      "title": "Show profile",
+      "icon": "fas fa-user",
+      "value": true
+    },
+    {
+      "id": "staffsection",
+      "title": "Staff Section",
+      "icon": "fas fa-address-card",
+      "value": true
+    },
+    {
+      "id": "reviewedcount",
+      "if": {
+        "staffsection": true
+      },
+      "title": "Show review count",
+      "icon": "fas fa-walking",
+      "value": true
+    },
+    {
+      "id": "decline",
+      "if": {
+        "staffsection": true
+      },
+      "title": "Show declining",
+      "icon": "fas fa-times-circle",
+      "value": true
+    }
+  ]
 }

--- a/websites/T/top.gg/presence.ts
+++ b/websites/T/top.gg/presence.ts
@@ -2,7 +2,6 @@ const presence = new Presence({
   clientId: "629380028576301093"
 });
 
-
 presence.on("UpdateData", async () => {
   const presenceData: PresenceData = {
       largeImageKey: "dblregular"

--- a/websites/T/top.gg/presence.ts
+++ b/websites/T/top.gg/presence.ts
@@ -2,113 +2,195 @@ const presence = new Presence({
   clientId: "629380028576301093"
 });
 
+
 presence.on("UpdateData", async () => {
   const presenceData: PresenceData = {
-    largeImageKey: "dblregular"
-  };
+      largeImageKey: "dblregular"
+    },
+    privacy = await presence.getSetting("privacy"),
+    showServerInfo = (privacy ? await presence.getSetting("server") : true),
+    showBotInfo = (privacy ? await presence.getSetting("bots") : true),
+    showProfileVisit = (privacy ? await presence.getSetting("profiles") : true),
+    showStaff = await presence.getSetting("staffsection"),
+    showReviewCount = await presence.getSetting("reviewedcount"),
+    showDecline = await presence.getSetting("decline"),
+    isStaff = document.querySelectorAll(".menu")[0].textContent.trim().includes("Moderation");
+
+  if (isStaff) {
+    await presence.showSetting("staffsection");
+    await presence.showSetting("reviewedcount");
+    await presence.showSetting("decline");
+  } else {
+    await presence.hideSetting("staffsection");
+    await presence.hideSetting("reviewedcount");
+    await presence.hideSetting("decline");
+  }
+
   presenceData.details = "Viewing Page:";
 
   //Discord Bot List
   if (window.location.pathname.startsWith("/moderation")) {
-    presenceData.details = "Viewing DBL Staff section:";
-    presenceData.largeImageKey = "dblstaff";
 
-    if (window.location.pathname == "/moderation") {
-      const personalquota = document.getElementsByClassName("quotaindiv")[0]
-        .textContent;
-      const botamount = personalquota.substring(
-        personalquota.indexOf("reviewed") + 9,
-        personalquota.indexOf("/")
-      );
-      presenceData.state = "Reviewed " + botamount + " bots this week";
-    } else if (window.location.pathname == "/moderation/approve") {
-      presenceData.state = "Verification Queue";
-    } else if (window.location.pathname == "/moderation/certify") {
-      presenceData.state = "Certification Queue";
-    } else if (window.location.pathname == "/moderation/reports") {
-      presenceData.state = "Reports Queue";
-    } else if (window.location.pathname == "/moderation/reviews") {
-      presenceData.state = "Reviews Dashboard";
-    } else if (window.location.pathname.startsWith("/moderation/decline")) {
-      presenceData.state = document.querySelector("#botlistitle").textContent;
+    if (!showStaff) {
+
+      presenceData.details = "Discord Bot List";
+    } else {
+      presenceData.details = "Viewing DBL Staff section";
+      presenceData.largeImageKey = "dblstaff";
+
+      if (window.location.pathname == "/moderation") {
+        if (showReviewCount) {
+          const personalquota = document.getElementsByClassName("quotaindiv")[0]
+              .textContent,
+            botamount = personalquota.substring(
+              personalquota.indexOf("reviewed") + 9,
+              personalquota.indexOf("/")
+            );
+          presenceData.state = "Reviewed " + botamount + " bots this week";
+        }
+      } else if (window.location.pathname == "/moderation/approve") {
+        presenceData.state = "Verification Queue";
+      } else if (window.location.pathname == "/moderation/certify") {
+        presenceData.state = "Certification Queue";
+      } else if (window.location.pathname == "/moderation/reports") {
+        presenceData.state = "Reports Queue";
+      } else if (window.location.pathname == "/moderation/reviews") {
+        presenceData.state = "Reviews Dashboard";
+      } else if (window.location.pathname.startsWith("/moderation/decline")) {
+        if (showDecline) {
+          presenceData.state = document.querySelector("#botlistitle").textContent;
+        }
+      }
     }
   } else if (window.location.pathname.startsWith("/bot/")) {
     if (window.location.pathname.endsWith("/edit")) {
-      presenceData.details = "Editing a Discord bot:";
-      presenceData.state = document
-        .querySelector("#botlistitle")
-        .textContent.substring(8);
+      presenceData.details = "Editing a Discord bot";
+      if (showBotInfo) {
+        presenceData.state = document
+          .querySelector("#botlistitle")
+          .textContent.substring(8);
+      }
     } else if (window.location.pathname.endsWith("/vote")) {
-      presenceData.details = "Voting for a Discord bot:";
-      presenceData.state = document
-        .querySelector("#totalContent > div > p")
-        .textContent.trim();
+      presenceData.details = "Voting for a Discord bot";
+      if (showBotInfo) {
+        presenceData.state = document
+          .querySelector("#entity-title")
+          .textContent.trim();
+      }
     } else if (window.location.pathname.endsWith("/report")) {
       //Might not be the smartest idea to expose someone reporting bots
       presenceData.state = "Discord Bot List";
     } else if (window.location.pathname.endsWith("/new")) {
       presenceData.state = "Add a bot";
     } else if (document.querySelector(".entity-queue-message__indicator")) {
-      presenceData.details =
-        "Viewing a Discord bot: " +
-        document.querySelector(".entity-header__name").textContent.trim();
-      presenceData.largeImageKey = "dblstaff";
-      presenceData.state = "Bot isn't approved yet";
+      if (showBotInfo) {
+        presenceData.details =
+          "Viewing a Discord bot: " +
+          document
+            .querySelector(".entity-header__name")
+            .textContent.trim();
+        if (isStaff) {
+          presenceData.largeImageKey = "dblstaff";
+        }
+        presenceData.state = "Bot isn't approved yet";
+      } else {
+        presenceData.details =
+          "Viewing a Discord bot";
+      }
     } else {
-      presenceData.details = "Viewing a Discord bot:";
-      presenceData.state = document
-        .querySelector(".entity-header__name")
-        .textContent.trim();
+      presenceData.details = "Viewing a Discord bot";
+      if (showBotInfo) {
+        presenceData.state = document
+          .querySelector(".entity-header__name")
+          .textContent.trim();
+      }
     }
   } else if (window.location.pathname.startsWith("/list/")) {
-    presenceData.details = "Viewing a list of Discord bots:";
-    presenceData.state = document
-      .querySelector("#botlistitle")
-      .textContent.split("-")[0]
-      .trim();
+    presenceData.details = "Viewing a list of Discord bots";
+
+    if (showBotInfo) {
+      presenceData.state = document
+        .querySelector("#botlistitle")
+        .textContent.split("-")[0]
+        .trim();
+    }
   } else if (window.location.pathname.startsWith("/tag/")) {
-    presenceData.details = "Viewing Discord bots with tag:";
-    presenceData.state = document
-      .querySelector("#botlistitle")
-      .textContent.split("-")[0]
-      .trim();
+    if (showBotInfo) {
+      presenceData.details = "Viewing Discord bots with tag";
+
+      presenceData.state = document
+        .querySelector("#botlistitle")
+        .textContent.split("-")[0]
+        .trim();
+    } else {
+      presenceData.details = "Viewing Discord Bots";
+
+    }
   } else if (
     window.location.pathname.startsWith("/user/") ||
     window.location.pathname == "/me"
   ) {
-    presenceData.details = "Viewing a profile:";
-    presenceData.state = document.querySelector(".header").textContent;
+    if (showProfileVisit) {
+      presenceData.details = "Viewing a profile:";
+      presenceData.state = document.querySelector(
+        ".header"
+      ).textContent;
+    } else {
+      presenceData.details = "Viewing a profile";
+    }
+
   } else if (window.location.pathname.startsWith("/api/docs")) {
     presenceData.state = "Discord Bot List API Documentation";
   }
 
   //Discord Server List
   else if (window.location.pathname.startsWith("/servers")) {
+
     presenceData.largeImageKey = "dslregular";
     if (
       window.location.pathname.startsWith("/servers/list/") ||
       window.location.pathname.startsWith("/servers/tag/")
     ) {
-      presenceData.details = "Viewing:";
-      presenceData.state = document.querySelector("#botlistitle").textContent;
-    } else if (document.querySelector(".entity-header__name")) {
+      if (showServerInfo) {
+        presenceData.details = "Viewing:";
+        presenceData.state = document.querySelector("#botlistitle").textContent;
+      } else {
+        presenceData.details = "Viewing Discord Servers";
+      }
+    } else if (
+      document.querySelector(".entity-header__name")
+    ) {
       if (document.querySelectorAll(".entity-header__button").length < 2) {
-        presenceData.details =
-          "Viewing a Discord Server | Server isn't published yet.";
+        if (showServerInfo) {
+          presenceData.details =
+            "Viewing a Discord Server | Server isn't published yet.";
+          presenceData.state = document
+            .querySelector(".entity-header__name")
+            .textContent.trim();
+        } else {
+          presenceData.details = "Viewing a Discord Server";
+        }
+      } else presenceData.details = "Viewing a Discord Server";
+      if (showServerInfo) {
         presenceData.state = document
           .querySelector(".entity-header__name")
           .textContent.trim();
-      } else presenceData.details = "Viewing a Discord Server:";
-      presenceData.state = document
-        .querySelector(".entity-header__name")
-        .textContent.trim();
+      }
     } else if (window.location.pathname.endsWith("/edit")) {
-      presenceData.details = "Editing a Discord Server:";
-      presenceData.state = document
-        .querySelector("#botlistitle")
-        .textContent.substring(8);
+      presenceData.details = "Editing a Discord Server";
+      if (showServerInfo) {
+        presenceData.state = document
+          .querySelector("#botlistitle")
+          .textContent.substring(8);
+      }
     } else if (window.location.pathname.startsWith("/servers/new")) {
       presenceData.details = "Adding a new Discord server...";
+    } else if (window.location.pathname.endsWith("/vote")) {
+      presenceData.details = "Voting for a Discord Server";
+      if (showServerInfo) {
+        presenceData.state = document.querySelector("#entity-title").textContent.trim();
+      }
+
     } else if (window.location.pathname.startsWith("/servers/me")) {
       presenceData.state = "My servers";
     } else {


### PR DESCRIPTION
Added settings for enabling/disabling specific aspects like showing the username of viewed profile on the presence and the server/bot name.
Additionally: Automatically hiding the Setting for users, who do not have access to the staff-section.

Added "Voting for discord server".
Added Staff Section options (showing reviewed bots, enable/disable the staff section presence, disable decline presence).

Fixed issue with the presence breaking when trying to vote for a bot (not showing "voting for bot").


Added settings
Staff-view: https://i.imgur.com/WApgRBS.png 
Normal user: https://i.imgur.com/fujnSNQ.png

Default (as staff): https://i.imgur.com/l1P2xE5.png
same with user, just without showing the staff section->Show declining options


Setting-Examples

Main site
Bot with "Show bot" disabled: https://i.imgur.com/7ycnJuH.png (applies to voting aswell)
Bot tags with "Show bot" disabled: https://i.imgur.com/iHBwSNK.png 
Server with "show server" disabled: https://i.imgur.com/NRSqAVB.png (applies to voting aswell)
Server tags with "show server" disabled: https://i.imgur.com/CQTLBei.png
Profile with "Show profile" disabled (both own profile and others): https://i.imgur.com/8PPJF2I.png

Staff-Section
Default: https://i.imgur.com/pVe8fub.png
Staff section disabled: https://i.imgur.com/cVeaQx5.png
Show Review count disabled: https://i.imgur.com/HVCbDjD.png
Show declining disabled: https://i.imgur.com/7VCTHsr.png


Fixes:
Voting on Server: https://i.imgur.com/yrR5n7E.png (previously broken)
Voting on Bot: https://i.imgur.com/5OAn6tO.png (previously broken)
