### PR TITLE
`getLevelInHeader` function fix, spelling corrections, added JP description translation.

### DIFF
--- a/websites/B/Bunpro/dist/metadata.json
+++ b/websites/B/Bunpro/dist/metadata.json
@@ -8,7 +8,7 @@
   "category": "other",
   "logo": "https://i.imgur.com/NkfEDwV.png",
   "thumbnail": "https://i.imgur.com/uKMafFN.png",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "color": "#5e6266",
   "tags": [
     "education",

--- a/websites/B/Bunpro/dist/metadata.json
+++ b/websites/B/Bunpro/dist/metadata.json
@@ -27,6 +27,7 @@
   "description": {
     "en": "Bunpro is a japanese grammar learning application.",
     "fr": "Bunpro est une application d'apprentissage de la grammaire japonaise.",
-    "nl": "Bunpro is een japanse grammatica leer applicatie."
+    "nl": "Bunpro is een japanse grammatica leer applicatie.",
+    "jp": "Bunproは日本語の文法学ぶアプリ"
   }
 }

--- a/websites/B/Bunpro/dist/metadata.json
+++ b/websites/B/Bunpro/dist/metadata.json
@@ -28,6 +28,6 @@
     "en": "Bunpro is a japanese grammar learning application.",
     "fr": "Bunpro est une application d'apprentissage de la grammaire japonaise.",
     "nl": "Bunpro is een japanse grammatica leer applicatie.",
-    "jp": "Bunproは日本語の文法学ぶアプリ"
+    "ja_JP": "Bunproは日本語の文法学ぶアプリ"
   }
 }

--- a/websites/B/Bunpro/presence.ts
+++ b/websites/B/Bunpro/presence.ts
@@ -21,6 +21,8 @@ function getLevelInHeader() {
   const levelElement: HTMLDivElement =
     document.querySelector(".navbar-user-level");
 
+  if (!levelElement) return null;
+
   return +levelElement.innerText.slice(6);
 }
 
@@ -87,13 +89,13 @@ presence.on("UpdateData", () => {
       case "/learn": {
         startTimestamp = Date.now();
 
-        const checkQuizzElement: HTMLDivElement = document.querySelector(
+        const checkQuizElement: HTMLDivElement = document.querySelector(
             "#learn-new-grammar-page"
           ),
-          isOnQuizz = checkQuizzElement.style.display === "block";
+          isOnQuiz = checkQuizElement.style.display === "block";
 
-        if (isOnQuizz) {
-          details = "Learning New Grammar (Quizz)";
+        if (isOnQuiz) {
+          details = "Learning New Grammar (Quiz)";
 
           const grammarPointElement: HTMLDivElement = document.querySelector(
               ".study-question-english-hint"


### PR DESCRIPTION
The bunpro.jp site had recent UI updates, and removed the `.navbar-user-level` class name. Which means the `getLevelInHeader()` function always throws an error, and prevents the Presence from continuing on with the `UpdateData` event.

As a quick fix, I have just added a null-check in the function (now it'll always return null, unless the `.navbar-user-level` class is ever re-added); however, I can't see the user's level reflected on every page, only their current XP and am not familiar with the XP->Level formula.

The current XP is just obtained with: `document.querySelector('.xp-current').innerText`