### PR TITLE
Overhaul JUKE.nl presence, Update Magister presence

### DIFF
--- a/websites/J/JUKE/dist/metadata.json
+++ b/websites/J/JUKE/dist/metadata.json
@@ -1,21 +1,32 @@
 {
   "author": {
-    "name": "STEPHAN",
-    "id": "183233556150091776"
+    "name": "QkeleQ10",
+    "id": "807917674477649943"
   },
+  "contributors": [
+    {
+      "name": "STEPHAN",
+      "id": "183233556150091776"
+    }
+  ],
   "service": "JUKE",
   "description": {
-    "en": "JUKE is a dutch radio channel collection site. JUKE is a Talpa Network Company.",
+    "en": "JUKE is a Dutch radio channel collection site. JUKE is a Talpa Network company.",
     "nl": "JUKE is een verzamelingssite voor radiostations. JUKE is een merk van Talpa Network."
   },
   "url": "juke.nl",
-  "version": "1.2.5",
-  "logo": "https://i.imgur.com/Rh4L1UQ.png",
-  "thumbnail": "https://i.imgur.com/yHG4Vyg.png",
+  "version": "2.0.0",
+  "logo": "https://i.imgur.com/axm6M00.png",
+  "thumbnail": "https://i.imgur.com/kVj50nG.png",
   "color": "#38af85",
   "tags": [
+    "juke",
+    "talpa",
+    "radio",
     "music",
-    "radio"
+    "muziek",
+    "free",
+    "gratis"
   ],
   "category": "music"
 }

