### PR TITLE
Add Dominion Online presence

### DIFF
--- a/websites/D/Dominion Online/dist/metadata.json
+++ b/websites/D/Dominion Online/dist/metadata.json
@@ -10,8 +10,8 @@
   },
   "url": "dominion.games",
   "version": "1.0.0",
-  "logo": "URL",
-  "thumbnail": "https://i.imgur.com/ZgXpZ9h.jpg",
+  "logo": "https://i.imgur.com/qYm3qWs.jpg",
+  "thumbnail": "https://i.imgur.com/VS6HVeg.jpg",
   "color": "#468c01",
   "tags": ["card", "game", "dominion"],
   "category": "games"

--- a/websites/D/Dominion Online/dist/metadata.json
+++ b/websites/D/Dominion Online/dist/metadata.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.3",
+  "author": {
+    "name": "Nep",
+    "id": "187577389419724800"
+  },
+  "service": "Dominion Online",
+  "description": {
+    "en": "Dominion Online, developed by Shuffle iT, is the official platform to play Dominion, the award-winning deckbuilding card game created by Donald X. Vaccarino."
+  },
+  "url": "dominion.games",
+  "version": "1.0.0",
+  "logo": "URL",
+  "thumbnail": "https://i.imgur.com/ZgXpZ9h.jpg",
+  "color": "#468c01",
+  "tags": ["card", "game", "dominion"],
+  "category": "games"
+}

--- a/websites/D/Dominion Online/presence.ts
+++ b/websites/D/Dominion Online/presence.ts
@@ -2,7 +2,8 @@ const presence = new Presence({
   clientId: "849684658563055627"
 });
 
-const generalStartTime = Math.floor(Date.now() / 1000);
+const logRegex = /^.+ - \w+$/,
+  generalStartTime = Math.floor(Date.now() / 1000);
 let lobbyStartTime: number,
   gameStartTime: number;
 
