### PR TITLE
Add Notion presence

### DIFF
--- a/websites/N/Notion/dist/metadata.json
+++ b/websites/N/Notion/dist/metadata.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.0",
+  "author": {
+    "name": "DecadeDecaf",
+    "id": "234109055554158593"
+  },
+  "url": [
+    "www.notion.so",
+    "notion.so"
+  ],
+  "description": {
+    "en": "Notion is the all-in-one workspace for your notes, tasks, wikis, and databases."
+  },
+  "service": "Notion",
+  "version": "1.0.0",
+  "logo": "https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png",
+  "thumbnail": "https://www.notion.so/images/meta/default.png",
+  "color": "#FF0000",
+  "tags": [
+    "productivity",
+    "management",
+    "notes"
+  ],
+  "color": "#FFFFFF",
+  "category": "other"
+}

--- a/websites/N/Notion/presence.ts
+++ b/websites/N/Notion/presence.ts
@@ -1,0 +1,31 @@
+const presence = new Presence({
+    clientId: "795902670647984159"
+  }),
+  strings = presence.getStrings({
+    viewing: "general.viewing",
+    editing: "general.editing"
+  });
+
+presence.on("UpdateData", async () => {
+  const viewingString = (await strings).viewing;
+  //const editingString = (await strings).editing;
+  
+  //i'm not too sure how to check if the page is currently being viewed or edited, so it just says "viewing" for every page right now
+  
+  const presenceData: PresenceData = {
+    largeImageKey: "icon",
+  };
+  
+  if (document.location.hostname.includes("notion.so")) {
+    const pageName = document.title; //page title seems like a safe way to get the page name
+    presenceData.details = viewingString //this would need to be replaced with an if-else for "editing" to show up
+    presenceData.state = pageName;
+  }
+  
+  if (presenceData.details == null) {
+    presence.setTrayTitle();
+    presence.setActivity();
+  } else {
+    presence.setActivity(presenceData);
+  }
+});

--- a/websites/N/Notion/tsconfig.json
+++ b/websites/N/Notion/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/"
+  }
+}


### PR DESCRIPTION
I've added rich presence for Notion (https://www.notion.so/).

It's a productivity website that can be used for a lot of things. Personally, I use it for writing and planning projects. The rich presence shows the page that you are viewing, but I couldn't figure out the best way to distinguish between "editing" and "viewing," so I kept it at just "viewing" for now.

Feel free to expand upon my presence or offer suggestions/tips. I'm experienced with JS, but this is my first time using TypeScript. Hopefully it's not a complete mess!

![image](https://user-images.githubusercontent.com/30052610/103625650-45d7c280-4f09-11eb-91db-bb8c72e2043c.png)