### PR TITLE
Crunchyroll Beta Website

### DIFF
--- a/websites/C/Crunchyroll/dist/metadata.json
+++ b/websites/C/Crunchyroll/dist/metadata.json
@@ -21,7 +21,10 @@
     "zh_CN": "Crunchyroll是美国的一家提供东亚相关流媒体影视服务和国际交流社区的网站。",
     "zh_TW": "Crunchyroll是美國的一家提供東亞相關串流媒體影視服務和國際交流社區的網站。"
   },
-  "url": "www.crunchyroll.com",
+  "url": [
+    "www.crunchyroll.com",
+    "beta.crunchyroll.com"
+    ],
   "version": "2.6.8",
   "logo": "https://i.imgur.com/LpTKP8c.png",
   "thumbnail": "https://i.imgur.com/hzM7YCb.png",


### PR DESCRIPTION
Added "beta.crunchyroll.com" for the Crunchyroll Beta Page.