### PR TITLE
Star+ presence

### DIFF
--- a/websites/S/Star+/dist/metadata.json
+++ b/websites/S/Star+/dist/metadata.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.3",
+  "author": {
+    "name": "Tiemen",
+    "id": "152164749868662784"
+  },
+  "contributors": [
+    {
+      "name": "ReivaJ",
+      "id": "343921797781258242"
+    }
+  ],
+  "service": "Star+",
+  "description": {
+    "en": "Star features television and film content intended for mature audiences, in contrast to the family- and franchise-oriented programming featured elsewhere in Disney+. This content is primarily drawn from the libraries of Disney subsidiaries, including FX, Freeform, Hulu, ABC Signature, 20th Television, 20th Television Animation, 20th Century Studios, Searchlight Pictures, Touchstone Pictures and Hollywood Pictures.",
+    "nl": "Star biedt televisie- en filmcontent die bedoeld is voor een volwassen publiek, in tegenstelling tot de familie- en franchisegerichte programmering die elders in Disney+ te zien is. Deze inhoud is voornamelijk afkomstig uit de bibliotheken van Disney-dochterondernemingen, waaronder FX, Freeform, Hulu, ABC Signature, 20th Television, 20th Television Animation, 20th Century Studios, Searchlight Pictures, Touchstone Pictures en Hollywood Pictures.",
+    "fr": "Star propose du contenu télévisuel et cinématographique destiné à un public adulte, contrairement à la programmation axée sur la famille et la franchise présentée ailleurs dans Disney +. Ce contenu provient principalement des bibliothèques des filiales de Disney, notamment FX, Freeform, Hulu, ABC Signature, 20th Television, 20th Television Animation, 20th Century Studios, Searchlight Pictures, Touchstone Pictures et Hollywood Pictures.",
+    "de": "Star bietet Fernseh- und Filminhalte, die für ein erwachsenes Publikum bestimmt sind, im Gegensatz zu den familien- und Franchise-orientierten Programmen, die anderswo in Disney+ gezeigt werden. Diese Inhalte stammen hauptsächlich aus den Bibliotheken von Disney-Tochtergesellschaften, darunter FX, Freeform, Hulu, ABC Signature, 20th Television, 20th Television Animation, 20th Century Studios, Searchlight Pictures, Touchstone Pictures und Hollywood Pictures.",
+    "it": "Star presenta contenuti televisivi e cinematografici destinati a un pubblico maturo, in contrasto con la programmazione orientata alla famiglia e al franchising presente altrove in Disney+. Questo contenuto è tratto principalmente dalle librerie delle filiali Disney, tra cui FX, Freeform, Hulu, ABC Signature, 20th Television, 20th Television Animation, 20th Century Studios, Searchlight Pictures, Touchstone Pictures e Hollywood Pictures.",
+    "es": "Star presenta contenido de televisión y películas destinado a audiencias maduras, en contraste con la programación orientada a la familia y la franquicia que se presenta en otras partes de Disney +. Este contenido se extrae principalmente de las bibliotecas de las subsidiarias de Disney, incluidas FX, Freeform, Hulu, ABC Signature, 20th Television, 20th Television Animation, 20th Century Studios, Searchlight Pictures, Touchstone Pictures y Hollywood Pictures.",
+    "pt": "Star apresenta conteúdo de televisão e filme voltado para o público adulto, em contraste com a programação voltada para a família e franquia apresentada em outros lugares da Disney +. Este conteúdo é obtido principalmente de bibliotecas de subsidiárias da Disney, incluindo FX, Freeform, Hulu, ABC Signature, 20th Television, 20th Television Animation, 20th Century Studios, Searchlight Pictures, Touchstone Pictures e Hollywood Pictures.",
+    "no": "Star inneholder TV- og filminnhold beregnet på et modent publikum, i motsetning til den familie- og franchiseorienterte programmeringen som er omtalt andre steder i Disney+. Dette innholdet er først og fremst hentet fra bibliotekene til Disney -datterselskaper, inkludert FX, Freeform, Hulu, ABC Signature, 20th Television, 20th Television Animation, 20th Century Studios, Searchlight Pictures, Touchstone Pictures og Hollywood Pictures.",
+    "fi": "Star sisältää televisio- ja elokuvasisältöä, joka on tarkoitettu aikuisille, toisin kuin perhe- ja franchising-suuntautunut ohjelmointi, jota esitetään muualla Disney+: ssa. Tämä sisältö on peräisin pääasiassa Disneyn tytäryhtiöiden kirjastoista, kuten FX, Freeform, Hulu, ABC Signature, 20th Television, 20th Television Animation, 20th Century Studios, Searchlight Pictures, Touchstone Pictures ja Hollywood Pictures.",
+    "sv_SE": "Star innehåller tv- och filminnehåll avsett för mogen publik, i motsats till den familj- och franchiseinriktade programmeringen som finns på andra håll i Disney+. Detta innehåll hämtas främst från biblioteken i Disneys dotterbolag, inklusive FX, Freeform, Hulu, ABC Signature, 20th Television, 20th Television Animation, 20th Century Studios, Searchlight Pictures, Touchstone Pictures och Hollywood Pictures."
+  },
+  "url": "www.starplus.com",
+  "regExp": "([a-z0-9-]+[.])*starplus[.]com[/]",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/egrBdbu.png",
+  "thumbnail": "https://i.imgur.com/w6TdhJd.png",
+  "color": "#271f44",
+  "tags": [
+    "star",
+    "star-plus",
+    "fox",
+    "marvel",
+    "freeform",
+    "video",
+    "media",
+    "streaming",
+    "streaming-service",
+    "hulu",
+    "fx",
+    "touchstone",
+    "20th-century",
+    "abc-signature"
+  ],
+  "category": "videos",
+  "settings": [
+    {
+      "id": "lang",
+      "multiLanguage": true
+    },
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "icon": "fad fa-user-secret",
+      "value": false
+    },
+    {
+      "id": "time",
+      "title": "Show Timestamps",
+      "icon": "fad fa-stopwatch",
+      "value": true
+    },
+    {
+      "id": "buttons",
+      "if": {
+        "privacy": false
+      },
+      "title": "Show Buttons",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true
+    },
+    {
+      "id": "groupWatchBtn",
+      "if": {
+        "buttons": true,
+        "privacy": false
+      },
+      "title": "Join GroupWatch Button",
+      "icon": "fas fa-users",
+      "value": false
+    }
+  ]
+}

