### PR TITLE
Fix issue #2831, added some presence settings & migrated to presence helpers

### DIFF
--- a/websites/J/Jellyfin/dist/metadata.json
+++ b/websites/J/Jellyfin/dist/metadata.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://schemas.premid.app/metadata/1.3",
   "author": {
     "name": "alexbcberio",
     "id": "202915432175239169"
@@ -25,5 +26,18 @@
     "tv",
     "media"
   ],
-  "regExp": ".*[/]web[/]index[.]html"
+  "regExp": ".*[/]web[/]index[.]html",
+  "settings": [
+    {
+      "id": "showMediaTimestamps",
+      "title": "Show media timestamps",
+      "icon": "fad fa-play",
+      "value": true
+    }, {
+      "id": "showTimestamps",
+      "title": "Show timestamps",
+      "icon": "fad fa-stopwatch",
+      "value": true
+    }
+  ]
 }

--- a/websites/J/Jellyfin/dist/metadata.json
+++ b/websites/J/Jellyfin/dist/metadata.json
@@ -15,7 +15,7 @@
     "en": "The Free Software Media System"
   },
   "service": "Jellyfin",
-  "version": "1.3.8",
+  "version": "1.4.0",
   "logo": "https://i.imgur.com/nPzEemG.png",
   "thumbnail": "https://i.imgur.com/J61378N.png",
   "color": "#00698c",

--- a/websites/J/Jellyfin/presence.ts
+++ b/websites/J/Jellyfin/presence.ts
@@ -708,6 +708,8 @@ function setDefaultsToPresence(): void {
   if (presenceData.endTimestamp) {
     delete presenceData.endTimestamp;
   }
+
+  presenceData.startTimestamp = Date.now();
 }
 
 /**
@@ -749,9 +751,10 @@ async function updateData(): Promise<void> {
     await handleWebClient();
   }
 
-  // force the display of some counter
-  if (!presenceData.startTimestamp || !presenceData.endTimestamp) {
-    presenceData.startTimestamp = Date.now();
+  // do not show any times when media is paused
+  if (presenceData.smallImageKey === PRESENCE_ART_ASSETS.pause) {
+    delete presenceData.endTimestamp;
+    delete presenceData.startTimestamp;
   }
 
   // if jellyfin is detected init/update the presence status

--- a/websites/J/Jellyfin/presence.ts
+++ b/websites/J/Jellyfin/presence.ts
@@ -283,26 +283,8 @@ const // official website
     largeImageKey: PRESENCE_ART_ASSETS.logo
   };
 
-let ApiClient: ApiClient;
-
-// generic log style for PMD_[info|error|success] calls
-const GENERIC_LOG_STYLE = "font-weight: 800; padding: 2px 5px; color: white;";
-
-/**
- * PMD_info - log into the user console info messages
- *
- * @param  {string} txt text to log into the console
- */
-function PMD_info(message: string): void {
-  console.log(
-    "%cPreMiD%cINFO%c " + message,
-    GENERIC_LOG_STYLE + "border-radius: 25px 0 0 25px; background: #596cae;",
-    GENERIC_LOG_STYLE + "border-radius: 0 25px 25px 0; background: #5050ff;",
-    "color: unset;"
-  );
-}
-
-let presence: Presence;
+let ApiClient: ApiClient,
+  presence: Presence;
 
 /**
  * handleAudioPlayback - handles the presence when the audio player is active
@@ -781,12 +763,13 @@ async function updateData(): Promise<void> {
  * init - check if the presence should be initialized, if so start doing the magic
  */
 async function init(): Promise<void> {
-  let validPage = false;
+  let validPage = false,
+    infoMessage;
 
   // jellyfin website
   if (location.host === JELLYFIN_URL) {
     validPage = true;
-    PMD_info("Jellyfin website detected");
+    infoMessage = "Jellyfin website detected";
 
     // web client
   } else {
@@ -800,7 +783,7 @@ async function init(): Promise<void> {
           30 * 1000
         ) {
           validPage = true;
-          PMD_info("Jellyfin web client detected");
+          infoMessage = "Jellyfin web client detected";
         }
       }
     } catch (e) {
@@ -813,6 +796,7 @@ async function init(): Promise<void> {
       clientId: "669359568391766018"
     });
 
+    presence.info(infoMessage);
     presence.on("UpdateData", updateData);
   }
 }

--- a/websites/J/Jellyfin/presence.ts
+++ b/websites/J/Jellyfin/presence.ts
@@ -411,8 +411,14 @@ async function obtainMediaInfo(itemId: string): Promise<string | MediaInfo> {
   }
 
   media[itemId] = "pending";
-
-  const res = await fetch(`/Users/${getUserId()}/Items/${itemId}`, {
+  const basePath = location.pathname.replace(
+    location.pathname
+      .split("/")
+      .slice(-2)
+      .join("/")
+    ,
+    ""),
+    res = await fetch(`${basePath}Users/${getUserId()}/Items/${itemId}`, {
       credentials: "include",
       headers: {
         "x-emby-authorization": `MediaBrowser Client="${ApiClient["_appName"]}", Device="${ApiClient["_deviceName"]}", DeviceId="${ApiClient["_deviceId"]}", Version="${ApiClient["_appVersion"]}", Token="${ApiClient["_serverInfo"]["AccessToken"]}"`


### PR DESCRIPTION
- Fix issue #2831 where getting presence metadata would fail if the service was installed under a subpath such as https://domain.tld/jellyfin.
- Used presence helpers for console logging, and getting timestamps from media elements.
- Added some presence settings:
  - Show media timestamps (boolean): show or hide timestamps when playing back media
  - Show timestamps (boolean): show or hide timestamps for other cases

Proof screenshots:

![presence settings](https://user-images.githubusercontent.com/22194879/105058318-61e57300-5a76-11eb-8495-39771139a583.png)
![show timestamps on true](https://user-images.githubusercontent.com/22194879/105058966-1384a400-5a77-11eb-80d1-c308a89f8938.png)
![show timestamps on false](https://user-images.githubusercontent.com/22194879/105059077-344cf980-5a77-11eb-83c5-0a92631823b9.png)
![show media timestamps on true](https://user-images.githubusercontent.com/22194879/105059262-60687a80-5a77-11eb-9259-4b56aa58a899.png)
![show media timestamps on false](https://user-images.githubusercontent.com/22194879/105059285-665e5b80-5a77-11eb-85e4-d7ff481d3c84.png)
![media paused](https://user-images.githubusercontent.com/22194879/105059419-8beb6500-5a77-11eb-9b1d-f3faa8e52b71.png)


