### PR TITLE
Replit - Fixed file editing presence

### DIFF
--- a/websites/R/Replit/dist/metadata.json
+++ b/websites/R/Replit/dist/metadata.json
@@ -11,7 +11,7 @@
     "en": "Replit, formerly Repl.it, is a San Francisco based start-up and an online IDE (integrated development environment) supporting 40 programming languages, including Python, Lua, JavaScript, Julia, C++, C++11, C, C#, HTML/CSS/JS, Python with turtle and LOLCODE. Replit allows users to write code and build apps using a browser, without having to install any software on their devices."
   },
   "url": "replit.com",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "logo": "https://i.imgur.com/jL7ohN5.png",
   "thumbnail": "https://i.imgur.com/4AwIxoc.png",
   "color": "#808080",

--- a/websites/R/Replit/presence.ts
+++ b/websites/R/Replit/presence.ts
@@ -21,7 +21,7 @@ presence.on("UpdateData", () => {
       presenceData.state = user;
     } else {
       const fileType: string = (document.querySelector(
-          "#workspace-root > div > div.jsx-132086333.content > div.jsx-77352756.workspace-page-wrapper.desktop > div > div > div:nth-child(1) > header > div > div.jsx-1874997921.left > div > div > div.jsx-2652062152.workspace-header-info > div.jsx-2652062152.language-icon-container > img"
+          "#workspace-root > div > div.jsx-132086333.content > div.jsx-77352756.workspace-page-wrapper.desktop > div > div > div:nth-child(1) > header > div > div.jsx-2650114939.left > div > div > div.jsx-2652062152.workspace-header-info > div.jsx-2652062152.language-icon-container > img"
         ) as HTMLImageElement).alt,
         projectName: string =
           Path.split("/").filter((elm) => elm !== "")[1] +


### PR DESCRIPTION
Due to DOM changes, presence while editing a file was broken. Updated the presence to fix this.

Screenshot
![image](https://user-images.githubusercontent.com/39941042/116820590-87187000-ab93-11eb-825d-204a65b8bbb7.png)

