### PR TITLE
Scratch: Metadata images moved to Imgur

### DIFF
--- a/websites/S/Scratch/dist/metadata.json
+++ b/websites/S/Scratch/dist/metadata.json
@@ -10,8 +10,8 @@
   },
   "url": "scratch.mit.edu",
   "version": "1.2.5",
-  "logo": "http://i.cubeupload.com/vHaa4W.png",
-  "thumbnail": "https://downbeat.is-inside.me/iLWNLsjM.png",
+  "logo": "https://i.imgur.com/8ENJO3c.png",
+  "thumbnail": "https://i.imgur.com/WREKZyg.png",
   "color": "#fc8c03",
   "tags": [
     "creations",

--- a/websites/S/Scratch/dist/metadata.json
+++ b/websites/S/Scratch/dist/metadata.json
@@ -9,7 +9,7 @@
     "nl": "Scratch is een visuele programmeertaal op basis van blokken en een online gemeenschap die vooral op kinderen is gericht. Gebruikers van de site kunnen online projecten creëren met behulp van een blokachtige interface. De dienst is ontwikkeld door het MIT Media Lab, is vertaald in meer dan 70 talen, en wordt gebruikt in de meeste delen van de wereld."
   },
   "url": "scratch.mit.edu",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "logo": "https://i.imgur.com/8ENJO3c.png",
   "thumbnail": "https://i.imgur.com/WREKZyg.png",
   "color": "#fc8c03",


### PR DESCRIPTION
Presence for Scratch has its logo hosted on cubeupload.com. This link is not working for me as proven below (page is returning 500):
![scratch_logo_server_500](https://user-images.githubusercontent.com/53856821/137190638-2aaa4a56-06fd-48ba-a9bc-052551ac8252.png)
For that reason I uploaded that logo (which I've found on [Wayback Machine](http://web.archive.org/web/20210303221403/https://i.cubeupload.com/vHaa4W.png)) to Imgur and changed the metadata. I decided to do the same for thumbnail, even though that link was working.