### PR TITLE
Disney+: add space between episode number and title for Hotstar

### DIFF
--- a/websites/D/Disney+/dist/metadata.json
+++ b/websites/D/Disney+/dist/metadata.json
@@ -21,7 +21,7 @@
   },
   "url": "www.disneyplus.com",
   "regExp": "([a-z0-9-]+[.])*disneyplus[.]com[/]|([a-z0-9-]+[.])*hotstar[.]com[/]",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "logo": "https://i.imgur.com/zuUeb2A.png",
   "thumbnail": "https://i.imgur.com/Tp9oYPj.png",
   "color": "#233778",

--- a/websites/D/Disney+/presence.ts
+++ b/websites/D/Disney+/presence.ts
@@ -52,11 +52,11 @@ presence.on("UpdateData", async () => {
     strings = await getStrings();
   }
 
-  if (isHostDP) {
+  if (isHostDP) 
     data.largeImageKey = "disneyplus-logo";
-  } else if (isHostHS) {
+   else if (isHostHS) 
     data.largeImageKey = "disneyplus-hotstar-logo";
-  }
+  
 
   // Disney+ video
   if (isHostDP && location.pathname.includes("/video/")) {
@@ -92,11 +92,11 @@ presence.on("UpdateData", async () => {
         data.details = `${title} ${subtitle ? `- ${subtitle}` : ""}`;
         data.state = "In a GroupWatch";
       } else {
-        if (privacy)
-          data.state = subtitle
+        if (privacy) {
+data.state = subtitle
             ? strings.watchingSeries
             : strings.watchingMovie;
-        else {
+} else {
           data.details = title;
           data.state = subtitle || "Movie";
         }

--- a/websites/D/Disney+/presence.ts
+++ b/websites/D/Disney+/presence.ts
@@ -85,8 +85,8 @@ presence.on("UpdateData", async () => {
           ".btm-media-overlays-container .subtitle-field"
         );
 
-      title = titleField?.textContent;
-      subtitle = subtitleField?.textContent; // episode or empty if it's a movie
+      title = titleField?.innerText;
+      subtitle = subtitleField?.innerText; // episode or empty if it's a movie
 
       if (!privacy && groupWatchId) {
         data.details = `${title} ${subtitle ? `- ${subtitle}` : ""}`;
@@ -156,8 +156,8 @@ presence.on("UpdateData", async () => {
     `);
 
     if (seriesFields.length > 0) {
-      title = seriesFields[0]?.textContent;
-      subtitle = seriesFields[1]?.textContent;
+      title = seriesFields[0]?.innerText;
+      subtitle = seriesFields[1]?.innerText;
     } else {
       const movieField: HTMLImageElement = document.querySelector(
         "#webAppScene main #group + div:not([id]) img[alt]"
@@ -197,8 +197,8 @@ presence.on("UpdateData", async () => {
           ".controls-overlay .show-title"
         );
 
-      title = titleField?.textContent;
-      subtitle = subtitleField?.textContent; // episode or empty if it's a movie
+      title = titleField?.innerText;
+      subtitle = subtitleField?.innerText; // episode or empty if it's a movie
 
       if (privacy)
         data.state = subtitle ? strings.watchingSeries : strings.watchingMovie;

--- a/websites/D/Disney+/presence.ts
+++ b/websites/D/Disney+/presence.ts
@@ -52,11 +52,11 @@ presence.on("UpdateData", async () => {
     strings = await getStrings();
   }
 
-  if (isHostDP) 
+  if (isHostDP)
     data.largeImageKey = "disneyplus-logo";
-   else if (isHostHS) 
+   else if (isHostHS)
     data.largeImageKey = "disneyplus-hotstar-logo";
-  
+
 
   // Disney+ video
   if (isHostDP && location.pathname.includes("/video/")) {
@@ -68,7 +68,7 @@ presence.on("UpdateData", async () => {
       const groupWatchId = new URLSearchParams(location.search).get(
           "groupWatchId"
         ),
-        timestamps: number[] = presence.getTimestampsfromMedia(video);
+        [startTimestamp, endTimestamp] = presence.getTimestampsfromMedia(video);
 
       if (!privacy && groupWatchId) {
         groupWatchCount = Number(
@@ -93,10 +93,10 @@ presence.on("UpdateData", async () => {
         data.state = "In a GroupWatch";
       } else {
         if (privacy) {
-data.state = subtitle
+          data.state = subtitle
             ? strings.watchingSeries
             : strings.watchingMovie;
-} else {
+        } else {
           data.details = title;
           data.state = subtitle || "Movie";
         }
@@ -104,8 +104,8 @@ data.state = subtitle
 
       data.smallImageKey = video.paused ? "pause" : "play";
       data.smallImageText = video.paused ? strings.pause : strings.play;
-      data.startTimestamp = timestamps[0];
-      data.endTimestamp = timestamps[1];
+      data.startTimestamp = startTimestamp;
+      data.endTimestamp = endTimestamp;
 
       // remove timestamps if video is paused or user disabled timestamps
       if (video.paused || !time) {
@@ -189,7 +189,7 @@ data.state = subtitle
       document.querySelector(".player-base video");
 
     if (video && !isNaN(video.duration)) {
-      const timestamps: number[] = presence.getTimestampsfromMedia(video),
+      const [startTimestamp, endTimestamp] = presence.getTimestampsfromMedia(video),
         titleField: HTMLDivElement = document.querySelector(
           ".controls-overlay .primary-title"
         ),
@@ -208,8 +208,8 @@ data.state = subtitle
       }
       data.smallImageKey = video.paused ? "pause" : "play";
       data.smallImageText = video.paused ? strings.pause : strings.play;
-      data.startTimestamp = timestamps[0];
-      data.endTimestamp = timestamps[1];
+      data.startTimestamp = startTimestamp;
+      data.endTimestamp = endTimestamp;
 
       if (video.paused || !time) {
         delete data.startTimestamp;


### PR DESCRIPTION
Fixes a bug where there wouldn't be a space between the episode number and title on Disney+ Hotstar.