--- a/websites/J/JUKE/presence.ts
+++ b/websites/J/JUKE/presence.ts
@@ -8,9 +8,9 @@ presence.on("UpdateData", async () => {
   };
 
   if (document.querySelector("span[class*=eC-title]")) {
-    presenceData.details = document.querySelector("span[class*=eC-title]").innerHTML.replace("De ", "de ").replace("Het ", "het ").replace("&amp;", "&")
+    presenceData.details = document.querySelector("span[class*=eC-title]").innerHTML.replace("De ", "de ").replace("Het ", "het ").replace("&amp;", "&");
     if (document.querySelector("span[class*=eC-subtitle]")) {
-      presenceData.state = document.querySelector("span[class*=eC-subtitle]").innerHTML.replace("De ", "de ").replace("Het ", "het ").replace("&amp;", "&")
+      presenceData.state = document.querySelector("span[class*=eC-subtitle]").innerHTML.replace("De ", "de ").replace("Het ", "het ").replace("&amp;", "&");
     }
   }
 
@@ -20,14 +20,14 @@ presence.on("UpdateData", async () => {
   }
 
   if (document.querySelector("rect")) {
-    presenceData.smallImageKey = "playing"
-    presenceData.smallImageText = "Wordt afgespeeld"
+    presenceData.smallImageKey = "playing";
+    presenceData.smallImageText = "Wordt afgespeeld";
   } else if (document.querySelector("[class*=spinner]")) {
-    presenceData.smallImageKey = "waiting"
-    presenceData.smallImageText = "Wordt geladen"
+    presenceData.smallImageKey = "waiting";
+    presenceData.smallImageText = "Wordt geladen";
   } else if (document.querySelector("polygon")) {
-    presenceData.smallImageKey = "paused"
-    presenceData.smallImageText = "Gepauzeerd"
+    presenceData.smallImageKey = "paused";
+    presenceData.smallImageText = "Gepauzeerd";
   }
 
   if (presenceData.details == null) {

--- a/websites/J/JUKE/presence.ts
+++ b/websites/J/JUKE/presence.ts
@@ -1,12 +1,39 @@
-var presence = new Presence({
-  clientId: "629751665242669056"
+const presence = new Presence({
+  clientId: "811305223783448627"
 });
 
 presence.on("UpdateData", async () => {
-  const testPresenceData: PresenceData = {
-    details: "Luister radio op juke.nl",
-    state: "Browsen...",
-    largeImageKey: "juke-large"
+  const presenceData: PresenceData = {
+    largeImageKey: "juke-crown"
   };
-  presence.setActivity(testPresenceData);
+
+  if (document.querySelector("span[class*=eC-title]")) {
+    presenceData.details = document.querySelector("span[class*=eC-title]").innerHTML.replace("De ", "de ").replace("Het ", "het ").replace("&amp;", "&")
+    if (document.querySelector("span[class*=eC-subtitle]")) {
+      presenceData.state = document.querySelector("span[class*=eC-subtitle]").innerHTML.replace("De ", "de ").replace("Het ", "het ").replace("&amp;", "&")
+    }
+  }
+
+  if (!presenceData.details) {
+    presenceData.details = "Bladert op JUKE.nl";
+    presenceData.state = `Pagina '${document.title.replace(" |", "|").split("|")[0].replace("JUKE - Luister nu jouw favoriete radiozenders, non-stop muziek en podcasts!", "Home")}'`;
+  }
+
+  if (document.querySelector("rect")) {
+    presenceData.smallImageKey = "playing"
+    presenceData.smallImageText = "Wordt afgespeeld"
+  } else if (document.querySelector("[class*=spinner]")) {
+    presenceData.smallImageKey = "waiting"
+    presenceData.smallImageText = "Wordt geladen"
+  } else if (document.querySelector("polygon")) {
+    presenceData.smallImageKey = "paused"
+    presenceData.smallImageText = "Gepauzeerd"
+  }
+
+  if (presenceData.details == null) {
+    presence.setTrayTitle();
+    presence.setActivity();
+  } else {
+    presence.setActivity(presenceData);
+  }
 });

--- a/websites/J/JUKE/presence.ts
+++ b/websites/J/JUKE/presence.ts
@@ -4,7 +4,8 @@ const presence = new Presence({
 
 presence.on("UpdateData", async () => {
   const presenceData: PresenceData = {
-    largeImageKey: "juke-crown"
+    largeImageKey: "juke-crown",
+    buttons: [{ label: "Radio luisteren", url: document.location.href }]
   };
 
   if (document.querySelector("span[class*=eC-title]")) {
@@ -22,6 +23,7 @@ presence.on("UpdateData", async () => {
   if (document.querySelector("rect")) {
     presenceData.smallImageKey = "playing";
     presenceData.smallImageText = "Wordt afgespeeld";
+    presenceData.buttons = [{ label: "Ook radio luisteren", url: document.location.href }];
   } else if (document.querySelector("[class*=spinner]")) {
     presenceData.smallImageKey = "waiting";
     presenceData.smallImageText = "Wordt geladen";

--- a/websites/M/Magister/dist/metadata.json
+++ b/websites/M/Magister/dist/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schemas.premid.app/metadata/1.0",
   "author": {
-    "name": "106926",
+    "name": "QkeleQ10",
     "id": "807917674477649943"
   },
   "url": "magister.net",
@@ -10,9 +10,9 @@
     "en": "Magister 6 is a popular student information system in the Netherlands.",
     "nl": "Magister 6 is een populair leerlingvolgsysteem in Nederland."
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "service": "Magister",
-  "logo": "https://i.imgur.com/1TtM9A1.png",
+  "logo": "https://i.imgur.com/jk4XMSO.png",
   "thumbnail": "https://i.imgur.com/TVjDmC4.png",
   "color": "#1F97F9",
   "tags": [


### PR DESCRIPTION
[JUKE.nl](https://juke.nl/) (try it out!):
![image](https://user-images.githubusercontent.com/55982900/108608947-c031a880-73ca-11eb-8347-835f2abe1d46.png)
![image](https://user-images.githubusercontent.com/55982900/108608939-ae500580-73ca-11eb-9554-c226ae7d8aa9.png)

Magister already worked.