### PR TITLE
AniList | Fix "user" const having whitespaces and tabs

### DIFF
--- a/websites/A/AniList/dist/metadata.json
+++ b/websites/A/AniList/dist/metadata.json
@@ -10,10 +10,11 @@
     "zh_CN": "AniList：追踪，发现，分享动漫和漫画-免费注册！赶快加入我们！",
     "zh_TW": "AniList：追踪，發掘，分享動漫和漫畫-免費註冊！趕快加入我們！",
     "ga_IE": "AniList: Track, Discover, Share Anime & Manga - Sign up for free!",
-    "nl": "AniList: volg, ontdek, deel anime en manga - meld je gratis aan!"
+    "nl": "AniList: volg, ontdek, deel anime en manga - meld je gratis aan!",
+    "it": "AniList: Traccia, Scopri, Condividi Anime & Manga - Registrati gratuitamente!"
   },
   "url": "anilist.co",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "logo": "https://i.imgur.com/fqyhsZ5.png",
   "thumbnail": "https://i.imgur.com/ooIBlD5.jpg",
   "color": "#02A9FF",

--- a/websites/A/AniList/presence.ts
+++ b/websites/A/AniList/presence.ts
@@ -17,7 +17,7 @@ presence.on("UpdateData", async () => {
     presenceData.details = (await strings).browsing;
     presenceData.state = "Home";
   } else if (pathname.startsWith(`/user`)) {
-    const user = document.querySelector(".name").textContent;
+    const user = document.querySelector(".name").textContent.trim();
     if (pathname.includes(`mangalist`)) {
       presenceData.details = `Viewing ${user}'s manga list`;
     } else if (pathname.includes(`animelist`)) {


### PR DESCRIPTION
- Fixed a bug with the "user" constant and textContent: the string contained whitespaces and tabs written as escape characters
- Added an Italian translation for the description
- Bumped version

<details>
<summary>Old behavior</summary>

![DiscordPTB_SocJ9edHXk](https://user-images.githubusercontent.com/75082274/126907525-6689061d-88a1-4c8d-916c-28deefab4226.png)
![brave_k24qKjO1Y3](https://user-images.githubusercontent.com/75082274/126907533-7fc4091b-0622-4831-9dc9-1f4185cb5eac.png)
</details>
<details>
<summary>New behavior</summary>

![DiscordPTB_4lpVDmkEEq](https://user-images.githubusercontent.com/75082274/126907581-9cb324ab-226d-422d-ae52-d858c01cdc24.png)
![brave_MoWUQdiR1Q](https://user-images.githubusercontent.com/75082274/126907636-19d29db4-ede1-4228-941e-72a5b2506660.png)
</details>