### PR TITLE
Update multiple presences (Gamepedia domain merge 2)

### DIFF
--- a/websites/F/Fandom/dist/metadata.json
+++ b/websites/F/Fandom/dist/metadata.json
@@ -6,7 +6,7 @@
   },
   "service": "Fandom",
   "url": "fandom.com",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "logo": "https://i.imgur.com/sko4P3c.png",
   "thumbnail": "https://i.imgur.com/VrVSD2b.png",
   "color": "#002A32",

--- a/websites/F/Fandom/presence.ts
+++ b/websites/F/Fandom/presence.ts
@@ -1,356 +1,370 @@
-const presence = new Presence({
-  clientId: "644400074008297512"
-});
+if (
+  !(
+    (
+      document.location.pathname.includes("/wiki/") &&
+      !document.querySelector("#globalNavigation")
+    )
+    // Only run on Fandom wikis.
+  )
+)
+  ((): void => {
+    const presence = new Presence({
+        clientId: "644400074008297512"
+      }),
+      browsingStamp = Math.floor(Date.now() / 1000);
+    let currentURL = new URL(document.location.href),
+      currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/"),
+      presenceData: PresenceData = {
+        details: "Viewing an unsupported page",
+        largeImageKey: "lg",
+        startTimestamp: browsingStamp
+      };
+    const updateCallback = {
+        _function: null as () => void,
+        get function(): () => void {
+          return this._function;
+        },
+        set function(parameter) {
+          this._function = parameter;
+        },
+        get present(): boolean {
+          return this._function !== null;
+        }
+      },
+      /**
+       * Initialize/reset presenceData.
+       */
+      resetData = (
+        defaultData: PresenceData = {
+          details: "Viewing an unsupported page",
+          largeImageKey: "lg",
+          startTimestamp: browsingStamp
+        }
+      ): void => {
+        currentURL = new URL(document.location.href);
+        currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
+        presenceData = { ...defaultData };
+      },
+      /**
+       * Search for URL parameters.
+       * @param urlParam The parameter that you want to know about the value.
+       */
+      getURLParam = (urlParam: string): string => {
+        return currentURL.searchParams.get(urlParam);
+      };
 
-let currentURL = new URL(document.location.href),
-  currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
-const browsingStamp = Math.floor(Date.now() / 1000);
-let presenceData: PresenceData = {
-  details: "Viewing an unsupported page",
-  largeImageKey: "lg",
-  startTimestamp: browsingStamp
-};
-const updateCallback = {
-    _function: null as () => void,
-    get function(): () => void {
-      return this._function;
-    },
-    set function(parameter) {
-      this._function = parameter;
-    },
-    get present(): boolean {
-      return this._function !== null;
-    }
-  },
-  /**
-   * Initialize/reset presenceData.
-   */
-  resetData = (
-    defaultData: PresenceData = {
-      details: "Viewing an unsupported page",
-      largeImageKey: "lg",
-      startTimestamp: browsingStamp
-    }
-  ): void => {
-    currentURL = new URL(document.location.href);
-    currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
-    presenceData = { ...defaultData };
-  },
-  /**
-   * Search for URL parameters.
-   * @param urlParam The parameter that you want to know about the value.
-   */
-  getURLParam = (urlParam: string): string => {
-    return currentURL.searchParams.get(urlParam);
-  };
+    ((): void => {
+      presence.info("Running...");
 
-((): void => {
-  if (currentURL.host === "www.fandom.com") {
-    /*
+      if (currentURL.host === "www.fandom.com") {
+        /*
 
 		Chapter 1
 		This one is for the editorial part of Fandom.
 		
 		*/
 
-    if (currentPath[0] === "") {
-      presenceData.details = "On the index page";
-    } else if (currentPath[0] === "signin") {
-      presenceData.details = "Signing in";
-    } else if (currentPath[0] === "register") {
-      presenceData.details = "Registering an account";
-    } else if (currentPath[0] === "articles") {
-      presenceData.details = "Reading an article";
-      presenceData.state = document.querySelector(
-        ".article-header__title"
-      ).textContent;
-    } else if (currentPath[0] === "topics") {
-      presenceData.details = "Viewing a topic";
-      presenceData.state = document.querySelector(
-        ".topic-header__title"
-      ).firstElementChild.innerHTML;
-    } else if (currentPath[0] === "video") {
-      presenceData.details = "Watching a video";
-      updateCallback.function = (): void => {
-        presenceData.state = document.querySelector(
-          ".video-page-featured-player__title"
-        ).textContent;
-        try {
-          if (
-            document
-              .querySelector(".jw-icon-playback")
-              .getAttribute("aria-label") === "Pause"
-          ) {
-            const video: HTMLVideoElement = document.querySelector(".jw-video"),
-              timestamps = presence.getTimestampsfromMedia(video);
-            presenceData.startTimestamp = timestamps[0];
-            presenceData.endTimestamp = timestamps[1];
-          } else {
-            delete presenceData.startTimestamp;
-            delete presenceData.endTimestamp;
-          }
-        } catch (e) {
+        if (currentPath[0] === "") {
+          presenceData.details = "On the index page";
+        } else if (currentPath[0] === "signin") {
+          presenceData.details = "Signing in";
+        } else if (currentPath[0] === "register") {
+          presenceData.details = "Registering an account";
+        } else if (currentPath[0] === "articles") {
+          presenceData.details = "Reading an article";
+          presenceData.state = document.querySelector(
+            ".article-header__title"
+          ).textContent;
+        } else if (currentPath[0] === "topics") {
+          presenceData.details = "Viewing a topic";
+          presenceData.state = document.querySelector(
+            ".topic-header__title"
+          ).firstElementChild.innerHTML;
+        } else if (currentPath[0] === "video") {
+          presenceData.details = "Watching a video";
           delete presenceData.startTimestamp;
-          delete presenceData.endTimestamp;
+          updateCallback.function = (): void => {
+            presenceData.state = document.querySelector(
+              ".video-page-featured-player__title"
+            ).textContent;
+            try {
+              if (
+                document
+                  .querySelector(".jw-icon-playback")
+                  .getAttribute("aria-label") === "Pause"
+              ) {
+                const video: HTMLVideoElement = document.querySelector(
+                    ".jw-video"
+                  ),
+                  timestamps = presence.getTimestampsfromMedia(video);
+                presenceData.endTimestamp = timestamps[1];
+              } else {
+                delete presenceData.endTimestamp;
+              }
+            } catch (e) {
+              delete presenceData.endTimestamp;
+            }
+          };
+        } else if (currentPath[0] === "curated") {
+          presenceData.details = "Viewing a curation";
+          presenceData.state = document.querySelector(
+            ".card__title"
+          ).textContent;
+        } else if (currentPath[0] === "u") {
+          presenceData.details = "Viewing a profile page";
+          presenceData.state = `${
+            document.querySelector(".profile-info-card__name").textContent
+          } (${
+            document.querySelector(".profile-info-card__username").textContent
+          })`;
+        } else {
+          presenceData.details = "Viewing a page";
+          if (currentPath[0] === "explore") presenceData.state = "Explore";
+          else if (currentPath[0] === "about") presenceData.state = "About";
+          else if (currentPath[0] === "carriers")
+            presenceData.state = "Carriers";
+          else if (currentPath[0] === "terms-of-use")
+            presenceData.state = "Terms of Use";
+          else if (currentPath[0] === "privacy-policy")
+            presenceData.state = "Privacy Policy";
+          else if (currentPath[0] === "mediakit")
+            presenceData.state = "Media Kit";
+          else if (currentPath[0] === "local-sitemap")
+            presenceData.state = "Local Sitemap";
         }
-      };
-    } else if (currentPath[0] === "curated") {
-      presenceData.details = "Viewing a curation";
-      presenceData.state = document.querySelector(".card__title").textContent;
-    } else if (currentPath[0] === "u") {
-      presenceData.details = "Viewing a profile page";
-      presenceData.state = `${
-        document.querySelector(".profile-info-card__name").textContent
-      } (${
-        document.querySelector(".profile-info-card__username").textContent
-      })`;
-    } else {
-      presenceData.details = "Viewing a page";
-      if (currentPath[0] === "explore") presenceData.state = "Explore";
-      else if (currentPath[0] === "about") presenceData.state = "About";
-      else if (currentPath[0] === "carriers") presenceData.state = "Carriers";
-      else if (currentPath[0] === "terms-of-use")
-        presenceData.state = "Terms of Use";
-      else if (currentPath[0] === "privacy-policy")
-        presenceData.state = "Privacy Policy";
-      else if (currentPath[0] === "mediakit") presenceData.state = "Media Kit";
-      else if (currentPath[0] === "local-sitemap")
-        presenceData.state = "Local Sitemap";
-    }
-  } else if (currentPath.includes("wiki")) {
-    /*
+      } else if (currentPath.includes("wiki")) {
+        /*
 
 		Chapter 2
 		This one is for the wiki part on the Fandom, which was Wikia a while ago.
 		
 		*/
 
-    if (!document.querySelector("#globalNavigation")) {
-      // Do not run on Gamepedia wikis.
-      presenceData = null;
-      return;
-    }
+        let title: string, sitename: string;
+        const actionResult = (): string =>
+            getURLParam("action") || getURLParam("veaction"),
+          lang = currentPath[0] === "wiki" ? "en" : currentPath[0],
+          titleFromURL = (): string => {
+            const raw: string =
+              currentPath[0] === "index.php"
+                ? getURLParam("title")
+                : currentPath[0] === "wiki"
+                ? currentPath.slice(1).join("/")
+                : currentPath.slice(2).join("/");
+            //let lang: string = currentPath[0]
+            return decodeURIComponent(raw.replace(/_/g, " "));
+          };
 
-    let title: string, sitename: string;
-    const actionResult = (): string =>
-        getURLParam("action") || getURLParam("veaction"),
-      titleFromURL = (): string => {
-        const raw: string =
-          currentPath[0] === "index.php"
-            ? getURLParam("title")
-            : currentPath[0] === "wiki"
-            ? currentPath.slice(1).join("/")
-            : currentPath.slice(2).join("/");
-        //let lang: string = currentPath[0]
-        return raw.replace(/_/g, " ");
-      };
-
-    try {
-      title = document.querySelector("h1").textContent;
-    } catch (e) {
-      title = titleFromURL();
-    }
-
-    try {
-      sitename = (document.querySelector(
-        "meta[property='og:site_name']"
-      ) as HTMLMetaElement).content;
-    } catch (e) {
-      sitename = document.querySelector(".wds-community-header__sitename")
-        .textContent;
-    }
-
-    /**
-     * Returns details based on the namespace.
-     * @link https://en.wikipedia.org/wiki/Wikipedia:Namespace
-     */
-    const namespaceDetails = (): string => {
-      const details: { [index: string]: string } = {
-        "-2": "Viewing a media",
-        "-1": "Viewing a special page",
-        0: "Reading an article",
-        1: "Viewing a talk page",
-        2: "Viewing a user page",
-        3: "Viewing a user talk page",
-        4: "Viewing a project page",
-        5: "Viewing a project talk page",
-        6: "Viewing a file",
-        7: "Viewing a file talk page",
-        8: "Viewing an interface page",
-        9: "Viewing an interface talk page",
-        10: "Viewing a template",
-        11: "Viewing a template talk page",
-        12: "Viewing a help page",
-        13: "Viewing a help talk page",
-        14: "Viewing a category",
-        15: "Viewing a category talk page",
-        100: "Viewing a portal",
-        101: "Viewing a portal talk page",
-        110: "Viewing a forum page",
-        111: "Viewing a forum talk page",
-        112: "Viewing an Admin Central page",
-        113: "Viewing an Admin Central talk page",
-        114: "Viewing an Admin Forum page",
-        115: "Viewing an Admin Forum talk page",
-        116: "Viewing an Admin Support page",
-        117: "Viewing an Admin Support talk page",
-        118: "Viewing an adoption request",
-        119: "Viewing an adoption request talk page",
-        120: "Viewing a bot scan page",
-        121: "Viewing a bot scan talk page",
-        122: "Viewing an archived page",
-        123: "Viewing an archived talk page",
-        150: "Viewing a hub",
-        151: "Viewing a hub talk page",
-        420: "Viewing a GeoJson page",
-        421: "Viewing a GeoJson talk page",
-        500: "Viewing a user blog", // handled again by function below
-        501: "Viewing a user blog comment", // depercated, redirected
-        502: "Viewing a blog",
-        503: "Viewing a blog talk page",
-        710: "Viewing a media's subtitles",
-        711: "Viewing a media's subtitles talk page",
-        828: "Viewing a module",
-        829: "Viewing a module talk page",
-        1200: "Viewing a message wall",
-        1202: "Viewing a message wall greeting",
-        2000: "Viewing a forum board", // depercated, redirected
-        2001: "Viewing a forum board thread", // depercated, redirected
-        2002: "Viewing a forum topic" // depercated, redirected
-      };
-      return (
-        details[
-          [...document.querySelector("body").classList]
-            .filter((v) => /ns--?\d/.test(v))[0]
-            .slice(3)
-        ] || "Viewing a wiki page"
-      );
-    };
-
-    if (title === "Home") {
-      sitename = (document.querySelector(
-        "meta[property='og:title']"
-      ) as HTMLMetaElement).content;
-      presenceData.details = "On the home page";
-    } else if (document.querySelector("#search-v2-form")) {
-      presenceData.details = "Searching for a page";
-      presenceData.state = (document.querySelector(
-        "#search-v2-input"
-      ) as HTMLInputElement).value;
-    } else if (actionResult() === "history") {
-      presenceData.details = "Viewing revision history";
-      presenceData.state = titleFromURL();
-    } else if (getURLParam("diff")) {
-      presenceData.details = "Viewing difference between revisions";
-      presenceData.state = titleFromURL();
-    } else if (getURLParam("oldid")) {
-      presenceData.details = "Viewing an old revision of a page";
-      presenceData.state = titleFromURL();
-    } else if (namespaceDetails() === "Viewing a user blog") {
-      if (title) {
-        presenceData.details = "Reading a user blog post";
-        presenceData.state =
-          title +
-          " by " +
-          document.querySelector(".page-header__blog-post-details")
-            .firstElementChild.textContent;
-      } else {
-        presenceData.details = namespaceDetails();
-        presenceData.state = titleFromURL();
-      }
-    } else if (
-      document.querySelector("#ca-ve-edit") ||
-      getURLParam("veaction")
-    ) {
-      presenceData.state = `${
-        title.toLowerCase() === titleFromURL().toLowerCase()
-          ? `${title}`
-          : `${title} (${titleFromURL()})`
-      }`;
-      updateCallback.function = (): void => {
-        if (actionResult() === "edit" || actionResult() === "editsource") {
-          presenceData.details = "Editing a page";
-        } else {
-          presenceData.details = namespaceDetails();
+        try {
+          title = document.querySelector("h1").textContent;
+        } catch (e) {
+          title = titleFromURL();
         }
-      };
-    } else {
-      if (actionResult() === "edit") {
-        presenceData.details = document.querySelector("#ca-edit")
-          ? "Editing a page"
-          : "Viewing source";
-        presenceData.state = titleFromURL();
-      } else {
-        presenceData.details = namespaceDetails();
-        presenceData.state = `${
-          title.toLowerCase() === titleFromURL().toLowerCase()
-            ? `${title}`
-            : `${title} (${titleFromURL()})`
-        }`;
-      }
-    }
 
-    if (presenceData.state) presenceData.state += " | " + sitename;
-    else presenceData.state = sitename;
-  } else if (currentPath[0] === "f") {
-    /*
+        try {
+          sitename = (document.querySelector(
+            "meta[property='og:site_name']"
+          ) as HTMLMetaElement).content;
+        } catch (e) {
+          sitename = document.querySelector(".wds-community-header__sitename")
+            .textContent;
+        }
+
+        /**
+         * Returns details based on the namespace.
+         * @link https://en.wikipedia.org/wiki/Wikipedia:Namespace
+         */
+        const namespaceDetails = (): string => {
+          const details: { [index: string]: string } = {
+            "-2": "Viewing a media",
+            "-1": "Viewing a special page",
+            0: "Reading an article",
+            1: "Viewing a talk page",
+            2: "Viewing a user page",
+            3: "Viewing a user talk page",
+            4: "Viewing a project page",
+            5: "Viewing a project talk page",
+            6: "Viewing a file",
+            7: "Viewing a file talk page",
+            8: "Viewing an interface page",
+            9: "Viewing an interface talk page",
+            10: "Viewing a template",
+            11: "Viewing a template talk page",
+            12: "Viewing a help page",
+            13: "Viewing a help talk page",
+            14: "Viewing a category",
+            15: "Viewing a category talk page",
+            100: "Viewing a portal",
+            101: "Viewing a portal talk page",
+            110: "Viewing a forum page",
+            111: "Viewing a forum talk page",
+            112: "Viewing an Admin Central page",
+            113: "Viewing an Admin Central talk page",
+            114: "Viewing an Admin Forum page",
+            115: "Viewing an Admin Forum talk page",
+            116: "Viewing an Admin Support page",
+            117: "Viewing an Admin Support talk page",
+            118: "Viewing an adoption request",
+            119: "Viewing an adoption request talk page",
+            120: "Viewing a bot scan page",
+            121: "Viewing a bot scan talk page",
+            122: "Viewing an archived page",
+            123: "Viewing an archived talk page",
+            150: "Viewing a hub",
+            151: "Viewing a hub talk page",
+            420: "Viewing a GeoJson page",
+            421: "Viewing a GeoJson talk page",
+            500: "Viewing a user blog", // handled again by function below
+            501: "Viewing a user blog comment", // depercated, redirected
+            502: "Viewing a blog",
+            503: "Viewing a blog talk page",
+            710: "Viewing a media's subtitles",
+            711: "Viewing a media's subtitles talk page",
+            828: "Viewing a module",
+            829: "Viewing a module talk page",
+            1200: "Viewing a message wall",
+            1202: "Viewing a message wall greeting",
+            2000: "Viewing a forum board", // depercated, redirected
+            2001: "Viewing a forum board thread", // depercated, redirected
+            2002: "Viewing a forum topic" // depercated, redirected
+          };
+          return (
+            details[
+              [...document.querySelector("body").classList]
+                .filter((v) => /ns--?\d/.test(v))[0]
+                .slice(3)
+            ] || "Viewing a wiki page"
+          );
+        };
+
+        if (title === "Home") {
+          sitename = (document.querySelector(
+            "meta[property='og:title']"
+          ) as HTMLMetaElement).content;
+          presenceData.details = "On the home page";
+        } else if (document.querySelector("#search-v2-form")) {
+          presenceData.details = "Searching for a page";
+          presenceData.state = (document.querySelector(
+            "#search-v2-input"
+          ) as HTMLInputElement).value;
+        } else if (actionResult() === "history") {
+          presenceData.details = "Viewing revision history";
+          presenceData.state = titleFromURL();
+        } else if (getURLParam("diff")) {
+          presenceData.details = "Viewing difference between revisions";
+          presenceData.state = titleFromURL();
+        } else if (getURLParam("oldid")) {
+          presenceData.details = "Viewing an old revision of a page";
+          presenceData.state = titleFromURL();
+        } else if (namespaceDetails() === "Viewing a user blog") {
+          if (title) {
+            presenceData.details = "Reading a user blog post";
+            presenceData.state =
+              title +
+              " by " +
+              document.querySelector(".page-header__blog-post-details")
+                .firstElementChild.textContent;
+          } else {
+            presenceData.details = namespaceDetails();
+            presenceData.state = titleFromURL();
+          }
+        } else if (
+          document.querySelector("#ca-ve-edit") ||
+          getURLParam("veaction")
+        ) {
+          presenceData.state = `${
+            title.toLowerCase() === titleFromURL().toLowerCase()
+              ? `${title}`
+              : `${title} (${titleFromURL()})`
+          }`;
+          updateCallback.function = (): void => {
+            if (actionResult() === "edit" || actionResult() === "editsource") {
+              presenceData.details = "Editing a page";
+            } else {
+              presenceData.details = namespaceDetails();
+            }
+          };
+        } else {
+          if (actionResult() === "edit") {
+            presenceData.details = document.querySelector("#ca-edit")
+              ? "Editing a page"
+              : "Viewing source";
+            presenceData.state = titleFromURL();
+          } else {
+            presenceData.details = namespaceDetails();
+            presenceData.state = `${
+              title.toLowerCase() === titleFromURL().toLowerCase()
+                ? `${title}`
+                : `${title} (${titleFromURL()})`
+            }`;
+          }
+        }
+
+        if (presenceData.state) presenceData.state += " | " + sitename;
+        else presenceData.state = sitename;
+
+        if (lang !== "en") {
+          if (presenceData.state) presenceData.state += ` (${lang})`;
+          else presenceData.details += ` (${lang})`;
+        }
+      } else if (currentPath[0] === "f") {
+        /*
 		
 		Chapter 3
 		This one is for the discussion parts on each wikis.
 		
 		*/
 
-    let sitename: string;
+        let sitename: string;
 
-    try {
-      sitename = (document.querySelector(
-        "meta[property='og:site_name']"
-      ) as HTMLMetaElement).content;
-    } catch (e) {
-      sitename = document.querySelector(".wds-community-header__sitename")
-        .textContent;
-    }
-
-    updateCallback.function = (): void => {
-      if (!currentPath[1]) {
-        const category = document.querySelector(
-          ".category-filter__dropdown-toggle"
-        ).textContent;
-        if (category === "Categories") {
-          presenceData.details = "Viewing the discussion page";
-        } else {
-          presenceData.details = "Viewing a discussion category";
-          presenceData.state = category;
+        try {
+          sitename = (document.querySelector(
+            "meta[property='og:site_name']"
+          ) as HTMLMetaElement).content;
+        } catch (e) {
+          sitename = document.querySelector(".wds-community-header__sitename")
+            .textContent;
         }
-      } else if (currentPath[1] === "p") {
-        presenceData.details = "Reading a discussion post";
-        presenceData.state = `${
-          document.querySelector(".post-info__title").textContent
-        } | ${sitename}`;
-      } else if (currentPath[1] === "u") {
-        presenceData.details = "Viewing a discussion user page";
-        presenceData.state = `${
-          document.querySelector(".user-overview__username").textContent
-        } | ${sitename}`;
+
+        updateCallback.function = (): void => {
+          if (!currentPath[1]) {
+            const category = document.querySelector(
+              ".category-filter__dropdown-toggle"
+            ).textContent;
+            if (category === "Categories") {
+              presenceData.details = "Viewing the discussion page";
+            } else {
+              presenceData.details = "Viewing a discussion category";
+              presenceData.state = category;
+            }
+          } else if (currentPath[1] === "p") {
+            presenceData.details = "Reading a discussion post";
+            presenceData.state = `${
+              document.querySelector(".post-info__title").textContent
+            } | ${sitename}`;
+          } else if (currentPath[1] === "u") {
+            presenceData.details = "Viewing a discussion user page";
+            presenceData.state = `${
+              document.querySelector(".user-overview__username").textContent
+            } | ${sitename}`;
+          }
+
+          if (presenceData.state) presenceData.state += " | " + sitename;
+          else presenceData.state = sitename;
+        };
       }
+    })();
 
-      if (presenceData.state) presenceData.state += " | " + sitename;
-      else presenceData.state = sitename;
-    };
-  }
-})();
-
-if (updateCallback.present) {
-  const defaultData = { ...presenceData };
-  if (presenceData)
-    presence.on("UpdateData", async () => {
-      resetData(defaultData);
-      updateCallback.function();
-      presence.setActivity(presenceData);
-    });
-} else {
-  if (presenceData)
-    presence.on("UpdateData", async () => {
-      presence.setActivity(presenceData);
-    });
-}
+    if (updateCallback.present) {
+      const defaultData = { ...presenceData };
+      presence.on("UpdateData", async () => {
+        resetData(defaultData);
+        updateCallback.function();
+        presence.setActivity(presenceData);
+      });
+    } else {
+      presence.on("UpdateData", async () => {
+        presence.setActivity(presenceData);
+      });
+    }
+  })();

--- a/websites/G/Gamepedia/dist/metadata.json
+++ b/websites/G/Gamepedia/dist/metadata.json
@@ -6,7 +6,7 @@
   },
   "service": "Gamepedia",
   "url": "gamepedia.com",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "logo": "https://i.imgur.com/EUu0IPu.png",
   "thumbnail": "https://i.imgur.com/Dr5wG06.png",
   "color": "#F48020",
@@ -15,5 +15,5 @@
     "en": "Gamepedia is the largest video game wiki platform on the web, featuring thousands of community-driven wiki projects.\nOwned and operated by FANDOM, Gamepedia is home to everything from indie title wikis to some of the best-known gaming wikis such as the Official Minecraft Wiki, Leaguepedia, and the Official ARK Wiki."
   },
   "category": "other",
-  "regExp": "[a-z0-9-]+[.]((gamepedia)|(fandom))[.]com[/]"
+  "regExp": "(([a-z0-9-]+[.])fandom[.]com[/])|(((www)|(fandomauth))[.]gamepedia[.]com[/])"
 }