@@ -36,7 +37,7 @@ presence.on("UpdateData", () => {
       const logText = logs[i].textContent.trim();
 
       // Append turn
-      if (/^.+ - \w+$/.test(logText)) {
+      if (logRegex.test(logText)) {
         presenceData.state = logText;
         break;
       }

--- a/websites/D/Dominion Online/presence.ts
+++ b/websites/D/Dominion Online/presence.ts
@@ -2,13 +2,14 @@ const presence = new Presence({
   clientId: "849684658563055627"
 });
 
+const generalStartTime = Math.floor(Date.now() / 1000);
 let lobbyStartTime: number,
   gameStartTime: number;
 
 presence.on("UpdateData", () => {
   const presenceData: PresenceData = {
     largeImageKey: "logo",
-    startTimestamp: Math.floor(Date.now() / 1000)
+    startTimestamp: generalStartTime
   };
 
   if (document.querySelector(".my-table") || document.querySelector(".score-page")) {

--- a/websites/D/Dominion Online/presence.ts
+++ b/websites/D/Dominion Online/presence.ts
@@ -2,8 +2,8 @@ const presence = new Presence({
   clientId: "849684658563055627"
 });
 
-let lobbyStartTime: number;
-let gameStartTime: number;
+let lobbyStartTime: number,
+  gameStartTime: number;
 
 presence.on("UpdateData", () => {
   const presenceData: PresenceData = {
@@ -12,31 +12,25 @@ presence.on("UpdateData", () => {
   };
 
   if (document.querySelector(".my-table") || document.querySelector(".score-page")) {
-    if (lobbyStartTime == 0) {
-      lobbyStartTime = Math.floor(Date.now() / 1000);
-    }
+    if (lobbyStartTime === 0) lobbyStartTime = Math.floor(Date.now() / 1000);
     gameStartTime = 0;
     
-    const isHost = document.querySelector(".rules-editor") !== null || document.querySelector("button[ng-click=\"$ctrl.editTable()\"]") !== null;
-    const members = document.querySelector(".participant-list-label").textContent.trim();
+    const isHost = document.querySelector(".rules-editor") !== null || document.querySelector("button[ng-click=\"$ctrl.editTable()\"]") !== null,
+      members = document.querySelector(".participant-list-label").textContent.trim();
 
     presenceData.details = `In Lobby: ${members}`;
     presenceData.state = isHost ? "Host" : null;
     presenceData.startTimestamp = lobbyStartTime;
   } else if (document.querySelector(".game-page")) {
-    if (gameStartTime == 0) {
-      gameStartTime = Math.floor(Date.now() / 1000);
-    }
+    if (gameStartTime === 0) gameStartTime = Math.floor(Date.now() / 1000);
     lobbyStartTime = 0;
 
-    const membersCount = document.querySelectorAll(".spec-list-line").length;
+    const membersCount = document.querySelectorAll(".spec-list-line").length,
+      logs = document.querySelectorAll(".actual-log");
     
     // Find last turn log from end
-    const logs = document.querySelectorAll(".actual-log");
     for (let i = logs.length; i > 0; i--) {
-      if (!logs[i]) {
-        continue;
-      }
+      if (!logs[i]) continue;
 
       const logText = logs[i].textContent.trim();
 
@@ -57,10 +51,8 @@ presence.on("UpdateData", () => {
     presenceData.details = "Loading...";
   }
 
-  if (presenceData.details == null) {
+  if (presenceData.details === null) {
     presence.setTrayTitle();
     presence.setActivity();
-  } else {
-    presence.setActivity(presenceData);
-  }
+  } else presence.setActivity(presenceData);
 });

--- a/websites/D/Dominion Online/presence.ts
+++ b/websites/D/Dominion Online/presence.ts
@@ -1,8 +1,7 @@
 const presence = new Presence({
   clientId: "849684658563055627"
-});
-
-const logRegex = /^.+ - \w+$/,
+}),
+  logRegex = /^.+ - \w+$/,
   generalStartTime = Math.floor(Date.now() / 1000);
 let lobbyStartTime: number,
   gameStartTime: number;

--- a/websites/D/Dominion Online/presence.ts
+++ b/websites/D/Dominion Online/presence.ts
@@ -18,7 +18,7 @@ presence.on("UpdateData", () => {
     gameStartTime = 0;
     
     const isHost = document.querySelector(".rules-editor") !== null || document.querySelector("button[ng-click=\"$ctrl.editTable()\"]") !== null;
-    const members = document.querySelector(".participant-list-label").textContent;
+    const members = document.querySelector(".participant-list-label").textContent.trim();
 
     presenceData.details = `In Lobby: ${members}`;
     presenceData.state = isHost ? "Host" : null;

--- a/websites/D/Dominion Online/presence.ts
+++ b/websites/D/Dominion Online/presence.ts
@@ -30,7 +30,7 @@ presence.on("UpdateData", () => {
       logs = document.querySelectorAll(".actual-log");
     
     // Find last turn log from end
-    for (let i = logs.length; i > 0; i--) {
+    for (let i = logs.length - 1; i >= 0; i--) {
       if (!logs[i]) continue;
 
       const logText = logs[i].textContent.trim();

--- a/websites/D/Dominion Online/tsconfig.json
+++ b/websites/D/Dominion Online/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/"
+  }
+}


### PR DESCRIPTION
Dominion Online => https://dominion.games/

Dominion Online, developed by Shuffle iT, is the official platform to play Dominion, the award-winning deckbuilding card game created by Donald X. Vaccarino.

This Presence provides PreMiD with the status of your Dominion Online play.

## Case 1: Main Menu

Displays as main menu before and after login.

![image](https://user-images.githubusercontent.com/7302150/120751701-7026be00-c543-11eb-8460-f7cb2b7e65f9.png)
![image](https://user-images.githubusercontent.com/7302150/120751784-93ea0400-c543-11eb-8cb6-eab80f6b2bcb.png)

## Case 2: In Lobby

Displays if you are the host of the lobby, and the number of players

![image](https://user-images.githubusercontent.com/7302150/120751954-d0b5fb00-c543-11eb-901f-7ed02a2a6178.png)

## Case 3: In Game

Displays elapsed time since start of the game, and the current turn and the player name.

![image](https://user-images.githubusercontent.com/7302150/120752122-1b377780-c544-11eb-80f8-c02ed3220f82.png)

## Case 4: In Lobby (after game)

It is the same as Case 2.

![image](https://user-images.githubusercontent.com/7302150/120752184-3904dc80-c544-11eb-9fa3-8c5939322b50.png)

## Case 5: Loading...

Displays as loading.

![image](https://user-images.githubusercontent.com/7302150/120752277-6487c700-c544-11eb-8bea-213b8d274d01.png)
