### PR TITLE
Update discord link to premid sub-domain

### DIFF
--- a/websites/P/Plex/dist/metadata.json
+++ b/websites/P/Plex/dist/metadata.json
@@ -10,14 +10,11 @@
     "de": "Mit Plex können Sie Ihre persönlichen Medien zusammen mit Premium-Inhalten verwalten und streamen. Genießen Sie Ihre eigenen Inhalte auf all Ihren Geräten, wo immer Sie mit Plex unterwegs sind."
   },
   "url": "www.plex.tv",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "logo": "https://i.imgur.com/FPxlGGE.png",
   "thumbnail": "https://i.imgur.com/DQvN7Nx.png",
   "color": "#d78c14",
-  "tags": [
-    "video",
-    "music"
-  ],
+  "tags": ["video", "music"],
   "category": "videos",
   "regExp": "(([a-z0-9-]+[.])*plex[.]tv[/])|( *[/]web[/]index[.]html#)"
 }

--- a/websites/P/Plex/presence.ts
+++ b/websites/P/Plex/presence.ts
@@ -159,7 +159,7 @@ function getTranslation(stringName: string): string {
       }
     default:
       PMD_error(
-        "Unknown StringName please contact the Developer of this presence!\nYou can contact him/her in the PreMiD Discord (discord.gg/premid)"
+        "Unknown StringName please contact the Developer of this presence!\nYou can contact him/her in the PreMiD Discord (discord.premid.app)"
       );
       return "Unknown stringName";
   }

--- a/websites/Z/Zalando/dist/metadata.json
+++ b/websites/Z/Zalando/dist/metadata.json
@@ -11,14 +11,11 @@
     "ga_IE": "Zalando | Ceannaigh bróga ar líne: Bróga ó na brandaí is fearr."
   },
   "url": "www.zalando.com",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "logo": "https://i.imgur.com/APLPI4i.png",
   "thumbnail": "https://i.imgur.com/lFWmRc9.png",
   "color": "#f47127",
-  "tags": [
-    "shop",
-    "fashion"
-  ],
+  "tags": ["shop", "fashion"],
   "category": "other",
   "regExp": "([a-z0-9-]+[.])*zalando([.][a-z]+)+[/]"
 }

--- a/websites/Z/Zalando/presence.ts
+++ b/websites/Z/Zalando/presence.ts
@@ -111,7 +111,7 @@ function getTranslation(stringName: string): string {
       break;
     default:
       PMD_error(
-        "Unknown StringName please contact the Developer of this presence!\nYou can contact him/her in the PreMiD Discord (discord.gg/premid)"
+        "Unknown StringName please contact the Developer of this presence!\nYou can contact him/her in the PreMiD Discord (discord.premid.app)"
       );
       return "Unknown stringName";
       break;


### PR DESCRIPTION
For both Plex and Zalando, they referenced an old redirect to the discord server.
Updated to the PreMiD Sub-Domain