### PR TITLE
fix(GitHub Codespaces): small fixes

### DIFF
--- a/websites/G/GitHub Codespaces/dist/metadata.json
+++ b/websites/G/GitHub Codespaces/dist/metadata.json
@@ -11,7 +11,7 @@
     "nl": "Draag bij aan projecten zonder uw lokale installatie ingewikkelder te maken. Zet met één klik een ontwikkelomgeving op, zelfs voor projecten waar u nog niet eerder aan hebt gewerkt, en schakel er gemakkelijk tussen."
   },
   "service": "GitHub Codespaces",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "logo": "https://i.imgur.com/JWaYQC8.png",
   "thumbnail": "https://i.imgur.com/fLQ6JLS.png",
   "color": "#000000",

--- a/websites/G/GitHub Codespaces/presence.ts
+++ b/websites/G/GitHub Codespaces/presence.ts
@@ -584,11 +584,13 @@ presence.on("UpdateData", async () => {
     data.details = "Preparing a codespace...";
     delete data.smallImageKey;
 
-    if (document.querySelector(".vso-button"))
+    if (document.querySelector(".vso-splash-screen__button"))
       data.details = "Inactive Codespace";
     // Idle/Start Screen
   } else if (activeTab && editorMode) {
-    const scmTab = document.querySelector("h3.title"),
+    const scmTabs = Array.from(document.querySelectorAll("#status\\.scm")).reverse(),
+      scmTab = scmTabs.find(scmTab => scmTab && scmTab.hasAttribute("aria-label")),
+      workspace = scmTab ? scmTab.getAttribute("aria-label").split("(Git)")[0] : null,
       filename = activeTab.getAttribute("data-resource-name"),
       filepath = activeTab.getAttribute("title"),
       syntaxMode = editorMode.getAttribute("aria-label").toLowerCase(),
@@ -620,15 +622,11 @@ presence.on("UpdateData", async () => {
       )
       .replace(
         /%workspace%/g,
-        scmTab && scmTab.hasAttribute("title")
-          ? scmTab.getAttribute("title").split(" (Git)")[0]
-          : "N/A"
+        workspace || "N/A"
       )
       .replace(
         /%workspaceOrFolder%/g,
-        scmTab && scmTab.hasAttribute("title")
-          ? scmTab.getAttribute("title").split(" (Git)")[0]
-          : filepath.split("/").reverse()[1]
+        workspace || filepath.split("/").reverse()[1]
       );
     data.state = (await presence.getSetting("state"))
       .replace(/%file%/g, filename)
@@ -640,15 +638,11 @@ presence.on("UpdateData", async () => {
       )
       .replace(
         /%workspace%/g,
-        scmTab && scmTab.hasAttribute("title")
-          ? scmTab.getAttribute("title").split(" (Git)")[0]
-          : "N/A"
+        workspace || "N/A"
       )
       .replace(
         /%workspaceOrFolder%/g,
-        scmTab && scmTab.hasAttribute("title")
-          ? scmTab.getAttribute("title").split(" (Git)")[0]
-          : filepath.split("/").reverse()[1]
+        workspace || filepath.split("/").reverse()[1]
       );
   } else if (!editorMode) {
     data.largeImageKey = "idle";


### PR DESCRIPTION
This PR fixes some things:
- Workspace titles being incorrect (blaming #4276), goes back to using SCM tabs and using the `aria-label` attribute instead.
- Fixed selectors for preparing/inactive presences

![](https://get.snaz.in/5JSdxDo.png)