### PR TITLE
Add notifications and settings page to AniList Presence

### DIFF
--- a/websites/A/AniList/dist/metadata.json
+++ b/websites/A/AniList/dist/metadata.json
@@ -11,7 +11,6 @@
     "zh_TW": "AniList：追踪，發掘，分享動漫和漫畫-免費註冊！趕快加入我們！"
   },
   "url": "anilist.co",
-  "version": "1.4.5",
   "version": "1.4.6",
   "logo": "https://i.imgur.com/fqyhsZ5.png",
   "thumbnail": "https://i.imgur.com/ooIBlD5.jpg",

--- a/websites/A/AniList/dist/metadata.json
+++ b/websites/A/AniList/dist/metadata.json
@@ -12,6 +12,7 @@
   },
   "url": "anilist.co",
   "version": "1.4.5",
+  "version": "1.4.6",
   "logo": "https://i.imgur.com/fqyhsZ5.png",
   "thumbnail": "https://i.imgur.com/ooIBlD5.jpg",
   "color": "#02A9FF",

--- a/websites/A/AniList/presence.ts
+++ b/websites/A/AniList/presence.ts
@@ -63,6 +63,10 @@ presence.on("UpdateData", async () => {
     presenceData.state = `${author}`;
     presenceData.smallImageKey = `reading`;
     presenceData.smallImageText = (await strings).reading;
+  } else if (pathname.startsWith(`/notifications`)) {
+    presenceData.details = `Viewing notifications`;
+  } else if (pathname.startsWith(`/settings`)) {
+    presenceData.details = `Changing settings`;
   }
   presence.setActivity(presenceData, true);
 });


### PR DESCRIPTION
### Changes
`ADD` Notifications and Settings page to AniList. (they previously showed nothing)

### Screenshots
![image](https://user-images.githubusercontent.com/23330390/103270574-018f7400-4997-11eb-93db-40f22ffad2be.png)
![Discord_IgYBDrQhHV](https://user-images.githubusercontent.com/23330390/103270635-28e64100-4997-11eb-9bd1-d6ab0f010155.png)