--- a/websites/S/Star+/presence.ts
+++ b/websites/S/Star+/presence.ts
@@ -107,8 +107,7 @@ presence.on("UpdateData", async () => {
 
       data.smallImageKey = video.paused ? "pause" : "play";
       data.smallImageText = video.paused ? strings.pause : strings.play;
-      data.startTimestamp = timestamps[0];
-      data.endTimestamp = timestamps[1];
+      [data.startTimestamp, data.endTimestamp] = timestamps;
 
       // remove timestamps if video is paused or user disabled timestamps
       if (video.paused || !time) {

--- a/websites/S/Star+/presence.ts
+++ b/websites/S/Star+/presence.ts
@@ -57,9 +57,9 @@ presence.on("UpdateData", async () => {
     strings = await getStrings();
   }
 
-  if (isHostSP) {
+  if (isHostSP)
     data.largeImageKey = "starplus-logo";
-  }
+  
 
   // Star+ videos
   if (isHostSP && location.pathname.includes("/video/")) {
@@ -82,8 +82,8 @@ presence.on("UpdateData", async () => {
       }
 
       const titleField: HTMLDivElement = document.querySelector(
-          ".btm-media-overlays-container .title-field"
-        ),
+        ".btm-media-overlays-container .title-field"
+      ),
         subtitleField: HTMLDivElement = document.querySelector(
           ".btm-media-overlays-container .subtitle-field"
         );
@@ -95,11 +95,11 @@ presence.on("UpdateData", async () => {
         data.details = `${title} ${subtitle ? `- ${subtitle}` : ""}`;
         data.state = "In a GroupWatch";
       } else {
-        if (privacy)
+        if (privacy) {
           data.state = subtitle
             ? strings.watchingSeries
             : strings.watchingMovie;
-        else {
+        } else {
           data.details = title;
           data.state = subtitle || "Movie";
         }
@@ -145,44 +145,43 @@ presence.on("UpdateData", async () => {
 
   //Star+ Livestreams
   } else if (isHostSP && location.pathname.includes("/live-event/")) {
-      const video: HTMLVideoElement = document.querySelector(
-        ".btm-media-clients video"
-      );
+    const video: HTMLVideoElement = document.querySelector(
+      ".btm-media-clients video"
+    );
   
-      if (video && !isNaN(video.duration)) {
-  
-        const titleField: HTMLDivElement = document.querySelector(
-            ".btm-media-overlays-container .title-field"
-          ),
-          subtitleField: HTMLDivElement = document.querySelector(
-            ".btm-media-overlays-container .subtitle-field"
-          );
-  
-        title = titleField?.textContent;
-        subtitle = subtitleField?.textContent; // episode or empty if it's a movie
-  
-        if (!privacy) {
-          data.details = `${title} ${subtitle ? `- ${subtitle}` : ""}`;
-          data.state = strings.watchLive;
-        } else {
-          if (privacy)
-            data.state = strings.watchingLive
-        }
-  
-        data.smallImageKey = video.paused ? "pause" : "play";
-        data.smallImageText = video.paused ? strings.pause : strings.play;
-  
-        // add buttons, if enabled
-        if (!privacy && buttons) {
-          data.buttons = [
-            {
-              label: strings.watchStream,
-              url: `https://www.starplus.com${location.pathname}`
-            }
-          ];
-        }
-        if (title) presence.setActivity(data, !video.paused);
+    if (video && !isNaN(video.duration)) {
+      const titleField: HTMLDivElement = document.querySelector(
+          ".btm-media-overlays-container .title-field"
+        ),
+        subtitleField: HTMLDivElement = document.querySelector(
+          ".btm-media-overlays-container .subtitle-field"
+        );
+
+      title = titleField?.textContent;
+      subtitle = subtitleField?.textContent; // episode or empty if it's a movie
+
+      if (!privacy) {
+        data.details = `${title} ${subtitle ? `- ${subtitle}` : ""}`;
+        data.state = strings.watchLive;
+      } else {
+        if (privacy)
+          data.state = strings.watchingLive;
       }
+  
+      data.smallImageKey = video.paused ? "pause" : "play";
+      data.smallImageText = video.paused ? strings.pause : strings.play;
+  
+      // add buttons, if enabled
+      if (!privacy && buttons) {
+        data.buttons = [
+          {
+            label: strings.watchStream,
+            url: `https://www.starplus.com${location.pathname}`
+          }
+        ];
+      }
+      if (title) presence.setActivity(data, !video.paused);
+    }
 
   // GroupWatch lobby
   } else if (

--- a/websites/S/Star+/presence.ts
+++ b/websites/S/Star+/presence.ts
@@ -1,0 +1,235 @@
+const presence: Presence = new Presence({
+  clientId: "897325334200975360"
+});
+
+interface LangStrings {
+  play: string;
+  pause: string;
+  browsing: string;
+  watchingMovie: string;
+  watchingSeries: string;
+  watchingLive: string;
+  watchEpisode: string;
+  watchVideo: string;
+  watchLive: string;
+  watchStream: string
+}
+
+async function getStrings(): Promise<LangStrings> {
+  return presence.getStrings(
+    {
+      play: "general.playing",
+      pause: "general.paused",
+      browsing: "general.browsing",
+      watchingMovie: "general.watchingMovie",
+      watchingSeries: "general.watchingSeries",
+      watchingLive: "general.watchingLive",
+      watchEpisode: "general.buttonViewEpisode",
+      watchVideo: "general.buttonWatchVideo",
+      watchLive: "general.live",
+      watchStream: "general.buttonWatchStream"
+    },
+    await presence.getSetting("lang").catch(() => "en")
+  );
+}
+
+let strings: LangStrings,
+  oldLang: string,
+  title: string,
+  subtitle: string,
+  groupWatchCount: number;
+
+presence.on("UpdateData", async () => {
+  const newLang: string = await presence.getSetting("lang").catch(() => "en"),
+    privacy: boolean = await presence.getSetting("privacy"),
+    time: boolean = await presence.getSetting("time"),
+    buttons: boolean = await presence.getSetting("buttons"),
+    groupWatchBtn: boolean = await presence.getSetting("groupWatchBtn"),
+    isHostSP = /(www\.)?starplus\.com/.test(location.hostname),
+    data: PresenceData & {
+      partySize?: number;
+      partyMax?: number;
+    } = {};
+
+  // Update strings when user sets language
+  if (!oldLang || oldLang !== newLang) {
+    oldLang = newLang;
+    strings = await getStrings();
+  }
+
+  if (isHostSP) {
+    data.largeImageKey = "starplus-logo";
+  }
+
+  // Star+ videos
+  if (isHostSP && location.pathname.includes("/video/")) {
+    const video: HTMLVideoElement = document.querySelector(
+      ".btm-media-clients video"
+    );
+
+    if (video && !isNaN(video.duration)) {
+      const groupWatchId = new URLSearchParams(location.search).get(
+          "groupWatchId"
+        ),
+        timestamps: number[] = presence.getTimestampsfromMedia(video);
+
+      if (!privacy && groupWatchId) {
+        groupWatchCount = Number(
+          document.querySelector(
+            ".btm-media-overlays-container .group-profiles-control .group-profiles-control__count"
+          )?.textContent
+        );
+      }
+
+      const titleField: HTMLDivElement = document.querySelector(
+          ".btm-media-overlays-container .title-field"
+        ),
+        subtitleField: HTMLDivElement = document.querySelector(
+          ".btm-media-overlays-container .subtitle-field"
+        );
+
+      title = titleField?.textContent;
+      subtitle = subtitleField?.textContent; // episode or empty if it's a movie
+
+      if (!privacy && groupWatchId) {
+        data.details = `${title} ${subtitle ? `- ${subtitle}` : ""}`;
+        data.state = "In a GroupWatch";
+      } else {
+        if (privacy)
+          data.state = subtitle
+            ? strings.watchingSeries
+            : strings.watchingMovie;
+        else {
+          data.details = title;
+          data.state = subtitle || "Movie";
+        }
+      }
+
+      data.smallImageKey = video.paused ? "pause" : "play";
+      data.smallImageText = video.paused ? strings.pause : strings.play;
+      data.startTimestamp = timestamps[0];
+      data.endTimestamp = timestamps[1];
+
+      // remove timestamps if video is paused or user disabled timestamps
+      if (video.paused || !time) {
+        delete data.startTimestamp;
+        delete data.endTimestamp;
+      }
+
+      // set GroupWatch participants size
+      if (!privacy && groupWatchId) {
+        data.partySize = groupWatchCount;
+        data.partyMax = 7;
+      }
+
+      // add buttons, if enabled
+      if (!privacy && buttons) {
+        data.buttons = [
+          {
+            label: subtitle ? strings.watchEpisode : strings.watchVideo,
+            url: `https://www.starplus.com${location.pathname}`
+          }
+        ];
+
+        // change button if GroupWatch is active and user enabled the button
+        if (groupWatchId && groupWatchBtn) {
+          data.buttons.push({
+            label: "Join GroupWatch",
+            url: `https://www.starplus.com/groupwatch/${groupWatchId}`
+          });
+        }
+      }
+
+      if (title) presence.setActivity(data, !video.paused);
+    }
+
+  //Star+ Livestreams
+  } else if (isHostSP && location.pathname.includes("/live-event/")) {
+      const video: HTMLVideoElement = document.querySelector(
+        ".btm-media-clients video"
+      );
+  
+      if (video && !isNaN(video.duration)) {
+  
+        const titleField: HTMLDivElement = document.querySelector(
+            ".btm-media-overlays-container .title-field"
+          ),
+          subtitleField: HTMLDivElement = document.querySelector(
+            ".btm-media-overlays-container .subtitle-field"
+          );
+  
+        title = titleField?.textContent;
+        subtitle = subtitleField?.textContent; // episode or empty if it's a movie
+  
+        if (!privacy) {
+          data.details = `${title} ${subtitle ? `- ${subtitle}` : ""}`;
+          data.state = strings.watchLive;
+        } else {
+          if (privacy)
+            data.state = strings.watchingLive
+        }
+  
+        data.smallImageKey = video.paused ? "pause" : "play";
+        data.smallImageText = video.paused ? strings.pause : strings.play;
+  
+        // add buttons, if enabled
+        if (!privacy && buttons) {
+          data.buttons = [
+            {
+              label: strings.watchStream,
+              url: `https://www.starplus.com${location.pathname}`
+            }
+          ];
+        }
+        if (title) presence.setActivity(data, !video.paused);
+      }
+
+  // GroupWatch lobby
+  } else if (
+    isHostSP &&
+    !privacy &&
+    location.pathname.includes("/groupwatch/")
+  ) {
+    groupWatchCount = document.querySelectorAll(
+      ".gw-avatar-enter-done:not([id=gw-invite-button])"
+    ).length;
+
+    const seriesFields: NodeListOf<HTMLDivElement> = document.querySelectorAll(`
+      #webAppScene main #group + div:not([id]) h3[style]:nth-of-type(1),
+      #webAppScene main #group + div:not([id]) h3[style]:nth-of-type(2)
+    `);
+
+    if (seriesFields.length > 0) {
+      title = seriesFields[0]?.textContent;
+      subtitle = seriesFields[1]?.textContent;
+    } else {
+      const movieField: HTMLImageElement = document.querySelector(
+        "#webAppScene main #group + div:not([id]) img[alt]"
+      );
+      title = movieField?.alt;
+    }
+
+    data.details = `${title} ${subtitle ? `- ${subtitle}` : ""}`;
+    data.state = "Starting a GroupWatch";
+    // set GroupWatch participants size
+    data.partySize = groupWatchCount;
+    data.partyMax = 7;
+
+    // add button, if enabled
+    if (buttons && groupWatchBtn) {
+      data.buttons = [
+        {
+          label: "Join GroupWatch",
+          url: location.pathname
+        }
+      ];
+    }
+
+    if (title) presence.setActivity(data, false);
+  
+  //Browsing
+  } else {
+    data.details = strings.browsing;
+    presence.setActivity(data);
+  }
+});

--- a/websites/S/Star+/presence.ts
+++ b/websites/S/Star+/presence.ts
@@ -151,8 +151,8 @@ presence.on("UpdateData", async () => {
   
     if (video && !isNaN(video.duration)) {
       const titleField: HTMLDivElement = document.querySelector(
-          ".btm-media-overlays-container .title-field"
-        ),
+        ".btm-media-overlays-container .title-field"
+      ),
         subtitleField: HTMLDivElement = document.querySelector(
           ".btm-media-overlays-container .subtitle-field"
         );

--- a/websites/S/Star+/tsconfig.json
+++ b/websites/S/Star+/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/"
+  }
+}


### PR DESCRIPTION
Presence for Star+: Star features television and film content intended for mature audiences, in contrast to the family- and franchise-oriented programming featured elsewhere in Disney+. This content is primarily drawn from the libraries of Disney subsidiaries, including FX, Freeform, Hulu, ABC Signature, 20th Television, 20th Television Animation, 20th Century Studios, Searchlight Pictures, Touchstone Pictures and Hollywood Pictures.


Disney+ and Star+ are basically the same website so i took the code by @ThaTiemsz (original author of Disney+ presence) and made it work on Star+