### PR TITLE
Netflix UI update

### DIFF
--- a/websites/N/Netflix/dist/metadata.json
+++ b/websites/N/Netflix/dist/metadata.json
@@ -57,7 +57,7 @@
     "www.netflix.com",
     "netflix.com"
   ],
-  "version": "4.1.3",
+  "version": "4.2.0",
   "logo": "https://i.imgur.com/LyG9Afx.png",
   "thumbnail": "https://i.imgur.com/LWcRBZs.jpg",
   "color": "#db0000",

--- a/websites/N/Netflix/presence.ts
+++ b/websites/N/Netflix/presence.ts
@@ -89,9 +89,9 @@ presence.on("UpdateData", async () => {
       ".watch-video--player-view video"
     );
     if (video && !isNaN(video.duration)) {
-      const showCheck = document.querySelector(
-          "[data-uia$='video-title'] span"
-        )
+      const showCheck = (document.querySelector(
+        "[class$='title'] .ellipsize-text span"
+      ) || document.querySelector("[data-uia$='video-title'] span"))
           ? true
           : false,
         timestamps = presence.getTimestampsfromMedia(video);
@@ -112,38 +112,42 @@ presence.on("UpdateData", async () => {
         if (showSeries) {
           let state: string;
           if (
-            document.querySelector(
-              "[data-uia$='video-title'] span:nth-child(3)"
-            )
+            document.querySelector("[class$='title'] .ellipsize-text span:nth-child(3)")
+            ||
+            document.querySelector("[data-uia$='video-title'] span:nth-child(3)")
           ) {
             //* if the episode has a title, it's added to season and episode numbers
             state =
-              `${document.querySelector("[data-uia$='video-title'] span")
-                .textContent 
-              } ${ 
-              document.querySelector(
-                "[data-uia$='video-title'] span:nth-child(3)"
-              ).textContent}`;
+              `${(document.querySelector("[class$='title'] .ellipsize-text span")
+              ?? document.querySelector("[data-uia$='video-title'] span")).textContent
+              } ${
+              (document.querySelector("[class$='title'] .ellipsize-text span:nth-child(3)")
+              ?? document.querySelector("[data-uia$='video-title'] span:nth-child(3)")).textContent}`;
           } else {
             //* if no episode title, it proceeds with the season and episode numbers only
-            state = document.querySelector(
+            state = (document.querySelector(
+              "[class$='title'] .ellipsize-text span"
+            )
+            ?? document.querySelector(
               "[data-uia$='video-title'] span"
-            ).textContent;
+            )).textContent;
           }
 
           if (!privacy) {
             presenceData.details = seriesDetail
               .replace(
                 "%title%",
-                document.querySelector("[data-uia$='video-title'] h4")
-                  .textContent
+                (document.querySelector("[class$='title'] .ellipsize-text h4")
+                ?? document.querySelector("[data-uia$='video-title'] h4")
+                ).textContent
               )
               .replace("%episode%", state);
             presenceData.state = seriesState
               .replace(
                 "%title%",
-                document.querySelector("[data-uia$='video-title'] h4")
-                  .textContent
+                (document.querySelector("[class$='title'] .ellipsize-text h4")
+                ?? document.querySelector("[data-uia$='video-title'] h4")
+                ).textContent
               )
               .replace("%episode%", state);
             presenceData.buttons = [
@@ -170,9 +174,12 @@ presence.on("UpdateData", async () => {
         }
       } else {
         //* if not a show
-        const title = document.querySelector(
+        const title =(document.querySelector(
+          "[class$='title'] h4.ellipsize-text"
+        )
+        ?? document.querySelector(
           "[data-uia$='video-title']"
-        ).textContent;
+        )).textContent;
         if (/\(([^)]+)\)/.test(title.toLowerCase())) {
           if (showSeries && !privacy) {
             //* if is an extra, trailer, teaser or something else

--- a/websites/N/Netflix/presence.ts
+++ b/websites/N/Netflix/presence.ts
@@ -174,7 +174,7 @@ presence.on("UpdateData", async () => {
         }
       } else {
         //* if not a show
-        const title =(document.querySelector(
+        const title = (document.querySelector(
           "[class$='title'] h4.ellipsize-text"
         )
         ?? document.querySelector(

--- a/websites/N/Netflix/presence.ts
+++ b/websites/N/Netflix/presence.ts
@@ -85,13 +85,11 @@ presence.on("UpdateData", async () => {
   }
 
   if (document.location.pathname.includes("/watch")) {
-    const video: HTMLVideoElement = document.querySelector(
-      ".watch-video--player-view video"
-    );
+    const video: HTMLVideoElement = document.querySelector(".VideoContainer video")
+      ?? document.querySelector(".watch-video--player-view video");
     if (video && !isNaN(video.duration)) {
-      const showCheck = (document.querySelector(
-        "[class$='title'] .ellipsize-text span"
-      ) || document.querySelector("[data-uia$='video-title'] span"))
+      const showCheck = (document.querySelector("[class$='title'] .ellipsize-text span") 
+          || document.querySelector("[data-uia$='video-title'] span"))
           ? true
           : false,
         timestamps = presence.getTimestampsfromMedia(video);
@@ -113,8 +111,7 @@ presence.on("UpdateData", async () => {
           let state: string;
           if (
             document.querySelector("[class$='title'] .ellipsize-text span:nth-child(3)")
-            ||
-            document.querySelector("[data-uia$='video-title'] span:nth-child(3)")
+            || document.querySelector("[data-uia$='video-title'] span:nth-child(3)")
           ) {
             //* if the episode has a title, it's added to season and episode numbers
             state =
@@ -125,12 +122,8 @@ presence.on("UpdateData", async () => {
               ?? document.querySelector("[data-uia$='video-title'] span:nth-child(3)")).textContent}`;
           } else {
             //* if no episode title, it proceeds with the season and episode numbers only
-            state = (document.querySelector(
-              "[class$='title'] .ellipsize-text span"
-            )
-            ?? document.querySelector(
-              "[data-uia$='video-title'] span"
-            )).textContent;
+            state = (document.querySelector("[class$='title'] .ellipsize-text span")
+            ?? document.querySelector("[data-uia$='video-title'] span")).textContent;
           }
 
           if (!privacy) {
@@ -138,16 +131,14 @@ presence.on("UpdateData", async () => {
               .replace(
                 "%title%",
                 (document.querySelector("[class$='title'] .ellipsize-text h4")
-                ?? document.querySelector("[data-uia$='video-title'] h4")
-                ).textContent
+                ?? document.querySelector("[data-uia$='video-title'] h4")).textContent
               )
               .replace("%episode%", state);
             presenceData.state = seriesState
               .replace(
                 "%title%",
                 (document.querySelector("[class$='title'] .ellipsize-text h4")
-                ?? document.querySelector("[data-uia$='video-title'] h4")
-                ).textContent
+                ?? document.querySelector("[data-uia$='video-title'] h4")).textContent
               )
               .replace("%episode%", state);
             presenceData.buttons = [
@@ -174,12 +165,8 @@ presence.on("UpdateData", async () => {
         }
       } else {
         //* if not a show
-        const title = (document.querySelector(
-          "[class$='title'] h4.ellipsize-text"
-        )
-        ?? document.querySelector(
-          "[data-uia$='video-title']"
-        )).textContent;
+        const title = (document.querySelector("[class$='title'] h4.ellipsize-text")
+        ?? document.querySelector("[data-uia$='video-title']")).textContent;
         if (/\(([^)]+)\)/.test(title.toLowerCase())) {
           if (showSeries && !privacy) {
             //* if is an extra, trailer, teaser or something else

--- a/websites/N/Netflix/presence.ts
+++ b/websites/N/Netflix/presence.ts
@@ -86,11 +86,11 @@ presence.on("UpdateData", async () => {
 
   if (document.location.pathname.includes("/watch")) {
     const video: HTMLVideoElement = document.querySelector(
-      ".VideoContainer video"
+      ".watch-video--player-view video"
     );
     if (video && !isNaN(video.duration)) {
       const showCheck = document.querySelector(
-          "[class$='title'] .ellipsize-text span"
+          "[data-uia$='video-title'] span"
         )
           ? true
           : false,
@@ -113,21 +113,21 @@ presence.on("UpdateData", async () => {
           let state: string;
           if (
             document.querySelector(
-              "[class$='title'] .ellipsize-text span:nth-child(3)"
+              "[data-uia$='video-title'] span:nth-child(3)"
             )
           ) {
             //* if the episode has a title, it's added to season and episode numbers
             state =
-              document.querySelector("[class$='title'] .ellipsize-text span")
+              document.querySelector("[data-uia$='video-title'] span")
                 .textContent +
               " " +
               document.querySelector(
-                "[class$='title'] .ellipsize-text span:nth-child(3)"
+                "[data-uia$='video-title'] span:nth-child(3)"
               ).textContent;
           } else {
             //* if no episode title, it proceeds with the season and episode numbers only
             state = document.querySelector(
-              "[class$='title'] .ellipsize-text span"
+              "[data-uia$='video-title'] span"
             ).textContent;
           }
 
@@ -135,14 +135,14 @@ presence.on("UpdateData", async () => {
             presenceData.details = seriesDetail
               .replace(
                 "%title%",
-                document.querySelector("[class$='title'] .ellipsize-text h4")
+                document.querySelector("[data-uia$='video-title'] h4")
                   .textContent
               )
               .replace("%episode%", state);
             presenceData.state = seriesState
               .replace(
                 "%title%",
-                document.querySelector("[class$='title'] .ellipsize-text h4")
+                document.querySelector("[data-uia$='video-title'] h4")
                   .textContent
               )
               .replace("%episode%", state);
@@ -171,7 +171,7 @@ presence.on("UpdateData", async () => {
       } else {
         //* if not a show
         const title = document.querySelector(
-          "[class$='title'] h4.ellipsize-text"
+          "[data-uia$='video-title']"
         ).textContent;
         if (/\(([^)]+)\)/.test(title.toLowerCase())) {
           if (showSeries && !privacy) {

--- a/websites/N/Netflix/presence.ts
+++ b/websites/N/Netflix/presence.ts
@@ -77,9 +77,9 @@ presence.on("UpdateData", async () => {
     browsingStamp = Math.floor(Date.now() / 1000);
   }
 
-  if (!oldLang) {
+  if (!oldLang) 
     oldLang = newLang;
-  } else if (oldLang !== newLang) {
+   else if (oldLang !== newLang) {
     oldLang = newLang;
     strings = getStrings();
   }
@@ -118,12 +118,12 @@ presence.on("UpdateData", async () => {
           ) {
             //* if the episode has a title, it's added to season and episode numbers
             state =
-              document.querySelector("[data-uia$='video-title'] span")
-                .textContent +
-              " " +
+              `${document.querySelector("[data-uia$='video-title'] span")
+                .textContent 
+              } ${ 
               document.querySelector(
                 "[data-uia$='video-title'] span:nth-child(3)"
-              ).textContent;
+              ).textContent}`;
           } else {
             //* if no episode title, it proceeds with the season and episode numbers only
             state = document.querySelector(
@@ -159,9 +159,9 @@ presence.on("UpdateData", async () => {
               }
             ];
             if (seriesState.includes("{0}")) delete presenceData.state;
-          } else {
+          } else 
             presenceData.details = (await strings).watchingSeries;
-          }
+          
         } else if (showBrowsing) {
           presenceData.details = (await strings).browse;
           delete presenceData.endTimestamp;
@@ -184,17 +184,17 @@ presence.on("UpdateData", async () => {
               .replace("%title%", title.replace(regExp[0], ""))
               .replace("%episode%", regExp[1]);
             if (seriesState.includes("{0}")) delete presenceData.state;
-          } else if (showSeries) {
+          } else if (showSeries) 
             presenceData.details = (await strings).watchingSeries;
-          } else if (showBrowsing) {
+           else if (showBrowsing) 
             presenceData.details = (await strings).browse;
-          }
+          
         } else if (showMovie && !privacy) {
           if (!(movieDetail === "{0}" && movieState === "{0}")) {
             //* if it's a movie
-            if (movieDetail === "{0}") {
+            if (movieDetail === "{0}") 
               presenceData.details = movieState.replace("%title%", title);
-            } else {
+             else {
               presenceData.details = movieDetail.replace("%title%", title);
               if (movieState !== "{0}")
                 presenceData.state = movieState.replace("%title%", title);
@@ -207,9 +207,9 @@ presence.on("UpdateData", async () => {
               url: document.URL.split("?")[0]
             }
           ];
-        } else if (showMovie) {
+        } else if (showMovie) 
           presenceData.details = (await strings).watchingMovie;
-        } else if (showBrowsing) {
+         else if (showBrowsing) {
           presenceData.details = (await strings).browse;
           delete presenceData.endTimestamp;
           presenceData.startTimestamp = browsingStamp;
@@ -218,28 +218,28 @@ presence.on("UpdateData", async () => {
       }
 
       if (presenceData.details.length < 3)
-        presenceData.details = " " + presenceData.details;
+        presenceData.details = ` ${presenceData.details}`;
 
       if (!showTimestamp) {
         delete presenceData.startTimestamp;
         delete presenceData.endTimestamp;
       }
 
-      if (!showButtons) {
+      if (!showButtons) 
         delete presenceData.buttons;
-      }
+      
 
       if (presenceData.details == null) {
         presence.setActivity();
         presence.setTrayTitle();
-      } else {
+      } else 
         presence.setActivity(presenceData, !video.paused);
-      }
+      
     }
   } else {
     const path = location.href
         .replace(/\/?$/, "/")
-        .replace("https://" + document.location.hostname, "")
+        .replace(`https://${document.location.hostname}`, "")
         .replace("?", "/")
         .replace("=", "/"),
       statics: {
@@ -343,9 +343,9 @@ presence.on("UpdateData", async () => {
       }
     }
 
-    if (showTimestamp) {
+    if (showTimestamp) 
       presenceData.startTimestamp = browsingStamp;
-    }
+    
 
     if (privacy && presenceData.smallImageKey === "search") {
       presenceData.details = (await strings).searchSomething;
@@ -355,15 +355,15 @@ presence.on("UpdateData", async () => {
       delete presenceData.state;
     }
 
-    if (!showButtons || privacy) {
+    if (!showButtons || privacy) 
       delete presenceData.buttons;
-    }
+    
 
     if (!showBrowsing) {
       presence.setActivity();
       presence.setTrayTitle();
-    } else {
+    } else 
       presence.setActivity(presenceData);
-    }
+    
   }
 });


### PR DESCRIPTION
# Fixes: #4228 

Netflix Presence v4.2.0

Change querySelector to find HTML by `data-uid` instead of class. 
Fix applies to users with the new Netflix Web UI.

(Somewhat lazily) Tested on

Device:
- macOS Big Sur 11.5.2

Browsers: 
- Chrome
- Firefox
- Safari

Netflix Web UI Version: `10.15.7`


# Proof

## Before
<img width="1680" alt="Screen Shot 2021-08-19 at 6 04 03 AM" src="https://user-images.githubusercontent.com/30040440/130059127-bacfa66f-c059-4adf-a408-fdff36b7a96a.png">


## After
<img width="1680" alt="Screen Shot 2021-08-19 at 6 09 35 AM" src="https://user-images.githubusercontent.com/30040440/130059203-831f1833-b82c-4902-9ed3-f9296b237113.png">
<img width="1680" alt="Screen Shot 2021-08-19 at 6 13 15 AM" src="https://user-images.githubusercontent.com/30040440/130059333-ccab2394-8ccb-4750-8003-d42e66bdd6f8.png">


 