### PR TITLE
MangaSee fix | added missing url

### DIFF
--- a/websites/M/MangaSee/dist/metadata.json
+++ b/websites/M/MangaSee/dist/metadata.json
@@ -14,7 +14,7 @@
       "manga",
       "manhwa"
     ],
-    "url": "www.mangasee123.com",
+    "url": ["www.mangasee123.com", "mangasee123.com"],
     "description": {
       "en": "Read free manga online. Read the latest chapters of Tower of God, One Piece, Onepunch-Man, Berserk, Boku no Hero Academia, Naruto."
     },


### PR DESCRIPTION
Since the website doesn't redirect to www subdomain, I added the url without it so it works.