### PR TITLE
Fixed URL problems for Overleaf Presence

### DIFF
--- a/websites/O/Overleaf/dist/metadata.json
+++ b/websites/O/Overleaf/dist/metadata.json
@@ -4,22 +4,8 @@
     "name": "Enevevet",
     "id": "329669021043523594"
   },
-  "url": [
-    "www.overleaf.com",
-    "cs.overleaf.com",
-    "es.overleaf.com",
-    "pt.overleaf.com",
-    "fr.overleaf.com",
-    "de.overleaf.com",
-    "sv.overleaf.com",
-    "tr.overleaf.com",
-    "it.overleaf.com",
-    "cn.overleaf.com",
-    "no.overleaf.com",
-    "da.overleaf.com",
-    "ko.overleaf.com",
-    "ja.overleaf.com"
-  ],
+  "url": "www.overleaf.com",
+  "regExp": "([a-z0-9-]+[.])*overleaf[.]com[/]",
   "description": {
     "en": "Overleaf is a collaborative cloud-based LaTeX editor used for writing, editing and publishing scientific documents. It partners with a wide range of scientific publishers to provide official journal LaTeX templates, and direct submission links.",
     "fr": "Overleaf est un éditeur LaTeX en ligne collaboratif en temps réel utilisé pour écrire, éditer et publier des documents scientifiques. Il fournit différents modèles LaTeX de journaux officiels et permet d'y publier directement des documents grâce à ses partenariats avec des éditeurs scientifiques.",

--- a/websites/O/Overleaf/dist/metadata.json
+++ b/websites/O/Overleaf/dist/metadata.json
@@ -4,14 +4,29 @@
     "name": "Enevevet",
     "id": "329669021043523594"
   },
-  "url": "www.overleaf.com",
+  "url": [
+    "www.overleaf.com",
+    "cs.overleaf.com",
+    "es.overleaf.com",
+    "pt.overleaf.com",
+    "fr.overleaf.com",
+    "de.overleaf.com",
+    "sv.overleaf.com",
+    "tr.overleaf.com",
+    "it.overleaf.com",
+    "cn.overleaf.com",
+    "no.overleaf.com",
+    "da.overleaf.com",
+    "ko.overleaf.com",
+    "ja.overleaf.com"
+  ],
   "description": {
     "en": "Overleaf is a collaborative cloud-based LaTeX editor used for writing, editing and publishing scientific documents. It partners with a wide range of scientific publishers to provide official journal LaTeX templates, and direct submission links.",
     "fr": "Overleaf est un éditeur LaTeX en ligne collaboratif en temps réel utilisé pour écrire, éditer et publier des documents scientifiques. Il fournit différents modèles LaTeX de journaux officiels et permet d'y publier directement des documents grâce à ses partenariats avec des éditeurs scientifiques.",
     "nl": "Overleaf is een op samenwerking gebaseerde LaTeX-editor in de cloud die wordt gebruikt voor het schrijven, bewerken en publiceren van wetenschappelijke documenten. Het werkt samen met een breed scala aan wetenschappelijke uitgevers om LaTeX-sjablonen van officiële tijdschriften en directe indieningslinks te bieden."
   },
   "service": "Overleaf",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "logo": "https://i.imgur.com/FbpZZg1.png",
   "thumbnail": "https://i.imgur.com/lWInfl3.png",
   "color": "#138A07",


### PR DESCRIPTION
The language is not that important in the Presence since the language is just the display language for Overleaf and doesn't change the rest. The Presence just needed to be triggered on some specific subdomains.