### PR TITLE
Fix buttons type

### DIFF
--- a/@types/premid/index.d.ts
+++ b/@types/premid/index.d.ts
@@ -33,10 +33,11 @@ interface PresenceData {
     /**
      * Array of buttons, max 2, label is the button text, and url is the link
      */
-    buttons?: {
-        label: string;
-        url: string;
-    }[];
+    buttons?: [ButtonData, ButtonData?];
+}
+interface ButtonData {
+  label: string
+  url: string
 }
 /**
  * Options that change the behavior of the presence


### PR DESCRIPTION
This makes it so that you can only have a maximum of 2 buttons and not infinite like previously. I only made the second element of the array optional because I assume you'd want to add at least one button when setting buttons, although passing an empty array would technically also be correct.