### PR TITLE
Add vidio.com & zhycorp.com website

### DIFF
--- a/websites/V/Vidio/dist/metadata.json
+++ b/websites/V/Vidio/dist/metadata.json
@@ -1,0 +1,24 @@
+{
+    "author": {
+      "name": "Zen",
+      "id": "725331428962992131"
+    },
+    "service": "Vidio",
+    "description": {
+      "en": "Vidio.com is a video streaming service with various streaming content for tv, films, soap operas, original series and sports such as League 1, Champions and Europe"
+    },
+    "url": [
+      "vidio.com",
+      "www.vidio.com"
+    ],
+    "version": "1.0.0",
+    "logo": "https://i.imgur.com/WiWFwcn.png",
+    "thumbnail": "https://i.imgur.com/rrNGa2h.jpg",
+    "color": "#ffffff",
+    "tags": [
+      "streaming",
+      "vidio",
+      "other"
+    ],
+    "category": "videos"
+  }

--- a/websites/V/Vidio/presence.ts
+++ b/websites/V/Vidio/presence.ts
@@ -1,0 +1,82 @@
+const presence = new Presence({
+  clientId: "795564487910227968"
+}),
+presenceData: PresenceData = {
+  largeImageKey: "vidio"
+};
+
+presence.on("UpdateData", async () => {
+  presenceData.startTimestamp = Math.floor(Date.now() / 1000);
+  switch (document.location.pathname.endsWith("/") &&
+      document.location.pathname.length > 1
+      ? document.location.pathname.slice(0, document.location.pathname.length - 1)
+      : document.location.pathname) {
+      case "/":
+        presenceData.details = "Viewing homepage";
+        break;
+      case "/live":
+        presenceData.details = "Viewing live streaming video";
+        break;
+      case "/search":
+        presenceData.smallImageKey = "search";
+        presenceData.details = "Searching for";
+        presenceData.state = (document.querySelector("#q") as HTMLInputElement).value;
+        break;
+      case "/packages":
+        presenceData.details = "Viewing packages pricing";
+        break;
+      default: {
+        if (document.location.pathname.startsWith("/dashboard")) {
+          presenceData.details = "Viewing account dashbaord";
+        }
+        if (document.location.pathname.startsWith("/categories")) {
+          presenceData.details = `Viewing ${toTitleCase(document.location.pathname.substring("categories".length + 2).split("-").slice(1).join(" "))} category`;
+        }
+        if (document.location.pathname.startsWith("/premier")) {
+          presenceData.details = "Viewing a series";
+          presenceData.state = document.querySelector(".profile-info__title").textContent;
+        }
+        if (document.location.pathname.startsWith("/watch")) {
+          const video: HTMLVideoElement = document.querySelector("#vod-player_html5_api");
+          if (video) {
+            const title = document.querySelector(".video-property__title");
+            if (title) presenceData.details = title.textContent;
+            else presenceData.details = document.querySelector(".content-title-season").textContent;
+            const series = document.querySelector(".user-name.video-channel");
+            if (series) presenceData.state = series.textContent;
+            else presenceData.state = document.querySelector(".content-title-big").textContent;
+            const timestamps = presence.getTimestamps(video.currentTime, video.duration);
+            presenceData.startTimestamp = timestamps[0];
+            presenceData.endTimestamp = timestamps[1];
+            if (video.paused) {
+              presenceData.smallImageKey = "pause";
+              presenceData.smallImageText = "Video Paused";
+            } else {
+              presenceData.smallImageKey = "play";
+              presenceData.smallImageText = "Playing";
+            }
+          }
+        }
+        if (document.location.pathname.startsWith("/live/")) {
+          const video = document.querySelector("#livestreaming-player__player_html5_api") as HTMLVideoElement;
+          if (video) {
+            presenceData.details = document.getElementsByClassName("b-livestreaming-detail__title section__title")[1].textContent;
+            presenceData.state = document.querySelector(".b-livestreaming-user__name").textContent;
+            if (video.paused) {
+              presenceData.smallImageKey = "pause";
+              presenceData.smallImageText = "Live Paused";
+            } else {
+              presenceData.smallImageKey = "live";
+              presenceData.smallImageText = "Playing";
+            }
+          }
+        }
+        break;
+      }
+  }
+  presence.setActivity(presenceData);
+});
+
+function toTitleCase(string: string) {
+  return string.split(" ").map(x => x.charAt(0).toUpperCase() + x.slice(1)).join(" ");
+}

--- a/websites/V/Vidio/tsconfig.json
+++ b/websites/V/Vidio/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../../../tsconfig.json",
+    "compilerOptions": {
+      "outDir": "./dist/"
+    }
+  }
+  

--- a/websites/Z/Zhycorp/dist/metadata.json
+++ b/websites/Z/Zhycorp/dist/metadata.json
@@ -1,0 +1,24 @@
+{
+    "author": {
+      "name": "Zen",
+      "id": "725331428962992131"
+    },
+    "service": "Zhycorp",
+    "description": {
+      "en": "Zhycorp is a fairly active and growing community, filled with imaginative members, which might make this community even more interesting."
+    },
+    "url": [
+        "zhycorp.com",
+        "bin.zhycorp.com"
+    ],
+    "version": "1.0.0",
+    "logo": "https://i.imgur.com/YR1SNzp.png",
+    "thumbnail": "https://i.imgur.com/CxO5lUg.png",
+    "color": "#ffffff",
+    "tags": [
+      "zhycorp",
+      "botlist",
+      "other"
+    ],
+    "category": "other"
+  }

