### PR TITLE
Add small image Auto-generated

### DIFF
--- a/websites/B/BeatSaver/dist/metadata.json
+++ b/websites/B/BeatSaver/dist/metadata.json
@@ -9,7 +9,7 @@
     "en": "Beat Saber's #1 unofficial beatmap distributor!"
   },
   "url": "beatsaver.com",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "logo": "https://i.imgur.com/fU3XbbC.png",
   "thumbnail": "https://i.imgur.com/v6ZBdah.png",
   "color": "#232325",

--- a/websites/B/BeatSaver/dist/metadata.json
+++ b/websites/B/BeatSaver/dist/metadata.json
@@ -9,7 +9,7 @@
       "en": "Beat Saber's #1 unofficial beatmap distributor!"
     },
     "url": "beatsaver.com",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "logo": "https://i.imgur.com/fU3XbbC.png",
     "thumbnail": "https://i.imgur.com/v6ZBdah.png",
     "color": "#232325",

--- a/websites/B/BeatSaver/presence.ts
+++ b/websites/B/BeatSaver/presence.ts
@@ -10,13 +10,18 @@ presence.on("UpdateData", async () => {
     presenceData: PresenceData = {
       largeImageKey: "logo",
       startTimestamp: browsingStamp
-    };
+    },
+    showAutos = <HTMLInputElement>document.querySelector("#showAutos");
 
   if (document.location.pathname.includes("/search")) {
     presenceData.details = "Searching Beatmaps";
     presenceData.state = document
       .querySelector("input.input")
       .getAttribute("value");
+    if (showAutos.checked == true) {
+      presenceData.smallImageKey = "showauto";
+      presenceData.smallImageText = "Showing Auto-generated Beatmaps";
+    }
   } else if (document.location.pathname.includes("/beatmap/")) {
     if (document.querySelector("span.tag.is-expert-plus") != null)
       presenceData.smallImageKey = "expert_",
@@ -51,17 +56,23 @@ presence.on("UpdateData", async () => {
       }
     ];
   }
-  else if (document.location.pathname.includes("/uploader/"))
-    presenceData.details = "Browsing By Uploader",
-      presenceData.state = document
-        .querySelector("h1.is-size-2.has-text-weight-light.has-text-centered")
-        .textContent.split(" ")[2],
-      presenceData.buttons = [
-        {
-          label: "View Page",
-          url: document.location.href
-        }
-      ];
+  else if (document.location.pathname.includes("/uploader/")) {
+    presenceData.details = "Browsing By Uploader";
+    presenceData.state = document
+      .querySelector("h1.is-size-2.has-text-weight-light.has-text-centered")
+      .textContent.split(" ")[2];
+    presenceData.buttons = [
+      {
+        label: "View Page",
+        url: document.location.href
+      }
+    ];
+    if (showAutos.checked == true) {
+      presenceData.smallImageKey = "showauto";
+      presenceData.smallImageText = "Showing Auto-generated Beatmaps";
+    }
+  }
+
   switch (document.location.pathname) {
     case "/browse/latest":
       presenceData.details = "Browsing By Latest";
@@ -99,6 +110,13 @@ presence.on("UpdateData", async () => {
     case "/":
       presenceData.details = "Viewing Home Page";
       break;
+  }
+
+  if (document.location.pathname.split("/")[1].includes("browse")) {
+    if (showAutos.checked == true) {
+      presenceData.smallImageKey = "showauto";
+      presenceData.smallImageText = "Showing Auto-generated Beatmaps";
+    }
   }
 
   if (!time)

--- a/websites/B/BeatSaver/presence.ts
+++ b/websites/B/BeatSaver/presence.ts
@@ -18,7 +18,7 @@ presence.on("UpdateData", async () => {
     presenceData.state = document
       .querySelector("input.input")
       .getAttribute("value");
-    if (showAutos.checked == true) {
+    if (showAutos.checked) {
       presenceData.smallImageKey = "showauto";
       presenceData.smallImageText = "Showing Auto-generated Beatmaps";
     }
@@ -67,7 +67,7 @@ presence.on("UpdateData", async () => {
         url: document.location.href
       }
     ];
-    if (showAutos.checked == true) {
+    if (showAutos.checked) {
       presenceData.smallImageKey = "showauto";
       presenceData.smallImageText = "Showing Auto-generated Beatmaps";
     }
@@ -113,7 +113,7 @@ presence.on("UpdateData", async () => {
   }
 
   if (document.location.pathname.split("/")[1].includes("browse")) {
-    if (showAutos.checked == true) {
+    if (showAutos.checked) {
       presenceData.smallImageKey = "showauto";
       presenceData.smallImageText = "Showing Auto-generated Beatmaps";
     }


### PR DESCRIPTION
Adds a small image to indicate that user is showing auto-generated beatmaps.

Show auto-generated beatmaps checked:
![Discord_Qpz689BNUK](https://user-images.githubusercontent.com/44418429/116929205-6537ef80-ac5e-11eb-90df-b5a2b1d6ef36.png)
![Discord_8sUKSdsNTN](https://user-images.githubusercontent.com/44418429/116929426-b34cf300-ac5e-11eb-8b96-ccf9ab45c7e1.png)
![Discord_wH0DMScJAI](https://user-images.githubusercontent.com/44418429/116929508-d081c180-ac5e-11eb-8ba4-bb5e2979cb85.png)

Show auto-generated beatmaps unchecked:
![Discord_f9KkpBpRwv](https://user-images.githubusercontent.com/44418429/116929275-797bec80-ac5e-11eb-8eb3-d752094fc7b8.png)
![Discord_yTf8VxYmdN](https://user-images.githubusercontent.com/44418429/116929437-b6e07a00-ac5e-11eb-9d1a-0f550c4a6856.png)
![Discord_1mkLzsOikt](https://user-images.githubusercontent.com/44418429/116929505-ce1f6780-ac5e-11eb-8538-49ee2997493f.png)

Works on every Browse page and the Search and Uploader pages