--- a/websites/G/Gamepedia/presence.ts
+++ b/websites/G/Gamepedia/presence.ts
@@ -1,266 +1,280 @@
-const presence = new Presence({
-  clientId: "652880245371699222"
-});
+if (
+  !(
+    (
+      document.location.hostname.endsWith("fandom.com") &&
+      document.location.pathname.includes("/wiki/") &&
+      !document.querySelector("#netbar")
+    )
+    // Only run on Gamepedia wikis.
+  ) &&
+  document.location.hostname !== "www.fandom.com"
+  // Do not run on www.fandom.com.
+)
+  ((): void => {
+    const presence = new Presence({
+        clientId: "652880245371699222"
+      }),
+      browsingStamp = Math.floor(Date.now() / 1000);
+    let currentURL = new URL(document.location.href),
+      currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/"),
+      presenceData: PresenceData = {
+        details: "Viewing an unsupported page",
+        largeImageKey: "lg",
+        startTimestamp: browsingStamp
+      };
+    const updateCallback = {
+        _function: null as () => void,
+        get function(): () => void {
+          return this._function;
+        },
+        set function(parameter) {
+          this._function = parameter;
+        },
+        get present(): boolean {
+          return this._function !== null;
+        }
+      },
+      /**
+       * Initialize/reset presenceData.
+       */
+      resetData = (
+        defaultData: PresenceData = {
+          details: "Viewing an unsupported page",
+          largeImageKey: "lg",
+          startTimestamp: browsingStamp
+        }
+      ): void => {
+        currentURL = new URL(document.location.href);
+        currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
+        presenceData = { ...defaultData };
+      },
+      /**
+       * Search for URL parameters.
+       * @param urlParam The parameter that you want to know about the value.
+       */
+      getURLParam = (urlParam: string): string => {
+        return currentURL.searchParams.get(urlParam);
+      };
 
-let currentURL = new URL(document.location.href),
-  currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
-const browsingStamp = Math.floor(Date.now() / 1000);
-let presenceData: PresenceData = {
-  details: "Viewing an unsupported page",
-  largeImageKey: "lg",
-  startTimestamp: browsingStamp
-};
-const updateCallback = {
-    _function: null as () => void,
-    get function(): () => void {
-      return this._function;
-    },
-    set function(parameter) {
-      this._function = parameter;
-    },
-    get present(): boolean {
-      return this._function !== null;
-    }
-  },
-  /**
-   * Initialize/reset presenceData.
-   */
-  resetData = (
-    defaultData: PresenceData = {
-      details: "Viewing an unsupported page",
-      largeImageKey: "lg",
-      startTimestamp: browsingStamp
-    }
-  ): void => {
-    currentURL = new URL(document.location.href);
-    currentPath = currentURL.pathname.replace(/^\/|\/$/g, "").split("/");
-    presenceData = { ...defaultData };
-  },
-  /**
-   * Search for URL parameters.
-   * @param urlParam The parameter that you want to know about the value.
-   */
-  getURLParam = (urlParam: string): string => {
-    return currentURL.searchParams.get(urlParam);
-  };
+    ((): void => {
+      presence.info("Running...");
 
-((): void => {
-  if (currentURL.hostname === "www.gamepedia.com") {
-    /*
+      if (currentURL.hostname === "www.gamepedia.com") {
+        /*
 
 		Chapter 1
 		This part is for the editorial part of Gamepedia.
 		
 		*/
 
-    if (currentPath[0] === "") {
-      presenceData.details = "On the index page";
-    } else if (currentPath[0] === "news") {
-      presenceData.details = "Reading an news article";
-      presenceData.state = document.querySelector(
-        ".p-article-title"
-      ).textContent;
-    } else if (currentPath[0] === "blog") {
-      presenceData.details = "Reading a blog article";
-      presenceData.state = document.querySelector(
-        ".p-article-title"
-      ).textContent;
-    } else if (currentPath[0] === "members") {
-      presenceData.details = "Reading a blog article";
-      presenceData.state = document.querySelector(".username").textContent;
-    } else {
-      presenceData.details = "Viewing a page";
-      if (currentPath[0] === "PRO") presenceData.state = "Gamepedia PRO";
-      else presenceData.state = document.title.split(" - ")[0];
-    }
-  } else if (currentURL.hostname === "fandomauth.gamepedia.com") {
-    if (currentPath[0] === "signin") {
-      presenceData.details = "Signing in";
-    } else if (currentPath[0] === "register") {
-      presenceData.details = "Registering an account";
-    }
-  } else if (
-    currentURL.hostname.endsWith("fandom.com") &&
-    currentPath.includes("wiki")
-  ) {
-    /*
+        if (currentPath[0] === "") {
+          presenceData.details = "On the index page";
+        } else if (currentPath[0] === "news") {
+          presenceData.details = "Reading an news article";
+          presenceData.state = document.querySelector(
+            ".p-article-title"
+          ).textContent;
+        } else if (currentPath[0] === "blog") {
+          presenceData.details = "Reading a blog article";
+          presenceData.state = document.querySelector(
+            ".p-article-title"
+          ).textContent;
+        } else if (currentPath[0] === "members") {
+          presenceData.details = "Reading a blog article";
+          presenceData.state = document.querySelector(".username").textContent;
+        } else {
+          presenceData.details = "Viewing a page";
+          if (currentPath[0] === "PRO") presenceData.state = "Gamepedia PRO";
+          else presenceData.state = document.title.split(" - ")[0];
+        }
+      } else if (currentURL.hostname === "fandomauth.gamepedia.com") {
+        if (currentPath[0] === "signin") {
+          presenceData.details = "Signing in";
+        } else if (currentPath[0] === "register") {
+          presenceData.details = "Registering an account";
+        }
+      } else {
+        /*
 
 		Chapter 2
 		This part is for the wiki part of Gamepedia.
 		
 		*/
 
-    if (!document.querySelector("#netbar")) {
-      // Do not run on Fandom wikis.
-      presenceData = null;
-      return;
-    }
+        let title: string, sitename: string;
+        const actionResult = (): string =>
+            getURLParam("action") || getURLParam("veaction"),
+          lang = currentPath[0] === "wiki" ? "en" : currentPath[0],
+          titleFromURL = (): string => {
+            const raw: string =
+              currentPath[0] === "index.php"
+                ? getURLParam("title")
+                : currentPath[0] === "wiki"
+                ? currentPath.slice(1).join("/")
+                : currentPath.slice(2).join("/");
+            //let lang: string = currentPath[0]
+            return decodeURIComponent(raw.replace(/_/g, " "));
+          };
 
-    let title: string, sitename: string;
-    const actionResult = (): string =>
-        getURLParam("action") || getURLParam("veaction"),
-      titleFromURL = (): string => {
-        const raw: string =
-          currentPath[0] === "index.php"
-            ? getURLParam("title")
-            : currentPath[0] === "wiki"
-            ? currentPath.slice(1).join("/")
-            : currentPath.slice(2).join("/");
-        //let lang: string = currentPath[0]
-        return raw.replace(/_/g, " ");
-      };
-
-    try {
-      title = document.querySelector("h1").textContent;
-    } catch (e) {
-      title = titleFromURL();
-    }
-
-    try {
-      sitename = (document.querySelector(
-        "meta[property='og:site_name']"
-      ) as HTMLMetaElement).content;
-    } catch (e) {
-      const mainPageHref = ((document.querySelector(
-          "#n-mainpage-description a"
-        ) ||
-          document.querySelector("#p-navigation a") ||
-          document.querySelector(".mw-wiki-logo")) as HTMLAnchorElement).href,
-        mainPageURL = new URL(mainPageHref),
-        mainPagePath = mainPageURL.pathname.replace(/^\/|\/$/g, "").split("/"),
-        mainPageRaw = decodeURI(
-          mainPagePath[0] === "index.php"
-            ? getURLParam("title")
-            : mainPagePath[0] === "wiki"
-            ? mainPagePath.slice(1).join("/")
-            : mainPagePath.slice(2).join("/")
-        );
-      sitename = mainPageRaw.replace(/_/g, " ");
-    }
-
-    /**
-     * Returns details based on the namespace.
-     * @link https://en.wikipedia.org/wiki/Wikipedia:Namespace
-     */
-    const namespaceDetails = (): string => {
-      const details: { [index: string]: string } = {
-        "-2": "Viewing a media",
-        "-1": "Viewing a special page",
-        0: "Reading an article",
-        1: "Viewing a talk page",
-        2: "Viewing a user page",
-        3: "Viewing a user talk page",
-        4: "Viewing a project page",
-        5: "Viewing a project talk page",
-        6: "Viewing a file",
-        7: "Viewing a file talk page",
-        8: "Viewing an interface page",
-        9: "Viewing an interface talk page",
-        10: "Viewing a template",
-        11: "Viewing a template talk page",
-        12: "Viewing a help page",
-        13: "Viewing a help talk page",
-        14: "Viewing a category",
-        15: "Viewing a category talk page",
-        110: "Viewing a forum page",
-        111: "Viewing a forum talk page",
-        202: "Viewing a user profile", // handled again by function below
-        274: "Viewing a widget page",
-        275: "Viewing a widget talk page",
-        420: "Viewing a GeoJson page",
-        421: "Viewing a GeoJson talk page",
-        710: "Viewing a media's subtitles",
-        711: "Viewing a media's subtitles talk page",
-        828: "Viewing a module",
-        829: "Viewing a module talk page",
-        // Wikis like Minecraft Wiki have custom namespaces above 9999 for other topics.
-        // They work like normal main pages.
-        10000: "Reading an article",
-        10001: "Viewing a talk page",
-        10002: "Reading an article",
-        10003: "Viewing a talk page"
-      };
-      return (
-        details[
-          [...document.querySelector("body").classList]
-            .filter((v) => /ns--?\d/.test(v))[0]
-            .slice(3)
-        ] || "Viewing a wiki page"
-      );
-    };
-
-    if (
-      ((document.querySelector("#n-mainpage-description a") ||
-        document.querySelector("#p-navigation a") ||
-        document.querySelector(".mw-wiki-logo")) as HTMLAnchorElement).href ===
-      currentURL.href
-    ) {
-      presenceData.details = "On the home page";
-    } else if (document.querySelector(".unified-search__form")) {
-      presenceData.details = "Searching for a page";
-      presenceData.state = (document.querySelector(
-        ".unified-search__input__query"
-      ) as HTMLInputElement).value;
-    } else if (actionResult() === "history") {
-      presenceData.details = "Viewing revision history";
-      presenceData.state = titleFromURL();
-    } else if (getURLParam("diff")) {
-      presenceData.details = "Viewing difference between revisions";
-      presenceData.state = titleFromURL();
-    } else if (getURLParam("oldid")) {
-      presenceData.details = "Viewing an old revision of a page";
-      presenceData.state = titleFromURL();
-    } else if (namespaceDetails() === "Viewing a user profile") {
-      presenceData.details = namespaceDetails();
-      presenceData.state = document.querySelector(".mw-headline").textContent;
-    } else if (
-      document.querySelector("#ca-ve-edit") ||
-      getURLParam("veaction")
-    ) {
-      presenceData.state = `${
-        title.toLowerCase() === titleFromURL().toLowerCase()
-          ? `${title}`
-          : `${title} (${titleFromURL()})`
-      }`;
-      updateCallback.function = (): void => {
-        if (actionResult() === "edit" || actionResult() === "editsource") {
-          presenceData.details = "Editing a page";
-        } else {
-          presenceData.details = namespaceDetails();
+        try {
+          title = document.querySelector("h1").textContent;
+        } catch (e) {
+          title = titleFromURL();
         }
-      };
-    } else {
-      if (actionResult() === "edit") {
-        presenceData.details = document.querySelector("#ca-edit")
-          ? "Editing a page"
-          : "Viewing source";
-        presenceData.state = titleFromURL();
-      } else {
-        presenceData.details = namespaceDetails();
-        presenceData.state = `${
-          title.toLowerCase() === titleFromURL().toLowerCase()
-            ? `${title}`
-            : `${title} (${titleFromURL()})`
-        }`;
+
+        try {
+          sitename = (document.querySelector(
+            "meta[property='og:site_name']"
+          ) as HTMLMetaElement).content;
+        } catch (e) {
+          const mainPageHref = ((document.querySelector(
+              "#n-mainpage-description a"
+            ) ||
+              document.querySelector("#p-navigation a") ||
+              document.querySelector(".mw-wiki-logo")) as HTMLAnchorElement)
+              .href,
+            mainPageURL = new URL(mainPageHref),
+            mainPagePath = mainPageURL.pathname
+              .replace(/^\/|\/$/g, "")
+              .split("/"),
+            mainPageRaw =
+              mainPagePath[0] === "index.php"
+                ? getURLParam("title")
+                : mainPagePath[0] === "wiki"
+                ? mainPagePath.slice(1).join("/")
+                : mainPagePath.slice(2).join("/");
+          sitename = decodeURIComponent(mainPageRaw.replace(/_/g, " "));
+        }
+
+        /**
+         * Returns details based on the namespace.
+         * @link https://en.wikipedia.org/wiki/Wikipedia:Namespace
+         */
+        const namespaceDetails = (): string => {
+          const details: { [index: string]: string } = {
+            "-2": "Viewing a media",
+            "-1": "Viewing a special page",
+            0: "Reading an article",
+            1: "Viewing a talk page",
+            2: "Viewing a user page",
+            3: "Viewing a user talk page",
+            4: "Viewing a project page",
+            5: "Viewing a project talk page",
+            6: "Viewing a file",
+            7: "Viewing a file talk page",
+            8: "Viewing an interface page",
+            9: "Viewing an interface talk page",
+            10: "Viewing a template",
+            11: "Viewing a template talk page",
+            12: "Viewing a help page",
+            13: "Viewing a help talk page",
+            14: "Viewing a category",
+            15: "Viewing a category talk page",
+            110: "Viewing a forum page",
+            111: "Viewing a forum talk page",
+            202: "Viewing a user profile", // handled again by function below
+            274: "Viewing a widget page",
+            275: "Viewing a widget talk page",
+            420: "Viewing a GeoJson page",
+            421: "Viewing a GeoJson talk page",
+            710: "Viewing a media's subtitles",
+            711: "Viewing a media's subtitles talk page",
+            828: "Viewing a module",
+            829: "Viewing a module talk page",
+            // Wikis like Minecraft Wiki have custom namespaces above 9999 for other topics.
+            // They work like normal main pages.
+            10000: "Reading an article",
+            10001: "Viewing a talk page",
+            10002: "Reading an article",
+            10003: "Viewing a talk page"
+          };
+          return (
+            details[
+              [...document.querySelector("body").classList]
+                .filter((v) => /ns--?\d/.test(v))[0]
+                .slice(3)
+            ] || "Viewing a wiki page"
+          );
+        };
+
+        if (
+          ((document.querySelector("#n-mainpage-description a") ||
+            document.querySelector("#p-navigation a") ||
+            document.querySelector(".mw-wiki-logo")) as HTMLAnchorElement)
+            .href === currentURL.href
+        ) {
+          presenceData.details = "On the home page";
+        } else if (document.querySelector(".unified-search__form")) {
+          presenceData.details = "Searching for a page";
+          presenceData.state = (document.querySelector(
+            ".unified-search__input__query"
+          ) as HTMLInputElement).value;
+        } else if (actionResult() === "history") {
+          presenceData.details = "Viewing revision history";
+          presenceData.state = titleFromURL();
+        } else if (getURLParam("diff")) {
+          presenceData.details = "Viewing difference between revisions";
+          presenceData.state = titleFromURL();
+        } else if (getURLParam("oldid")) {
+          presenceData.details = "Viewing an old revision of a page";
+          presenceData.state = titleFromURL();
+        } else if (namespaceDetails() === "Viewing a user profile") {
+          presenceData.details = namespaceDetails();
+          presenceData.state = document.querySelector(
+            ".mw-headline"
+          ).textContent;
+        } else if (
+          document.querySelector("#ca-ve-edit") ||
+          getURLParam("veaction")
+        ) {
+          presenceData.state = `${
+            title.toLowerCase() === titleFromURL().toLowerCase()
+              ? `${title}`
+              : `${title} (${titleFromURL()})`
+          }`;
+          updateCallback.function = (): void => {
+            if (actionResult() === "edit" || actionResult() === "editsource") {
+              presenceData.details = "Editing a page";
+            } else {
+              presenceData.details = namespaceDetails();
+            }
+          };
+        } else {
+          if (actionResult() === "edit") {
+            presenceData.details = document.querySelector("#ca-edit")
+              ? "Editing a page"
+              : "Viewing source";
+            presenceData.state = titleFromURL();
+          } else {
+            presenceData.details = namespaceDetails();
+            presenceData.state = `${
+              title.toLowerCase() === titleFromURL().toLowerCase()
+                ? `${title}`
+                : `${title} (${titleFromURL()})`
+            }`;
+          }
+        }
+
+        if (presenceData.state) presenceData.state += " | " + sitename;
+        else presenceData.state = sitename;
+
+        if (lang !== "en") {
+          if (presenceData.state) presenceData.state += ` (${lang})`;
+          else presenceData.details += ` (${lang})`;
+        }
       }
+    })();
+
+    if (updateCallback.present) {
+      const defaultData = { ...presenceData };
+      presence.on("UpdateData", async () => {
+        resetData(defaultData);
+        updateCallback.function();
+        presence.setActivity(presenceData);
+      });
+    } else {
+      presence.on("UpdateData", async () => {
+        presence.setActivity(presenceData);
+      });
     }
-
-    if (presenceData.state) presenceData.state += " | " + sitename;
-    else presenceData.state = sitename;
-  }
-})();
-
-if (updateCallback.present) {
-  const defaultData = { ...presenceData };
-  if (presenceData)
-    presence.on("UpdateData", async () => {
-      resetData(defaultData);
-      updateCallback.function();
-      presence.setActivity(presenceData);
-    });
-} else {
-  if (presenceData)
-    presence.on("UpdateData", async () => {
-      presence.setActivity(presenceData);
-    });
-}
+  })();


### PR DESCRIPTION
## Description

Well, it looks that my first attempt on resolving this issue kind of failed. Here's the second one, along with additional additions that are astonishingly overlooked.

By the way, I need to wrap the entire code in an if statement, so that's why the changes looked a lot. [This is the commit that I made on my side](https://github.com/Hans5958/PreMiD-Presences-Personal/commit/838a89d01adebc110479add5d3edf94e548b470b).

This PR includes updates to the following presences:

- Fandom (1.2.3)
- Gamepedia (1.2.3)

## Changelog

- Change method of early termination to fix critical bug where Fandom and Gamepedia presence can't run at the same time
- Add language code on the state/details for other languages than English (feature from WP)
- Revert feature "updating when there is presence data"
- Fix regex to only allow select Gamepedia domain (Gamepedia)
- Use `decodeURIComponent()` instead of `decodeURI()` for more correct title from the URL
- Use "!==" instead of negated "===" (DeepScan) (Gamepedia)
- Change position to save `let`/`const` keyword (@Bas950)

## Images

| Image | Link visited |
| ----- | ------------ |
| ![](https://user-images.githubusercontent.com/11584103/114367476-acbee480-9ba6-11eb-9082-af2dc7ce3b39.png) | https://www.fandom.com/ |
| ![](https://user-images.githubusercontent.com/11584103/114367482-ae88a800-9ba6-11eb-9ec3-1765efe685f0.png) | <https://nier.fandom.com/wiki/NieR_Replicant_ver.1.22474487139...> |
| ![](https://user-images.githubusercontent.com/11584103/114367491-b0526b80-9ba6-11eb-9272-24f1d52a438c.png) | https://www.gamepedia.com/ |
| ![](https://user-images.githubusercontent.com/11584103/114368150-530aea00-9ba7-11eb-9afd-d9a7203221e3.png) | https://minecraft.fandom.com/wiki/Java_Edition_1.16.5 |