--- a/websites/Z/Zhycorp/dist/metadata.json
+++ b/websites/Z/Zhycorp/dist/metadata.json
@@ -14,7 +14,7 @@
     "version": "1.0.0",
     "logo": "https://i.imgur.com/YR1SNzp.png",
     "thumbnail": "https://i.imgur.com/CxO5lUg.png",
-    "color": "#ffffff",
+    "color": "#2C2F33",
     "tags": [
       "zhycorp",
       "botlist",

--- a/websites/Z/Zhycorp/dist/metadata.json
+++ b/websites/Z/Zhycorp/dist/metadata.json
@@ -11,7 +11,7 @@
         "zhycorp.com",
         "bin.zhycorp.com"
     ],
-    "version": "2.0.0",
+    "version": "1.0.0",
     "logo": "https://i.imgur.com/YR1SNzp.png",
     "thumbnail": "https://i.imgur.com/CxO5lUg.png",
     "color": "#ffffff",

--- a/websites/Z/Zhycorp/dist/metadata.json
+++ b/websites/Z/Zhycorp/dist/metadata.json
@@ -11,7 +11,7 @@
         "zhycorp.com",
         "bin.zhycorp.com"
     ],
-    "version": "1.0.0",
+    "version": "2.0.0",
     "logo": "https://i.imgur.com/YR1SNzp.png",
     "thumbnail": "https://i.imgur.com/CxO5lUg.png",
     "color": "#ffffff",

--- a/websites/Z/Zhycorp/presence.ts
+++ b/websites/Z/Zhycorp/presence.ts
@@ -45,7 +45,3 @@ presence.on("UpdateData", async () => {
   }
   presence.setActivity(presenceData);
 });
-
-function toTitleCase(string: string) {
-  return string.split(" ").map(x => x.charAt(0).toUpperCase() + x.slice(1)).join(" ");
-}

--- a/websites/Z/Zhycorp/presence.ts
+++ b/websites/Z/Zhycorp/presence.ts
@@ -8,8 +8,15 @@ presenceData: PresenceData = {
 presence.on("UpdateData", async () => {
   presenceData.startTimestamp = Math.floor(Date.now() / 1000);
   if (document.location.hostname.startsWith("bin")) {
-    presenceData.details = "Viewing zhycorp's hastebin";
     presenceData.largeImageKey = "hastebin";
+    if (document.location.pathname.endsWith("/") && document.location.pathname.length > 1 ? document.location.pathname.slice(0, document.location.pathname.length - 1) : document.location.pathname === "/") {
+      if (document.querySelector("textarea").value !== "") {
+        presenceData.details = "Writing something..";
+      } else presenceData.details = "Viewing zhycorp's hastebin";
+    } else {
+      presenceData.details = "Reading a hastebin";
+      presenceData.smallImageKey = "reading";
+    }
   } else {
     switch (document.location.pathname.endsWith("/") &&
         document.location.pathname.length > 1

--- a/websites/Z/Zhycorp/presence.ts
+++ b/websites/Z/Zhycorp/presence.ts
@@ -1,0 +1,44 @@
+const presence = new Presence({
+  clientId: "795629338401832990"
+}),
+presenceData: PresenceData = {
+  largeImageKey: "zhycorp"
+};
+
+presence.on("UpdateData", async () => {
+  presenceData.startTimestamp = Math.floor(Date.now() / 1000);
+  if (document.location.hostname.startsWith("bin")) {
+    presenceData.details = "Viewing zhycorp's hastebin";
+    presenceData.largeImageKey = "hastebin";
+  } else {
+    switch (document.location.pathname.endsWith("/") &&
+        document.location.pathname.length > 1
+        ? document.location.pathname.slice(0, document.location.pathname.length - 1)
+        : document.location.pathname) {
+        case "/":
+          presenceData.details = "Viewing homepage";
+          break;
+        case "/member":
+          presenceData.details = "Viewing supporter page";
+          break;
+        case "/staff":
+          presenceData.details = "Viewing staff list page";
+          break;
+        default: {
+          if (document.location.pathname.startsWith("/bots")) {
+            presenceData.details = "Viewing bot list";
+            presenceData.state = `Page ${document.querySelector(".white-text.text-center.mt-2").textContent.split("/").join("of")}`;
+          } else if (document.location.pathname.startsWith("/bot")) {
+            presenceData.details = "Viewing bot";
+            presenceData.state = document.querySelector("title").textContent.substring("Zhycorp -".length).trim();
+          }
+          break;
+        }
+    }
+  }
+  presence.setActivity(presenceData);
+});
+
+function toTitleCase(string: string) {
+  return string.split(" ").map(x => x.charAt(0).toUpperCase() + x.slice(1)).join(" ");
+}

--- a/websites/Z/Zhycorp/tsconfig.json
+++ b/websites/Z/Zhycorp/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../../../tsconfig.json",
+    "compilerOptions": {
+      "outDir": "./dist/"
+    }
+  }
+  


### PR DESCRIPTION
# Presence **[vidio.com](https://vidio.com)**
- Track user paused the video or no
- Track duration of video or live streaming
- Track user viewing series
- Track user viewing dashboard account
- Track user viewing categories
- Track user searching a video/series
- Track user viewing packages pricing
Proof it works:
![image](https://user-images.githubusercontent.com/45705890/103537125-67fc2100-4ec6-11eb-919e-ae0bcda430bb.png)


# Presence **[zhycorp.com](https://zhycorp.com)**
- Track user viewing homepage
- Track user viewing hastebin
- Track user writing in hastebin
- Track user reading in hastebin
- Track user viewing bot listing
- Track user viewing the details of bot
- Track user viewing staff list page
- Track user viewing supporter list page
Proof it works:
![image](https://user-images.githubusercontent.com/45705890/103537059-3e42fa00-4ec6-11eb-9ae9-26c5e2518fcf.png)
