### PR TITLE
refactor(Presences): Updated Metadata Logos

### DIFF
--- a/websites/#/巴哈姆特/dist/metadata.json
+++ b/websites/#/巴哈姆特/dist/metadata.json
@@ -13,8 +13,8 @@
     "nl": "De grootste animatie- en gamecommunitywebsite voor Chinezen, met dagelijks ACG-nieuws, populaire ranglijsten en een schat aan discussie- en communicatieruimte, evenals briljante persoonlijke audio- en video-live- en blogposts."
   },
   "url": "forum.gamer.com.tw",
-  "version": "1.1.10",
-  "logo": "https://i.imgur.com/xiJm6Ee.png",
+  "version": "1.1.11",
+  "logo": "https://i.imgur.com/k5XqKom.png",
   "thumbnail": "https://i.imgur.com/WM3Rhii.png",
   "color": "#2E93A5",
   "tags": [

--- a/websites/0-9/1CAK/dist/metadata.json
+++ b/websites/0-9/1CAK/dist/metadata.json
@@ -13,8 +13,8 @@
     "nl": "1CAK is een Indonesische entertainmentsite die afbeeldingen en video's biedt die door gebruikers zijn geüpload. Deze site is ook bekend als entertainmentprovider via internetmeme. 1CAK-gebruikers kunnen afbeeldingen selecteren en erop reageren. Populaire afbeeldingen verschijnen op de hoofdwebsite"
   },
   "url": "1cak.com",
-  "version": "1.3.10",
-  "logo": "https://i.imgur.com/TIeg5it.png",
+  "version": "1.3.11",
+  "logo": "https://i.imgur.com/BQPTByr.png",
   "thumbnail": "https://i.imgur.com/q2Dr6OP.png",
   "color": "#ffffff",
   "tags": [

--- a/websites/0-9/7plus/dist/metadata.json
+++ b/websites/0-9/7plus/dist/metadata.json
@@ -17,8 +17,8 @@
     "nl": "7plus is een video-on-demand, inhaal-tv-dienst van het Seven Network. 7plus biedt ook online livestreaming van Channel Seven, 7TWO, 7mate, 7flix en Racing.com."
   },
   "service": "7plus",
-  "version": "1.0.6",
-  "logo": "https://i.imgur.com/ZY2K3CC.png",
+  "version": "1.0.7",
+  "logo": "https://i.imgur.com/BamXC8h.png",
   "thumbnail": "https://i.imgur.com/A50n9nx.png",
   "color": "#FF0000",
   "tags": [

--- a/websites/A/Akinator/dist/metadata.json
+++ b/websites/A/Akinator/dist/metadata.json
@@ -19,8 +19,8 @@
     "ga_IE": "Smaoinigh ar charachtar fíor nó ficseanúil. Déanfaidh mé iarracht buille faoi thuairim cé hé"
   },
   "url": "en.akinator.com",
-  "version": "1.3.8",
-  "logo": "https://i.imgur.com/XJ9h94X.png",
+  "version": "1.3.9",
+  "logo": "https://i.imgur.com/mQreXyR.png",
   "thumbnail": "https://i.imgur.com/CPWBwGM.png",
   "color": "#0000ff",
   "tags": [

--- a/websites/A/AniTürk/dist/metadata.json
+++ b/websites/A/AniTürk/dist/metadata.json
@@ -15,8 +15,8 @@
     "www.aniturk.net",
     "aniturk.net"
   ],
-  "version": "1.0.9",
-  "logo": "https://i.imgur.com/J9rcwoy.png",
+  "version": "1.0.10",
+  "logo": "https://i.imgur.com/xg4r7tM.png",
   "thumbnail": "https://i.imgur.com/0VdI8Mq.png",
   "color": "#ff31cb",
   "tags": [

--- a/websites/A/Anime Soul/dist/metadata.json
+++ b/websites/A/Anime Soul/dist/metadata.json
@@ -12,8 +12,8 @@
     "nl": "De grootste Anime Discord server ter wereld!"
   },
   "url": "animesoul.com",
-  "version": "1.1.11",
-  "logo": "https://i.imgur.com/OhVpByX.png",
+  "version": "1.1.12",
+  "logo": "https://i.imgur.com/fd4DHxK.png",
   "thumbnail": "https://i.imgur.com/jvhu7Ww.jpg",
   "color": "#7289da",
   "tags": [

--- a/websites/A/Anime-Sugoi/dist/metadata.json
+++ b/websites/A/Anime-Sugoi/dist/metadata.json
@@ -12,8 +12,8 @@
     "nl": "Anime-Sugoi streamt je favoriete anime volledig gratis met thai-sub en thai sound! ​ Deze website heeft mogelijk een VPN verbinding nodig voor toegang, andere landen dab thailand worden geblokkeerd!"
   },
   "url": "www.anime-sugoi.com",
-  "version": "1.0.11",
-  "logo": "https://i.imgur.com/7mAxf63.png",
+  "version": "1.0.12",
+  "logo": "https://i.imgur.com/DfHT5E8.png",
   "thumbnail": "https://i.imgur.com/3wTOxd0.jpg",
   "color": "#ff6666",
   "tags": [

--- a/websites/A/AnimeUltima/dist/metadata.json
+++ b/websites/A/AnimeUltima/dist/metadata.json
@@ -12,8 +12,8 @@
     "animeultima.to",
     "www1.animeultima.to"
   ],
-  "version": "1.0.3",
-  "logo": "https://i.imgur.com/BAFEKGq.png",
+  "version": "1.0.4",
+  "logo": "https://i.imgur.com/yL5SICQ.png",
   "thumbnail": "https://i.imgur.com/3K2hG7O.png",
   "color": "#FF3333",
   "tags": [

--- a/websites/A/AnimeXNovel/dist/metadata.json
+++ b/websites/A/AnimeXNovel/dist/metadata.json
@@ -18,8 +18,8 @@
     "ga_IE": "Léigh úrscéalta agus mangas."
   },
   "url": "www.animexnovel.com",
-  "version": "1.1.7",
-  "logo": "https://i.imgur.com/uyPh5yD.png",
+  "version": "1.1.8",
+  "logo": "https://i.imgur.com/LCiiBcG.png",
   "thumbnail": "https://i.imgur.com/umMu8Jc.png",
   "color": "#00a896",
   "tags": [

--- a/websites/A/Animes House/dist/metadata.json
+++ b/websites/A/Animes House/dist/metadata.json
@@ -13,8 +13,8 @@
     "nl": "Een van de meest comfortabele Braziliaanse websites om anime te bekijken"
   },
   "url": "animeshouse.net",
-  "version": "1.0.10",
-  "logo": "https://i.imgur.com/o8Px401.png",
+  "version": "1.0.11",
+  "logo": "https://i.imgur.com/dv1nn7J.png",
   "thumbnail": "https://i.imgur.com/1YqKDfY.png",
   "color": "#079ac7",
   "iframe": true,

--- a/websites/A/Animes Vision/dist/metadata.json
+++ b/websites/A/Animes Vision/dist/metadata.json
@@ -12,8 +12,8 @@
     "nl": "Animes Vision is een van de grootste Braziliaanse anime sites."
   },
   "service": "Animes Vision",
-  "version": "1.0.9",
-  "logo": "https://i.imgur.com/LRZPULY.png",
+  "version": "1.0.10",
+  "logo": "https://i.imgur.com/mzqXcKZ.png",
   "thumbnail": "https://i.imgur.com/OIHNhHg.png",
   "color": "#0EAFC1",
   "tags": [

--- a/websites/A/Arena of Kings/dist/metadata.json
+++ b/websites/A/Arena of Kings/dist/metadata.json
@@ -15,9 +15,9 @@
     "nl": "Arena of Kings is een snelle PvP Arena Game van de volgende generatie die gespeelt wordt in uw browser. Werk samen met helden om de troon op te eisen!",
     "zh_CN": "Arena of Kings是在浏览器中进行的快节奏PvP竞技场游戏。快来与英雄们联手夺取王位！"
   },
-  "version": "2.3.7",
+  "version": "2.3.8",
   "url": "arenaofkings.com",
-  "logo": "https://i.imgur.com/939UKF6.png",
+  "logo": "https://i.imgur.com/WLS3BqZ.png",
   "thumbnail": "https://i.imgur.com/2K6n54H.png",
   "color": "#4a4a4a",
   "tags": [

--- a/websites/A/AskUbuntu/dist/metadata.json
+++ b/websites/A/AskUbuntu/dist/metadata.json
@@ -21,8 +21,8 @@
     "www.askubuntu.com",
     "askubuntu.com"
   ],
-  "version": "1.2.6",
-  "logo": "https://i.imgur.com/if3xBTC.png",
+  "version": "1.2.7",
+  "logo": "https://i.imgur.com/pj2bELp.png",
   "thumbnail": "https://i.imgur.com/9Iy8Ibg.png",
   "color": "#dc461d",
   "tags": [

--- a/websites/A/animepahe/dist/metadata.json
+++ b/websites/A/animepahe/dist/metadata.json
@@ -16,8 +16,8 @@
     "animepahe.ru",
     "animepahe.org"
   ],
-  "version": "1.4.4",
-  "logo": "https://i.imgur.com/DqhX1vW.png",
+  "version": "1.4.5",
+  "logo": "https://i.imgur.com/LBb6FrK.png",
   "thumbnail": "https://i.imgur.com/Tm58ZXt.png",
   "color": "#d5015b",
   "tags": [

--- a/websites/B/BanG Dream! Wikia/dist/metadata.json
+++ b/websites/B/BanG Dream! Wikia/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Presence voor de Engelse Wikia van de BanG Dream! serie"
   },
   "url": "bandori.fandom.com",
-  "version": "1.3.7",
-  "logo": "https://i.imgur.com/3rm06ia.png",
+  "version": "1.3.8",
+  "logo": "https://i.imgur.com/pDL6BY7.png",
   "thumbnail": "https://i.imgur.com/5PF9Eyh.png",
   "color": "#E5004F",
   "tags": [

--- a/websites/B/Bargrooves/dist/metadata.json
+++ b/websites/B/Bargrooves/dist/metadata.json
@@ -13,8 +13,8 @@
     "nl": "Bargrooves stelt op maat gemaakte soundtracks samen voor veeleisende house muziekliefhebbers; compilaties en afspeellijsten die bij uw seizoensstemming passen, met de beste actuele dansmuziek naast geliefde klassiekers. Gebruik deze extensie om uw vrienden te laten zien waarnaar u luistert."
   },
   "service": "Bargrooves",
-  "version": "1.4.7",
-  "logo": "https://i.imgur.com/XbJf0LI.png",
+  "version": "1.4.8",
+  "logo": "https://i.imgur.com/VmWzplx.png",
   "thumbnail": "https://i.imgur.com/VUxIYVe.png",
   "color": "#FFBB00",
   "category": "music",

--- a/websites/B/Blkom/dist/metadata.json
+++ b/websites/B/Blkom/dist/metadata.json
@@ -15,8 +15,8 @@
     "nl": "Blkom - Arabische website om anime met Arabische ondertiteling te bekijken en te downloaden en het laatste nieuws over anime te krijgen."
   },
   "service": "Blkom",
-  "version": "1.0.5",
-  "logo": "https://i.imgur.com/XW4ouq1.png",
+  "version": "1.0.6",
+  "logo": "https://i.imgur.com/PfvR7jD.png",
   "thumbnail": "https://i.imgur.com/skws0oS.png",
   "color": "#FF6161",
   "tags": [

--- a/websites/B/Blockdit/dist/metadata.json
+++ b/websites/B/Blockdit/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "Blockdit is een sociaal netwerkplatform dat alle geweldige ideeën met elkaar verbindt. Blockdit biedt je opmerkelijke verhalen, ideeën en kennis in 'blokken' die gemakkelijk te lezen zijn"
   },
   "url": "www.blockdit.com",
-  "version": "1.0.5",
-  "logo": "https://i.imgur.com/WdOZbWQ.png",
+  "version": "1.0.6",
+  "logo": "https://i.imgur.com/4zIl3O7.png",
   "thumbnail": "https://i.imgur.com/s1U0Bq7.png",
   "color": "#4a7fe0",
   "tags": [

--- a/websites/B/Board Game Online/dist/metadata.json
+++ b/websites/B/Board Game Online/dist/metadata.json
@@ -21,8 +21,8 @@
     "boardgame-online.com",
     "www.boardgame-online.com"
   ],
-  "version": "1.1.12",
-  "logo": "https://i.imgur.com/MhNYI8n.png",
+  "version": "1.1.13",
+  "logo": "https://i.imgur.com/L6BgeAa.png",
   "thumbnail": "https://i.imgur.com/QTDzIqh.png",
   "color": "#EF3A26",
   "tags": [

--- a/websites/B/Bots on Discord/dist/metadata.json
+++ b/websites/B/Bots on Discord/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "Bots on Discord maakt een lijst van bots."
   },
   "url": "bots.ondiscord.xyz",
-  "version": "1.2.7",
-  "logo": "https://i.imgur.com/xHbTLj5.png",
+  "version": "1.2.8",
+  "logo": "https://i.imgur.com/5nbGMhE.png",
   "thumbnail": "https://i.imgur.com/TZOWrzr.png",
   "color": "#089BEF",
   "tags": [

--- a/websites/B/Branitube/dist/metadata.json
+++ b/websites/B/Branitube/dist/metadata.json
@@ -13,8 +13,8 @@
     "nl": "Branitube is een braziliaanse anime streaming website."
   },
   "url": "www.branitube.net",
-  "version": "2.5.7",
-  "logo": "https://i.imgur.com/7MI23R4.png",
+  "version": "2.5.8",
+  "logo": "https://i.imgur.com/x5yDUF9.png",
   "thumbnail": "https://i.imgur.com/c3ELKV2.png",
   "color": "#1384c3",
   "tags": [

--- a/websites/B/BugMeNot/dist/metadata.json
+++ b/websites/B/BugMeNot/dist/metadata.json
@@ -13,8 +13,8 @@
     "bugmenot.com",
     "www.bugmenot.com"
   ],
-  "version": "1.0.4",
-  "logo": "https://i.imgur.com/I8ZDjmA.png",
+  "version": "1.0.5",
+  "logo": "https://i.imgur.com/wRt2BfL.png",
   "thumbnail": "https://i.imgur.com/75lVUGU.png",
   "color": "#fa3631",
   "tags": [

--- a/websites/B/Bundle Haber/dist/metadata.json
+++ b/websites/B/Bundle Haber/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "De snelste manier om nieuws te vinden."
   },
   "url": "www.bundlehaber.com",
-  "version": "1.4.9",
-  "logo": "https://i.imgur.com/fshr89j.png",
+  "version": "1.4.10",
+  "logo": "https://i.imgur.com/GJTDdHF.png",
   "thumbnail": "https://i.imgur.com/ntbbC9T.png",
   "color": "#BBBBBB",
   "tags": [

--- a/websites/B/Bungie/dist/metadata.json
+++ b/websites/B/Bungie/dist/metadata.json
@@ -15,8 +15,8 @@
     "comics.bungie.net",
     "bungiestore.com"
   ],
-  "version": "1.0.5",
-  "logo": "https://i.imgur.com/7N4tOFk.jpg",
+  "version": "1.0.6",
+  "logo": "https://i.imgur.com/QQWLe6D.png",
   "thumbnail": "https://i.imgur.com/ivK2Uww.png",
   "color": "#12171C",
   "tags": [

--- a/websites/B/Byte/dist/metadata.json
+++ b/websites/B/Byte/dist/metadata.json
@@ -20,8 +20,8 @@
     "community.byte.co",
     "help.byte.co"
   ],
-  "version": "1.1.10",
-  "logo": "https://i.imgur.com/Ijm00A7.png",
+  "version": "1.1.11",
+  "logo": "https://i.imgur.com/oX5socK.png",
   "thumbnail": "https://i.imgur.com/MaC2lww.png",
   "color": "#6001E5",
   "tags": [

--- a/websites/C/Championgg/dist/metadata.json
+++ b/websites/C/Championgg/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "Champion.gg biedt League of Legends kampioenstatistieken, gidsen, builds, runen, meesterschap, vaardigheidsopdrachten en tellers per rol - inclusief winstpercentage, banpercentage ..."
   },
   "service": "Championgg",
-  "version": "1.0.9",
-  "logo": "https://i.imgur.com/4vqpAue.jpg",
+  "version": "1.0.10",
+  "logo": "https://i.imgur.com/xsFD9kI.png",
   "thumbnail": "https://i.imgur.com/td3BVmm.png",
   "color": "#02442F",
   "tags": [

--- a/websites/C/CliffsNotes/dist/metadata.json
+++ b/websites/C/CliffsNotes/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "CliffsNotes-studiegidsen zijn geschreven door echte leraren en professoren, dus wat je ook studeert, CliffsNotes kan je huiswerkhoofdpijn verlichten en je helpen hoog te scoren op examens."
   },
   "service": "CliffsNotes",
-  "version": "1.0.5",
-  "logo": "https://i.imgur.com/qLjfR9U.png",
+  "version": "1.0.6",
+  "logo": "https://i.imgur.com/t370zFk.png",
   "thumbnail": "https://i.imgur.com/XFCwrCc.png",
   "color": "#FFE500",
   "tags": [

--- a/websites/C/Codecademy/dist/metadata.json
+++ b/websites/C/Codecademy/dist/metadata.json
@@ -13,8 +13,8 @@
     "nl": "Leer de technische vaardigheden die u nodig heeft voor de baan die u zoekt. Als leiders op het gebied van online onderwijs en leren coderen, hebben we meer dan 45 miljoen mensen les gegeven met behulp van een getest curriculum en een interactieve leeromgeving. Begin met HTML, CSS, JavaScript, SQL, Python, Data Science en meer."
   },
   "service": "Codecademy",
-  "version": "1.1.5",
-  "logo": "https://i.imgur.com/TnKcxoz.jpg",
+  "version": "1.1.6",
+  "logo": "https://i.imgur.com/oew3JqR.png",
   "thumbnail": "https://i.imgur.com/Npzs51Y.png",
   "color": "#152B39",
   "tags": [

--- a/websites/C/Comic Space/dist/metadata.json
+++ b/websites/C/Comic Space/dist/metadata.json
@@ -12,8 +12,8 @@
     "nl": "Een scanlator met een schone website om online te lezen."
   },
   "url": "www.comicspace.com.br",
-  "version": "1.0.7",
-  "logo": "https://i.imgur.com/VMrDKci.png",
+  "version": "1.0.8",
+  "logo": "https://i.imgur.com/A46gK2x.png",
   "thumbnail": "https://i.imgur.com/XqvR2zv.png",
   "color": "#079ac7",
   "tags": [

--- a/websites/C/CoolMathGames/dist/metadata.json
+++ b/websites/C/CoolMathGames/dist/metadata.json
@@ -19,8 +19,8 @@
     "www.coolmathgames.com",
     "coolmathgames.com"
   ],
-  "version": "1.2.11",
-  "logo": "https://i.imgur.com/3eJRTgJ.png",
+  "version": "1.2.12",
+  "logo": "https://i.imgur.com/gg4LsW0.png",
   "thumbnail": "https://i.imgur.com/VZ4v1P7.png",
   "color": "#3DB5F9",
   "tags": [

--- a/websites/D/DaFont/dist/metadata.json
+++ b/websites/D/DaFont/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Archief van gratis downloadbare lettertypen. Blader door alfabetische lijst, stijl, auteur of populariteit."
   },
   "url": "www.dafont.com",
-  "version": "1.3.7",
-  "logo": "https://i.imgur.com/rc9ODvW.png",
+  "version": "1.3.8",
+  "logo": "https://i.imgur.com/PScrApw.png",
   "thumbnail": "https://i.imgur.com/OTjFjMj.jpg",
   "color": "#eb4034",
   "tags": [

--- a/websites/D/DashNet/dist/metadata.json
+++ b/websites/D/DashNet/dist/metadata.json
@@ -13,8 +13,8 @@
     "nl": "DashNet van Orteil en Opti, een team van twee mensen dat browsergames, generatoren en andere gekke experimenten maakt."
   },
   "url": "dashnet.org",
-  "version": "1.2.8",
-  "logo": "https://i.imgur.com/sbtwgku.png",
+  "version": "1.2.9",
+  "logo": "https://i.imgur.com/xcK0UqX.png",
   "thumbnail": "https://i.imgur.com/PnsZ4Nv.png",
   "color": "#042B48",
   "tags": [

--- a/websites/D/Discord Bot List/dist/metadata.json
+++ b/websites/D/Discord Bot List/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "Discord Bot List is een lijst van discord bots."
   },
   "url": "discordbotlist.com",
-  "version": "1.2.10",
-  "logo": "https://i.imgur.com/JDKasKl.png",
+  "version": "1.2.11",
+  "logo": "https://i.imgur.com/Nh2SWRD.png",
   "thumbnail": "https://i.imgur.com/s9urIYH.png",
   "color": "#10C0E7",
   "tags": [

--- a/websites/D/Disney+/dist/metadata.json
+++ b/websites/D/Disney+/dist/metadata.json
@@ -21,8 +21,8 @@
   },
   "url": "www.disneyplus.com",
   "regExp": "([a-z0-9-]+[.])*disneyplus[.]com[/]|([a-z0-9-]+[.])*hotstar[.]com[/]",
-  "version": "1.4.9",
-  "logo": "https://i.imgur.com/zuUeb2A.png",
+  "version": "1.4.10",
+  "logo": "https://i.imgur.com/KIZSYhc.png",
   "thumbnail": "https://i.imgur.com/Tp9oYPj.png",
   "color": "#233778",
   "tags": [

--- a/websites/D/Downdetector/dist/metadata.json
+++ b/websites/D/Downdetector/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Real-time probleem- en uitvalbewaking"
   },
   "service": "Downdetector",
-  "version": "1.2.7",
-  "logo": "https://i.imgur.com/STs8Nfw.png",
+  "version": "1.2.8",
+  "logo": "https://i.imgur.com/ba5AI1b.png",
   "thumbnail": "https://i.imgur.com/Qy1lbXE.png",
   "color": "#FF160A",
   "tags": [

--- a/websites/D/Dueling Nexus/dist/metadata.json
+++ b/websites/D/Dueling Nexus/dist/metadata.json
@@ -20,8 +20,8 @@
     "nl": "duelingnexus.com is een gratis online Yu-Gi-Oh-simulator voor browsers"
   },
   "url": "duelingnexus.com",
-  "version": "1.5.7",
-  "logo": "https://i.imgur.com/JFzVAdh.png",
+  "version": "1.5.8",
+  "logo": "https://i.imgur.com/zE6MjUq.png",
   "thumbnail": "https://i.imgur.com/7NXj9ih.jpg",
   "color": "#FF4500",
   "tags": [

--- a/websites/D/Durarara/dist/metadata.json
+++ b/websites/D/Durarara/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Durarara!! fan gemeenschap, DOLLARS chatroom."
   },
   "url": "drrr.com",
-  "version": "1.0.5",
-  "logo": "https://i.imgur.com/BBE7mHc.jpg",
+  "version": "1.0.6",
+  "logo": "https://i.imgur.com/8E6QIMT.png",
   "thumbnail": "https://i.imgur.com/h4NdSYG.png",
   "color": "#696969",
   "tags": [

--- a/websites/E/Edge Me Please/dist/metadata.json
+++ b/websites/E/Edge Me Please/dist/metadata.json
@@ -10,9 +10,9 @@
     "nl": "Het is een edging website als je daar in geïnteresseerd bent."
   },
   "url": "www.edgemeplease.com",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "thumbnail": "https://i.imgur.com/oyh6K6I.png",
-  "logo": "https://i.imgur.com/bYM3Ykg.jpg",
+  "logo": "https://i.imgur.com/scJSNj1.png",
   "color": "#121110",
   "tags": [
     "edging",

--- a/websites/E/e621/dist/metadata.json
+++ b/websites/E/e621/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "e621 is een volwassen imageboardvervanger voor het imageboard Sidechan. Een image board voor algemeen publiek, e926 (voorheen e961) vult deze site aan. E621 draait op het Ouroboros platform, een danbooru-achtige software speciaal ontworpen voor de site."
   },
   "url": "e621.net",
-  "version": "1.2.8",
-  "logo": "https://i.imgur.com/kw3r8T7.png",
+  "version": "1.2.9",
+  "logo": "https://i.imgur.com/NrwboRR.png",
   "thumbnail": "https://i.imgur.com/m0h7xnO.png",
   "color": "#284A81",
   "tags": [

--- a/websites/E/eggsy.codes/dist/metadata.json
+++ b/websites/E/eggsy.codes/dist/metadata.json
@@ -12,8 +12,8 @@
   },
   "url": "eggsy.xyz",
   "regExp": "eggsy[.]xyz(?![/]projects[/]premid[/]custom-status)",
-  "version": "1.2.9",
-  "logo": "https://i.imgur.com/AprfLlp.jpg",
+  "version": "1.2.10",
+  "logo": "https://i.imgur.com/MziDVWO.png",
   "thumbnail": "https://i.imgur.com/jy5yr4h.png",
   "color": "#212121",
   "tags": [

--- a/websites/E/exaroton/dist/metadata.json
+++ b/websites/E/exaroton/dist/metadata.json
@@ -13,8 +13,8 @@
     "exaroton.com",
     "support.exaroton.com"
   ],
-  "version": "1.0.3",
-  "logo": "https://i.imgur.com/uFAyLCK.png",
+  "version": "1.0.4",
+  "logo": "https://i.imgur.com/DTVwtiN.png",
   "thumbnail": "https://i.imgur.com/QYQLbKx.png",
   "color": "#17f013",
   "tags": [

--- a/websites/F/FairyAnime/dist/metadata.json
+++ b/websites/F/FairyAnime/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "FairyAnime streamt uw favoriete anime helemaal gratis met thai-sub en thais geluid!"
   },
   "url": "fairyanime.com",
-  "version": "1.0.5",
-  "logo": "https://i.imgur.com/VHH4EsR.png",
+  "version": "1.0.6",
+  "logo": "https://i.imgur.com/WBzbjlK.png",
   "thumbnail": "https://i.imgur.com/QvrAmhs.png",
   "color": "#f7a1f3",
   "tags": [

--- a/websites/F/freeCodeCamp/dist/metadata.json
+++ b/websites/F/freeCodeCamp/dist/metadata.json
@@ -20,8 +20,8 @@
     "nl": "Leer coderen. Bouw projecten. Verdien certificaten. Sinds 2015 hebben 40.000 afgestudeerden een baan gekregen bij technologiebedrijven als Google, Apple, Amazon en Microsoft."
   },
   "url": "www.freecodecamp.org",
-  "version": "1.1.6",
-  "logo": "https://i.imgur.com/asmbZdS.png",
+  "version": "1.1.7",
+  "logo": "https://i.imgur.com/DySHxnW.png",
   "thumbnail": "https://i.imgur.com/3jskcBw.png",
   "color": "#00008B",
   "tags": [

--- a/websites/G/GDBrowser/dist/metadata.json
+++ b/websites/G/GDBrowser/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Bekijk alle online functies van Geometry Dash, direct vanaf deze handige kleine website! Levels, profielen, klassementen, commentaar, en meer!"
   },
   "url": "gdbrowser.com",
-  "version": "1.3.9",
-  "logo": "https://i.imgur.com/H2S1hYI.png",
+  "version": "1.3.10",
+  "logo": "https://i.imgur.com/pEYBPbO.png",
   "thumbnail": "https://i.imgur.com/QLxFxIm.png",
   "color": "#FFFF00",
   "tags": [

--- a/websites/G/Garden/dist/metadata.json
+++ b/websites/G/Garden/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Een Franse Minecraft server gecultiveerd door toegewijde spelers."
   },
   "service": "Garden",
-  "version": "1.1.5",
-  "logo": "https://i.imgur.com/XjpOAvU.png",
+  "version": "1.1.6",
+  "logo": "https://i.imgur.com/PNc2c41.png",
   "thumbnail": "https://i.imgur.com/3L4UHk9.png",
   "color": "#0f7e49",
   "tags": [

--- a/websites/G/Gartic Phone/dist/metadata.json
+++ b/websites/G/Gartic Phone/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Het telefoonspel"
   },
   "service": "Gartic Phone",
-  "version": "1.0.4",
-  "logo": "https://i.imgur.com/zLBvs9k.png",
+  "version": "1.0.5",
+  "logo": "https://i.imgur.com/jT44n8u.png",
   "thumbnail": "https://i.imgur.com/f2oSx2u.png",
   "color": "#7424D9",
   "tags": [

--- a/websites/G/Giphy/dist/metadata.json
+++ b/websites/G/Giphy/dist/metadata.json
@@ -14,8 +14,8 @@
     "nl": "Giphy is een GIF-zoek- en creatiesysteem."
   },
   "url": "giphy.com",
-  "version": "1.2.7",
-  "logo": "https://i.imgur.com/VHG3gfC.png",
+  "version": "1.2.8",
+  "logo": "https://i.imgur.com/pVwjovM.png",
   "thumbnail": "https://i.imgur.com/Vtg6NxY.png",
   "color": "#00FF00",
   "tags": [

--- a/websites/G/GitLab/dist/metadata.json
+++ b/websites/G/GitLab/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "GitLab is a project management and code versioning system as well as a social network platform made for developers."
   },
   "url": "gitlab.com",
-  "version": "1.1.7",
-  "logo": "https://i.imgur.com/SWx8pPn.png",
+  "version": "1.1.8",
+  "logo": "https://i.imgur.com/R3DmkeK.png",
   "thumbnail": "https://i.imgur.com/ISBVR2q.png",
   "color": "#ff4400",
   "tags": [

--- a/websites/G/Glitch/dist/metadata.json
+++ b/websites/G/Glitch/dist/metadata.json
@@ -15,8 +15,8 @@
     "support.glitch.com",
     "status.glitch.com"
   ],
-  "version": "1.8.9",
-  "logo": "https://i.imgur.com/zU6eBwQ.png",
+  "version": "1.8.10",
+  "logo": "https://i.imgur.com/YFnN57M.png",
   "thumbnail": "https://i.imgur.com/mnilDhS.png",
   "color": "#f003fc",
   "tags": [

--- a/websites/G/Google Drive/dist/metadata.json
+++ b/websites/G/Google Drive/dist/metadata.json
@@ -19,8 +19,8 @@
     "nl": "Google Drive is een service voor bestandsopslag en synchronisatie die is gemaakt en wordt beheerd door Google. Met Google Drive kunnen documenten in de cloud worden opgeslagen, bestanden worden gedeeld en documenten samen met anderen worden bewerkt."
   },
   "url": "drive.google.com",
-  "version": "1.5.11",
-  "logo": "https://i.imgur.com/89wuDMP.png",
+  "version": "1.5.12",
+  "logo": "https://i.imgur.com/WdNIJe8.png",
   "thumbnail": "https://i.imgur.com/mZdtUw5.png",
   "color": "#3aa154",
   "tags": [

--- a/websites/G/Granblue Fantasy/dist/metadata.json
+++ b/websites/G/Granblue Fantasy/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Japans rollenspel"
   },
   "url": "game.granbluefantasy.jp",
-  "version": "1.2.10",
-  "logo": "https://i.imgur.com/W0nvASk.png",
+  "version": "1.2.11",
+  "logo": "https://i.imgur.com/XyHgDQX.png",
   "thumbnail": "https://i.imgur.com/2GPNZM8.jpg",
   "color": "#2F4F7A",
   "tags": [

--- a/websites/H/Hacktoberfest/dist/metadata.json
+++ b/websites/H/Hacktoberfest/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Hacktoberfest® staat open voor iedereen in onze wereldwijde gemeenschap. Of je nu een ontwikkelaar bent, een student die leert programmeren, een evenement organiseert of een bedrijf van welke omvang dan ook, je kunt de groei van open source stimuleren en een positieve bijdrage leveren aan een steeds groter wordende community. Alle achtergronden en vaardigheidsniveaus worden aangemoedigd om de uitdaging aan te gaan."
   },
   "url": "hacktoberfest.digitalocean.com",
-  "version": "1.0.4",
-  "logo": "https://i.imgur.com/W4srxuR.png",
+  "version": "1.0.5",
+  "logo": "https://i.imgur.com/VshdY7t.png",
   "thumbnail": "https://i.imgur.com/sTgmNCW.jpg",
   "color": "#183D5D",
   "tags": [

--- a/websites/H/HentaiFox/dist/metadata.json
+++ b/websites/H/HentaiFox/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "HentaiFox is een van de meest populaire gratis hentai-sites voor Engels vertaalde hentai-manga en doujinshi."
   },
   "url": "hentaifox.com",
-  "version": "1.0.5",
-  "logo": "https://i.imgur.com/OcUEF3h.png",
+  "version": "1.0.6",
+  "logo": "https://i.imgur.com/o9joHZX.png",
   "thumbnail": "https://i.imgur.com/aTgT0rO.png",
   "color": "#ff9f08",
   "tags": [

--- a/websites/H/Hentailib/dist/metadata.json
+++ b/websites/H/Hentailib/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "Website voor het lezen van hentai-manga in het Russisch"
   },
   "url": "hentailib.me",
-  "version": "1.1.4",
-  "logo": "https://i.imgur.com/LrbkRvj.png",
+  "version": "1.1.5",
+  "logo": "https://i.imgur.com/5II032W.png",
   "thumbnail": "https://i.imgur.com/1lXZCVd.png",
   "color": "#ff0048",
   "tags": [

--- a/websites/H/Honeygain/dist/metadata.json
+++ b/websites/H/Honeygain/dist/metadata.json
@@ -13,8 +13,8 @@
     "www.honeygain.com",
     "dashboard.honeygain.com"
   ],
-  "version": "1.1.8",
-  "logo": "https://i.imgur.com/fjaT2cF.jpg",
+  "version": "1.1.9",
+  "logo": "https://i.imgur.com/GUMs8VF.png",
   "thumbnail": "https://i.imgur.com/pThjE43.png",
   "color": "#fad63a",
   "tags": [

--- a/websites/H/Hytale/dist/metadata.json
+++ b/websites/H/Hytale/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "Ga op een reis vol avontuur en creativiteit! Hytale combineert de reikwijdte van een sandbox met de diepte van een rollenspel en dompelt spelers onder in een procedureel gegenereerde wereld waar wankelende torens en diepe kerkers rijke beloningen beloven."
   },
   "service": "Hytale",
-  "version": "1.0.6",
-  "logo": "https://i.imgur.com/ue65nDd.png",
+  "version": "1.0.7",
+  "logo": "https://i.imgur.com/xkIYckE.jpg",
   "thumbnail": "https://i.imgur.com/mvDxqep.png",
   "color": "#15243A",
   "tags": [

--- a/websites/I/IMDbFilmizle/dist/metadata.json
+++ b/websites/I/IMDbFilmizle/dist/metadata.json
@@ -20,8 +20,8 @@
     "nl": "Bekijk de nieuwste films in Full HD op onze website. De beste website om films te kijken als het om kwaliteit gaat."
   },
   "service": "IMDbFilmizle",
-  "version": "1.0.6",
-  "logo": "https://i.imgur.com/rDIoqZb.png",
+  "version": "1.0.7",
+  "logo": "https://i.imgur.com/cIr56HO.png",
   "thumbnail": "https://i.imgur.com/RdOXsqx.png",
   "color": "#FFDB4C",
   "tags": [

--- a/websites/I/ITV Hub/dist/metadata.json
+++ b/websites/I/ITV Hub/dist/metadata.json
@@ -13,8 +13,8 @@
     "www.itv.com",
     "itv.com"
   ],
-  "version": "1.4.7",
-  "logo": "https://i.imgur.com/3MyvsnD.png",
+  "version": "1.4.8",
+  "logo": "https://i.imgur.com/5PShoo9.png",
   "thumbnail": "https://i.imgur.com/WRttRBO.png",
   "color": "#2ABEC9",
   "tags": [

--- a/websites/I/Indiachan/dist/metadata.json
+++ b/websites/I/Indiachan/dist/metadata.json
@@ -6,9 +6,9 @@
     "id": "874685117891739749"
   },
   "category": "other",
-  "logo": "https://i.imgur.com/hYySiGD.png",
+  "logo": "https://i.imgur.com/caelFBx.png",
   "thumbnail": "https://i.imgur.com/EBTNFKT.png",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "color": "#ef8e00",
   "tags": [
     "imageboard",

--- a/websites/I/Instant-Gaming/dist/metadata.json
+++ b/websites/I/Instant-Gaming/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "Instant-Gaming.com - Al je favoriete games voor Steam-, Origin-, Battle.net-, Uplay- en Indie-games tot 70% korting! Digitale games, directe levering 24/7!"
   },
   "service": "Instant-Gaming",
-  "version": "1.1.8",
-  "logo": "https://i.imgur.com/ULmYGzW.png",
+  "version": "1.1.9",
+  "logo": "https://i.imgur.com/3htcFSM.png",
   "thumbnail": "https://i.imgur.com/N0SrNHb.jpg",
   "color": "#e37d00",
   "tags": [

--- a/websites/I/Issou TV/dist/metadata.json
+++ b/websites/I/Issou TV/dist/metadata.json
@@ -14,8 +14,8 @@
     "nl": "IssouTv is een community-videohostingplatform. Humor, onbehagen, muziek, games, volwassenen ... er is voor elk wat wils."
   },
   "service": "Issou TV",
-  "version": "1.0.8",
-  "logo": "https://i.imgur.com/bDaeC8K.png",
+  "version": "1.0.9",
+  "logo": "https://i.imgur.com/eOauOMV.png",
   "thumbnail": "https://i.imgur.com/MOwagyo.png",
   "color": "#637076",
   "tags": [

--- a/websites/J/Jackbox/dist/metadata.json
+++ b/websites/J/Jackbox/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Het is gemakkelijk om deze website te gebruiken om van je telefoon, tablet of computer een controller te maken voor een van de vele partygames van Jackbox Games. Het enige dat u nodig heeft, is een kamercode"
   },
   "url": "jackbox.tv",
-  "version": "1.4.8",
-  "logo": "https://i.imgur.com/Dyoab1j.jpg",
+  "version": "1.4.9",
+  "logo": "https://i.imgur.com/SXfEdnL.png",
   "thumbnail": "https://i.imgur.com/poY2KNc.png",
   "color": "#4254f4",
   "tags": [

--- a/websites/J/Japari Library/dist/metadata.json
+++ b/websites/J/Japari Library/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Japari Library is een wiki die is gebaseerd op de multimediafranchise Kemono Friends."
   },
   "service": "Japari Library",
-  "version": "1.1.9",
-  "logo": "https://i.imgur.com/Y3BtrFi.png",
+  "version": "1.1.10",
+  "logo": "https://i.imgur.com/9tsqblt.png",
   "thumbnail": "https://i.imgur.com/nGO9Amx.png",
   "color": "#4CC5FF",
   "category": "anime",

--- a/websites/J/Joox/dist/metadata.json
+++ b/websites/J/Joox/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "JOOX - muziekstreamingplatform dat u toegang geeft tot miljoenen nummers. Download JOOX GRATIS, gratis muziek, gratis radio, toplijsten, afspeellijsten, nieuwe releases"
   },
   "url": "www.joox.com",
-  "version": "1.0.5",
-  "logo": "https://i.imgur.com/h4Eb2q4.png",
+  "version": "1.0.6",
+  "logo": "https://i.imgur.com/yoQPcUK.png",
   "thumbnail": "https://i.imgur.com/CZeMH5Q.jpg",
   "color": "#5abf77",
   "tags": [

--- a/websites/J/Just Light Novels/dist/metadata.json
+++ b/websites/J/Just Light Novels/dist/metadata.json
@@ -16,8 +16,8 @@
     "nl": "Gewoon lichte romans! Huis van alle lichte romans"
   },
   "url": "justlightnovels.com",
-  "version": "1.2.7",
-  "logo": "https://i.imgur.com/HyOSTGP.png",
+  "version": "1.2.8",
+  "logo": "https://i.imgur.com/O2Xalve.png",
   "thumbnail": "https://i.imgur.com/KWY5wqt.png",
   "color": "#0000ff",
   "tags": [

--- a/websites/K/Kabal's/dist/metadata.json
+++ b/websites/K/Kabal's/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "De bot van Kabal biedt sociale aspecten, waaronder een ledenprofiel, leuke dingen en moderatie."
   },
   "url": "bot.emirkabal.com",
-  "version": "1.2.8",
-  "logo": "https://i.imgur.com/8V5NfYD.png",
+  "version": "1.2.9",
+  "logo": "https://i.imgur.com/FIkYpzN.png",
   "thumbnail": "https://i.imgur.com/nitFxle.png",
   "color": "#2942BF",
   "tags": [

--- a/websites/K/Kitsu/dist/metadata.json
+++ b/websites/K/Kitsu/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Deel anime- en manga-ervaringen, ontvang aanbevelingen en kijk wat vrienden kijken of lezen."
   },
   "url": "kitsu.io",
-  "version": "1.3.8",
-  "logo": "https://i.imgur.com/UpVUQCQ.png",
+  "version": "1.3.9",
+  "logo": "https://i.imgur.com/LlascQj.png",
   "thumbnail": "https://i.imgur.com/0yjRrph.png",
   "color": "#FD755C",
   "tags": [

--- a/websites/K/Komoot/dist/metadata.json
+++ b/websites/K/Komoot/dist/metadata.json
@@ -16,8 +16,8 @@
     "www.komoot.es",
     "www.komoot.nl"
   ],
-  "version": "1.0.3",
-  "logo": "https://i.imgur.com/TtuBUri.png",
+  "version": "1.0.4",
+  "logo": "https://i.imgur.com/G8vn23a.png",
   "thumbnail": "https://i.imgur.com/mbb326e.png",
   "color": "#FFFFFF",
   "category": "other",

--- a/websites/K/Koya/dist/metadata.json
+++ b/websites/K/Koya/dist/metadata.json
@@ -14,8 +14,8 @@
     "nl": "Een krachtige multifunctionele en configureerbare Discord-bot."
   },
   "service": "Koya",
-  "version": "1.2.8",
-  "logo": "https://i.imgur.com/WeKgGeX.png",
+  "version": "1.2.9",
+  "logo": "https://i.imgur.com/utYCZOS.png",
   "thumbnail": "https://i.imgur.com/zQ7KPjZ.png",
   "color": "#7289da",
   "tags": [

--- a/websites/K/kosmi.io/dist/metadata.json
+++ b/websites/K/kosmi.io/dist/metadata.json
@@ -13,8 +13,8 @@
     "nl": "Online Hangouts gemakkelijk gemaakt."
   },
   "service": "kosmi.io",
-  "version": "1.0.5",
-  "logo": "https://i.imgur.com/Qr9bR87.png",
+  "version": "1.0.6",
+  "logo": "https://i.imgur.com/RdGpMdg.png",
   "thumbnail": "https://i.imgur.com/ZzMzc1l.png",
   "color": "#322484",
   "tags": [

--- a/websites/L/Lawcodev/dist/metadata.json
+++ b/websites/L/Lawcodev/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "Lawcodev, sociaal netwerk voor programmeurs, u kunt video's over programmeren, foto's en publicaties delen."
   },
   "url": "www.lawcodev.com",
-  "version": "1.4.7",
-  "logo": "https://i.imgur.com/YehQEpz.png",
+  "version": "1.4.8",
+  "logo": "https://i.imgur.com/vADndhN.png",
   "thumbnail": "https://i.imgur.com/tT2mENc.png",
   "color": "#131313",
   "tags": [

--- a/websites/L/Love Live! Wikia/dist/metadata.json
+++ b/websites/L/Love Live! Wikia/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Aanwezigheid voor de Engelse Wikia van Love Live! School Idol Project-serie"
   },
   "url": "love-live.fandom.com",
-  "version": "1.3.7",
-  "logo": "https://i.imgur.com/LXtVWtr.png",
+  "version": "1.3.8",
+  "logo": "https://i.imgur.com/OBXvOaC.png",
   "thumbnail": "https://i.imgur.com/bc5hyE8.png",
   "color": "#E8218B",
   "tags": [

--- a/websites/L/LucidChart/dist/metadata.json
+++ b/websites/L/LucidChart/dist/metadata.json
@@ -13,8 +13,8 @@
     "www.lucidchart.com",
     "lucidchart.com"
   ],
-  "version": "1.3.7",
-  "logo": "https://i.imgur.com/dWTAS94.png",
+  "version": "1.3.8",
+  "logo": "https://i.imgur.com/VOZdP4X.png",
   "thumbnail": "https://i.imgur.com/XAxo7fd.png",
   "color": "#F38D32",
   "tags": [

--- a/websites/M/MLPOL/dist/metadata.json
+++ b/websites/M/MLPOL/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Welkom bij het Mongoolse politieke paardenverluisterforum, ook bekend als /mlpol/"
   },
   "service": "MLPOL",
-  "version": "1.0.4",
-  "logo": "https://i.imgur.com/djCvvIV.png",
+  "version": "1.0.5",
+  "logo": "https://i.imgur.com/VFNPebz.png",
   "thumbnail": "https://i.imgur.com/jORyHwa.png",
   "color": "#FF0000",
   "tags": [

--- a/websites/M/Mangalib/dist/metadata.json
+++ b/websites/M/Mangalib/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "Website voor het lezen van manga in het Russisch"
   },
   "url": "mangalib.me",
-  "version": "1.4.4",
-  "logo": "https://i.imgur.com/ed4EKND.png",
+  "version": "1.4.5",
+  "logo": "https://i.imgur.com/bQPdsZ1.png",
   "thumbnail": "https://i.imgur.com/0U4JNOJ.png",
   "color": "#ff8c00",
   "tags": [

--- a/websites/M/MangasPROJECT/dist/metadata.json
+++ b/websites/M/MangasPROJECT/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "MangasPROJECT - Lees online en organiseer je reads in mangasPROJECT. Lees in Portugese manga's en webtoons, de meeste leest in actie, romantiek, fantasie, isekai en anderen!"
   },
   "url": "leitor.net",
-  "version": "1.2.10",
-  "logo": "https://i.imgur.com/M33LuGj.png",
+  "version": "1.2.11",
+  "logo": "https://i.imgur.com/LSo5STJ.png",
   "thumbnail": "https://i.imgur.com/PGvPuOd.png",
   "color": "#d4c196",
   "tags": [

--- a/websites/M/Mark Scans/dist/metadata.json
+++ b/websites/M/Mark Scans/dist/metadata.json
@@ -12,8 +12,8 @@
     "nl": "Een Braziliaanse scanlator die webtoons en manga's maakt"
   },
   "url": "markscans.online",
-  "version": "1.0.4",
-  "logo": "https://i.imgur.com/jBlCITq.png",
+  "version": "1.0.5",
+  "logo": "https://i.imgur.com/yDmQsYg.png",
   "thumbnail": "https://i.imgur.com/QEdn2iJ.png",
   "tags": [
     "scan",

--- a/websites/M/Mavanimes/dist/metadata.json
+++ b/websites/M/Mavanimes/dist/metadata.json
@@ -6,9 +6,9 @@
     "id": "256458960666624003"
   },
   "category": "anime",
-  "logo": "https://i.imgur.com/xqLsTty.png",
+  "logo": "https://i.imgur.com/o4qNo1n.png",
   "thumbnail": "https://i.imgur.com/oeUAnJ2.png",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "color": "#0f61b8",
   "url": "www.mavanimes.co",
   "iframe": true,

--- a/websites/M/Microsoft Teams/dist/metadata.json
+++ b/websites/M/Microsoft Teams/dist/metadata.json
@@ -16,8 +16,8 @@
     "nl": "Blijf verbonden en georganiseerd. Bereik samen meer op het werk, op school en in het leven met Microsoft Teams."
   },
   "service": "Microsoft Teams",
-  "version": "1.1.3",
-  "logo": "https://i.imgur.com/7pDg1Eu.png",
+  "version": "1.1.4",
+  "logo": "https://i.imgur.com/G7Adh20.png",
   "thumbnail": "https://i.imgur.com/6HDv24v.png",
   "color": "#4A51BA",
   "tags": [

--- a/websites/M/MojeVideo/dist/metadata.json
+++ b/websites/M/MojeVideo/dist/metadata.json
@@ -5,14 +5,14 @@
     "id": "284370397535666188"
   },
   "url": "www.mojevideo.sk",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": {
     "en": "MojeVideo is a Slovak video streaming/sharing website mostly with funny, short videos",
     "sk": "Nové zábavné videá každý deň, zabavte sa, zasmejte sa, alebo nám pošlite vaše videá",
     "nl": "MojeVideo is een Slowaakse website voor het streamen / delen van video's, meestal met grappige, korte video's"
   },
   "service": "MojeVideo",
-  "logo": "https://i.imgur.com/gilsj7t.png",
+  "logo": "https://i.imgur.com/hZc3Hcn.png",
   "thumbnail": "https://i.imgur.com/Tud2vXt.png",
   "color": "#2e2e2e",
   "tags": [

--- a/websites/M/MyBOT/dist/metadata.json
+++ b/websites/M/MyBOT/dist/metadata.json
@@ -17,8 +17,8 @@
     "nl": "MyBOT is een platform met verschillende handleidingen en tools in het Spaans, gericht op de ontwikkeling van apps / bots en inhoud voor gemeenschappen van Discord."
   },
   "url": "portalmybot.com",
-  "version": "1.3.9",
-  "logo": "https://i.imgur.com/6NZfnIf.png",
+  "version": "1.3.10",
+  "logo": "https://i.imgur.com/u2f93Bf.png",
   "thumbnail": "https://i.imgur.com/B8x9D6k.png",
   "color": "#00fef4",
   "tags": [

--- a/websites/M/motorsport.com/dist/metadata.json
+++ b/websites/M/motorsport.com/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Motorsport.com is een website die gespecialiseerd is in nieuws over autoraces. Sporten zoals Formule 1, NASCAR, IndyCar, MotoGP en WEC."
   },
   "service": "motorsport.com",
-  "version": "1.0.5",
-  "logo": "https://i.imgur.com/Dvs107P.png",
+  "version": "1.0.6",
+  "logo": "https://i.imgur.com/u6MICx7.png",
   "thumbnail": "https://i.imgur.com/7ha5AqJ.jpg",
   "color": "#E7FF7B",
   "tags": [

--- a/websites/N/Neox Scanlator/dist/metadata.json
+++ b/websites/N/Neox Scanlator/dist/metadata.json
@@ -12,8 +12,8 @@
     "nl": "Een van de giganten fansubs in Brazilië waar ze vertalen en verspreiden onder het publiek, ook bekend om het vertalen van Solo Leveling en andere beroemde manga."
   },
   "url": "neoxscans.com",
-  "version": "1.0.11",
-  "logo": "https://i.imgur.com/L5sBw6j.png",
+  "version": "1.0.12",
+  "logo": "https://i.imgur.com/ruuxS0Z.png",
   "thumbnail": "https://i.imgur.com/ljNKCp1.png",
   "color": "#079ac7",
   "tags": [

--- a/websites/N/Nexus Mods/dist/metadata.json
+++ b/websites/N/Nexus Mods/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "We ondersteunen modding voor alle pc-games. Als je het kunt aanpassen, zullen we het hosten."
   },
   "service": "Nexus Mods",
-  "version": "1.2.7",
-  "logo": "https://i.imgur.com/An5OwGg.png",
+  "version": "1.2.8",
+  "logo": "https://i.imgur.com/1C3hyW0.png",
   "thumbnail": "https://i.imgur.com/RCC92Ny.png",
   "color": "#DA8E35",
   "tags": [

--- a/websites/N/Nookazon/dist/metadata.json
+++ b/websites/N/Nookazon/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Nookazon is een fansite waar gebruikers items en dorpelingen kunnen kopen en verkopen in \"Animal Crossing: New Horizons\"."
   },
   "url": "nookazon.com",
-  "version": "1.0.6",
-  "logo": "https://i.imgur.com/Bt6Nip9.png",
+  "version": "1.0.7",
+  "logo": "https://i.imgur.com/ey6oFrP.png",
   "thumbnail": "https://i.imgur.com/skoBmeu.png",
   "color": "#5FA0D7",
   "tags": [

--- a/websites/N/Nuxt.js/dist/metadata.json
+++ b/websites/N/Nuxt.js/dist/metadata.json
@@ -24,8 +24,8 @@
     "nl": "Nuxt is een progressief framework gebaseerd op Vue.js om moderne webapplicaties te maken. Het is gebaseerd op de officiële bibliotheken van Vue.js (vue, vue-router en vuex) en krachtige ontwikkeltools (webpack, Babel en PostCSS). Het doel van Nuxt is om webontwikkeling krachtig en performant te maken met een geweldige ontwikkelaarservaring in gedachten."
   },
   "service": "Nuxt.js",
-  "version": "1.2.8",
-  "logo": "https://i.imgur.com/XSYIbbu.png",
+  "version": "1.2.9",
+  "logo": "https://i.imgur.com/6A7Q1dP.png",
   "thumbnail": "https://i.imgur.com/mlwpfWK.png",
   "color": "#00c58e",
   "tags": [

--- a/websites/O/Otakudesu/dist/metadata.json
+++ b/websites/O/Otakudesu/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Download, bekijk en stream anime met Indonesische ondertiteling en met 240p, 360p, 480p en 720p resolutie met MP4-formaat en MKV samen met de batch."
   },
   "url": "otakudesu.moe",
-  "version": "1.0.6",
-  "logo": "https://i.imgur.com/RrlRhIJ.png",
+  "version": "1.0.7",
+  "logo": "https://i.imgur.com/OZNNQyi.png",
   "thumbnail": "https://i.imgur.com/wHfvj2a.png",
   "color": "#ffffff",
   "tags": [

--- a/websites/O/Overbuff/dist/metadata.json
+++ b/websites/O/Overbuff/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Overbuff is een website die is bedoeld om Overwatch-spelers te helpen hun spel te verbeteren. Je kunt je voortgang op helden volgen, zien wat je vrienden hebben gespeeld en professionele spelers in de gaten houden."
   },
   "url": "www.overbuff.com",
-  "version": "1.1.8",
-  "logo": "https://i.imgur.com/iPdbPrZ.png",
+  "version": "1.1.9",
+  "logo": "https://i.imgur.com/ceCTdEn.png",
   "thumbnail": "https://i.imgur.com/AvUP9R2.png",
   "color": "#FF8D00",
   "tags": [

--- a/websites/O/Overleaf/dist/metadata.json
+++ b/websites/O/Overleaf/dist/metadata.json
@@ -12,8 +12,8 @@
     "nl": "Overleaf is een op samenwerking gebaseerde LaTeX-editor in de cloud die wordt gebruikt voor het schrijven, bewerken en publiceren van wetenschappelijke documenten. Het werkt samen met een breed scala aan wetenschappelijke uitgevers om LaTeX-sjablonen van officiële tijdschriften en directe indieningslinks te bieden."
   },
   "service": "Overleaf",
-  "version": "1.0.5",
-  "logo": "https://i.imgur.com/FbpZZg1.png",
+  "version": "1.0.6",
+  "logo": "https://i.imgur.com/DcEM56x.png",
   "thumbnail": "https://i.imgur.com/lWInfl3.png",
   "color": "#138A07",
   "tags": [

--- a/websites/O/osu!kawata/dist/metadata.json
+++ b/websites/O/osu!kawata/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "Kawata is de eerste osu! privéserver die valsspelen mogelijk maakt."
   },
   "url": "kawata.pw",
-  "version": "1.3.9",
-  "logo": "https://i.imgur.com/WWutJmW.png",
+  "version": "1.3.10",
+  "logo": "https://i.imgur.com/0PDmn78.png",
   "thumbnail": "https://i.imgur.com/P47CM8o.png",
   "color": "#6EFBFE",
   "tags": [

--- a/websites/O/osu!ripple/dist/metadata.json
+++ b/websites/O/osu!ripple/dist/metadata.json
@@ -19,8 +19,8 @@
     "status.ripple.moe",
     "blog.ripple.moe"
   ],
-  "version": "1.3.9",
-  "logo": "https://i.imgur.com/mWU4B5Y.png",
+  "version": "1.3.10",
+  "logo": "https://i.imgur.com/bj86lDJ.png",
   "thumbnail": "https://i.imgur.com/00lpqgv.png",
   "color": "#FF66AA",
   "tags": [

--- a/websites/P/Pantip/dist/metadata.json
+++ b/websites/P/Pantip/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "Pantip is het populairste forum in Thailand om deel te nemen aan discussies over alle onderwerpen, waaronder entertainment, aandelen, schoonheid, reizen, auto's, sport, mobiele telefoons, eten, politiek, gezin, huis, wetenschap, gezondheid, zaken"
   },
   "url": "www.pantip.com",
-  "version": "1.0.5",
-  "logo": "https://i.imgur.com/Gx2uf9A.png",
+  "version": "1.0.6",
+  "logo": "https://i.imgur.com/pXOyBO5.png",
   "thumbnail": "https://i.imgur.com/5ji4rGg.png",
   "color": "#9d93f5",
   "tags": [

--- a/websites/P/Pastebin/dist/metadata.json
+++ b/websites/P/Pastebin/dist/metadata.json
@@ -13,8 +13,8 @@
     "pastebin.com",
     "www.pastebin.com"
   ],
-  "version": "1.3.7",
-  "logo": "https://i.imgur.com/bqmMq6t.png",
+  "version": "1.3.8",
+  "logo": "https://i.imgur.com/Y0yUAW1.png",
   "thumbnail": "https://i.imgur.com/kZT3m1r.png",
   "color": "#023859",
   "tags": [

--- a/websites/P/Pastr/dist/metadata.json
+++ b/websites/P/Pastr/dist/metadata.json
@@ -13,8 +13,8 @@
     "pastr.io",
     "www.pastr.io"
   ],
-  "version": "1.2.7",
-  "logo": "https://i.imgur.com/vHvJe1O.png",
+  "version": "1.2.8",
+  "logo": "https://i.imgur.com/xmniJkA.png",
   "thumbnail": "https://i.imgur.com/eNVKJVd.png",
   "color": "#008EFF",
   "tags": [

--- a/websites/P/Paybutik/dist/metadata.json
+++ b/websites/P/Paybutik/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "Paybutik is een aanbieder van online betaaldiensten aan klanten."
   },
   "url": "paybutik.net",
-  "version": "1.1.8",
-  "logo": "https://i.imgur.com/yLjWyU9.png",
+  "version": "1.1.9",
+  "logo": "https://i.imgur.com/Ly3FWW9.png",
   "thumbnail": "https://i.imgur.com/afOnttt.png",
   "color": "#eb8242",
   "tags": [

--- a/websites/P/Pocket Casts/dist/metadata.json
+++ b/websites/P/Pocket Casts/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Alle functies die je nodig hebt in een podcasting-app zonder een opgeblazen gevoel. Podcast luisteren is op 11 gezet."
   },
   "url": "play.pocketcasts.com",
-  "version": "1.2.8",
-  "logo": "https://i.imgur.com/dyQLFDS.png",
+  "version": "1.2.9",
+  "logo": "https://i.imgur.com/5tOAWM7.png",
   "thumbnail": "https://i.imgur.com/AJS6zcg.png",
   "color": "#F43E37",
   "tags": [

--- a/websites/P/Prambors Radio/dist/metadata.json
+++ b/websites/P/Prambors Radio/dist/metadata.json
@@ -14,8 +14,8 @@
     "live.pramborsfm.com",
     "streaming.pramborsfm.com"
   ],
-  "version": "1.3.4",
-  "logo": "https://i.imgur.com/GHM1owM.png",
+  "version": "1.3.5",
+  "logo": "https://i.imgur.com/1aHDZrS.png",
   "thumbnail": "https://i.imgur.com/mhwloZI.png",
   "color": "#ffc925",
   "tags": [

--- a/websites/P/Proxer/dist/metadata.json
+++ b/websites/P/Proxer/dist/metadata.json
@@ -11,9 +11,9 @@
     "nl": "Gratis en open Duitse Anime-community"
   },
   "service": "Proxer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "iframe": true,
-  "logo": "https://i.imgur.com/ZrO8bHg.png",
+  "logo": "https://i.imgur.com/jx65gdz.png",
   "thumbnail": "https://i.imgur.com/j0hV7nO.png",
   "color": "#8A0E0E",
   "tags": [

--- a/websites/P/PyPi/dist/metadata.json
+++ b/websites/P/PyPi/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "De Python Package Index (PyPI) is een opslagplaats van software voor de programmeertaal Python."
   },
   "url": "pypi.org",
-  "version": "1.4.7",
-  "logo": "https://i.imgur.com/Nzzr10E.png",
+  "version": "1.4.8",
+  "logo": "https://i.imgur.com/PWiUxFD.png",
   "thumbnail": "https://i.imgur.com/asXjia1.jpg",
   "color": "#ebcc34",
   "tags": [

--- a/websites/P/puhutv/dist/metadata.json
+++ b/websites/P/puhutv/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "puhutv is een Turkse service voor entertainment en video op aanvraag!"
   },
   "url": "puhutv.com",
-  "version": "1.1.10",
-  "logo": "https://i.imgur.com/VrbaJUB.png",
+  "version": "1.1.11",
+  "logo": "https://i.imgur.com/Sgp6UhI.png",
   "thumbnail": "https://i.imgur.com/PPc6zIe.png",
   "color": "#232527",
   "tags": [

--- a/websites/P/pxls.space/dist/metadata.json
+++ b/websites/P/pxls.space/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Pxls.space is een kloon van het sociale experiment r / place uitgevoerd door het sociale platform Reddit op 1 april 2017. (April Fools Day) Na enkele weken wordt het canvas gereset en krijgt het een nieuwe vorm."
   },
   "url": "pxls.space",
-  "version": "1.0.4",
-  "logo": "https://i.imgur.com/XEH4agn.jpeg",
+  "version": "1.0.5",
+  "logo": "https://i.imgur.com/oOfAfMP.png",
   "thumbnail": "https://i.imgur.com/Lvi2tue.png",
   "color": "#F00",
   "tags": [

--- a/websites/R/R10.net/dist/metadata.json
+++ b/websites/R/R10.net/dist/metadata.json
@@ -10,8 +10,8 @@
     "www.r10.net",
     "r10.net"
   ],
-  "version": "1.3.7",
-  "logo": "https://i.imgur.com/IsKBdO9.png",
+  "version": "1.3.8",
+  "logo": "https://i.imgur.com/dhdxyGa.png",
   "thumbnail": "https://i.imgur.com/ZG9BMOz.png",
   "color": "#1EFF12",
   "tags": [

--- a/websites/R/RadioMe/dist/metadata.json
+++ b/websites/R/RadioMe/dist/metadata.json
@@ -17,8 +17,8 @@
     "radiome.at",
     "radiome.fr"
   ],
-  "version": "1.2.8",
-  "logo": "https://i.imgur.com/wJ7eXXs.png",
+  "version": "1.2.9",
+  "logo": "https://i.imgur.com/T3x7Qfp.png",
   "thumbnail": "https://i.imgur.com/qvQjHkl.png",
   "color": "#67e350",
   "tags": [

--- a/websites/R/Ranobelib/dist/metadata.json
+++ b/websites/R/Ranobelib/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "Website voor het lezen van ranobe in het Russisch"
   },
   "url": "ranobelib.me",
-  "version": "1.1.4",
-  "logo": "https://i.imgur.com/chW9ryh.png",
+  "version": "1.1.5",
+  "logo": "https://i.imgur.com/a0XPpFb.png",
   "thumbnail": "https://i.imgur.com/SXMD2Qw.png",
   "color": "#0099ff",
   "tags": [

--- a/websites/R/RedTube/dist/metadata.json
+++ b/websites/R/RedTube/dist/metadata.json
@@ -25,8 +25,8 @@
     "jp.redtube.com",
     "fr.redtube.com"
   ],
-  "version": "2.2.8",
-  "logo": "https://i.imgur.com/MlqNqGr.jpg",
+  "version": "2.2.9",
+  "logo": "https://i.imgur.com/YrWWEZC.png",
   "thumbnail": "https://i.imgur.com/6DD83q7.png",
   "color": "#af181f",
   "tags": [

--- a/websites/R/ResetEra/dist/metadata.json
+++ b/websites/R/ResetEra/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "ResetEra is het internet's belangrijkste video gaming forum bestemming. Een smakelijk assortiment van enthousiastelingen, journalisten, & ontwikkelaars."
   },
   "url": "www.resetera.com",
-  "version": "1.3.7",
-  "logo": "https://i.imgur.com/3avmZfi.png",
+  "version": "1.3.8",
+  "logo": "https://i.imgur.com/dOetdz1.png",
   "thumbnail": "https://i.imgur.com/5fDktqC.png",
   "color": "#8050BF",
   "tags": [

--- a/websites/R/Rockstar Games/dist/metadata.json
+++ b/websites/R/Rockstar Games/dist/metadata.json
@@ -6,9 +6,9 @@
     "id": "359755774873960450"
   },
   "category": "games",
-  "logo": "https://i.imgur.com/CIXf7iW.png",
+  "logo": "https://i.imgur.com/EYSTLt6.png",
   "thumbnail": "https://i.imgur.com/1pthcL3.png",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "color": "#fbff00",
   "tags": [
     "rockstargames",

--- a/websites/R/Rooster Teeth/dist/metadata.json
+++ b/websites/R/Rooster Teeth/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Rooster Teeth is een baanbrekend media- en entertainmentbedrijf dat verantwoordelijk is voor enkele van de grootste online series in de geschiedenis, zoals de bekroonde en langstlopende webserie, Red vs. Blue"
   },
   "url": "roosterteeth.com",
-  "version": "1.1.10",
-  "logo": "https://i.imgur.com/sxZnjmY.png",
+  "version": "1.1.11",
+  "logo": "https://i.imgur.com/Z2on4c9.png",
   "thumbnail": "https://i.imgur.com/BwJU788.png",
   "color": "#2c2420",
   "tags": [

--- a/websites/R/RunoPW/dist/metadata.json
+++ b/websites/R/RunoPW/dist/metadata.json
@@ -17,8 +17,8 @@
     "nl": "Vrienden maken en chatten met miljoenen in een virtuele wereld"
   },
   "url": "runo.pw",
-  "version": "2.1.7",
-  "logo": "https://i.imgur.com/utrvCGI.png",
+  "version": "2.1.8",
+  "logo": "https://i.imgur.com/0ZL1dXI.png",
   "thumbnail": "https://i.imgur.com/6CXFU3R.png",
   "color": "#ffff00",
   "tags": [

--- a/websites/S/SCP Wiki/dist/metadata.json
+++ b/websites/S/SCP Wiki/dist/metadata.json
@@ -35,8 +35,8 @@
     "scp-sandbox-3.wikidot.com",
     "www.scpwiki.com"
   ],
-  "version": "1.2.8",
-  "logo": "https://i.imgur.com/S00mP8l.png",
+  "version": "1.2.9",
+  "logo": "https://i.imgur.com/sZutlAu.png",
   "thumbnail": "https://i.imgur.com/el9c68A.png",
   "color": "#BB0011",
   "tags": [

--- a/websites/S/Senpa.io/dist/metadata.json
+++ b/websites/S/Senpa.io/dist/metadata.json
@@ -14,8 +14,8 @@
     "nl": "De beste Dual Agario Unblocked io Private Server."
   },
   "service": "Senpa.io",
-  "version": "1.4.5",
-  "logo": "https://i.imgur.com/kP7R8IU.png",
+  "version": "1.4.6",
+  "logo": "https://i.imgur.com/smf7r3R.png",
   "thumbnail": "https://i.imgur.com/R4BjG18.png",
   "color": "#e67bbe",
   "tags": [

--- a/websites/S/Speedtest/dist/metadata.json
+++ b/websites/S/Speedtest/dist/metadata.json
@@ -13,8 +13,8 @@
     "nl": "De wereldwijde breedbandsnelheidstest"
   },
   "service": "Speedtest",
-  "version": "1.0.4",
-  "logo": "https://i.imgur.com/MOxmNLG.png",
+  "version": "1.0.5",
+  "logo": "https://i.imgur.com/CFAKdIH.png",
   "thumbnail": "https://i.imgur.com/JXIDlOL.png",
   "color": "#141526",
   "tags": [

--- a/websites/S/Stadia/dist/metadata.json
+++ b/websites/S/Stadia/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Stadia is een door Google geëxploiteerde cloudgamingdienst. Er wordt geadverteerd dat het videogames kan streamen tot 4K-resolutie bij 60 frames per seconde met ondersteuning voor high-dynamic-range, naar spelers via de talrijke datacenters van het bedrijf over de hele wereld, op voorwaarde dat ze een internetverbinding met voldoende hoge snelheid gebruiken. Het is toegankelijk via de Google Chrome-webbrowser op desktopcomputers, Pixel-smartphones, ondersteunde smartphones van Samsung, OnePlus, Razer en Asus, evenals Chrome OS-tablets en Chromecast voor tv-ondersteuning."
   },
   "service": "Stadia",
-  "version": "1.0.8",
-  "logo": "https://i.imgur.com/DwoRFyw.png",
+  "version": "1.0.9",
+  "logo": "https://i.imgur.com/beLx5ko.png",
   "thumbnail": "https://i.imgur.com/CyujQo7.png",
   "color": "#0081FF",
   "tags": [

--- a/websites/S/StatusBot/dist/metadata.json
+++ b/websites/S/StatusBot/dist/metadata.json
@@ -14,8 +14,8 @@
     "nl": "Website presence integratie voor StatusBot"
   },
   "service": "StatusBot",
-  "version": "1.0.5",
-  "logo": "https://i.imgur.com/hZ0ONFr.png",
+  "version": "1.0.6",
+  "logo": "https://i.imgur.com/BxCWr4I.png",
   "thumbnail": "https://i.imgur.com/llMPFYn.png",
   "color": "#4e73df",
   "tags": [

--- a/websites/S/SteamPrices.com/dist/metadata.json
+++ b/websites/S/SteamPrices.com/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "SteamPrices.com is een website die iedereen in staat stelt prijzen te vergelijken tussen regio's, zoals de VS, UK, en nog veel meer."
   },
   "service": "SteamPrices.com",
-  "version": "1.0.6",
-  "logo": "https://i.imgur.com/L2jiSxb.png",
+  "version": "1.0.7",
+  "logo": "https://i.imgur.com/vza3ijj.png",
   "thumbnail": "https://i.imgur.com/bL4A5Re.png",
   "color": "#4277BC",
   "tags": [

--- a/websites/S/StopotS/dist/metadata.json
+++ b/websites/S/StopotS/dist/metadata.json
@@ -20,8 +20,8 @@
     "nl": "StopotS, het stop spel op het internet. Speel dit populaire spel gratis en zonder downloads."
   },
   "url": "stopots.com",
-  "version": "1.2.11",
-  "logo": "https://i.imgur.com/2LqhoUb.png",
+  "version": "1.2.12",
+  "logo": "https://i.imgur.com/ciqA1gc.png",
   "thumbnail": "https://i.imgur.com/Bg869KE.png",
   "color": "#FFBE55",
   "tags": [

--- a/websites/S/Streamlabs/dist/metadata.json
+++ b/websites/S/Streamlabs/dist/metadata.json
@@ -16,8 +16,8 @@
     "nl": "Streamlabs maakt de beste streaming software tools."
   },
   "service": "Streamlabs",
-  "version": "1.1.7",
-  "logo": "https://i.imgur.com/a2NN4ax.png",
+  "version": "1.1.8",
+  "logo": "https://i.imgur.com/LvPRxYG.png",
   "thumbnail": "https://i.imgur.com/IuULwTC.png",
   "color": "#80F5D2",
   "tags": [

--- a/websites/S/Stuff.co.nz/dist/metadata.json
+++ b/websites/S/Stuff.co.nz/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Nieuws uit Nieuw-Zeeland en de wereld: het laatste nieuws, video's, sport, rugby, politiek, zaken, entertainment, lifestyle, reizen en onroerend goed."
   },
   "service": "Stuff.co.nz",
-  "version": "1.2.7",
-  "logo": "https://i.imgur.com/BvHIX05.png",
+  "version": "1.2.8",
+  "logo": "https://i.imgur.com/g1ncFAD.png",
   "thumbnail": "https://i.imgur.com/BvUwqSy.png",
   "color": "#000000",
   "tags": [

--- a/websites/S/surviv.io/dist/metadata.json
+++ b/websites/S/surviv.io/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Hou je van games zoals Player Unknown's Battlegrounds (PUBG), Fortnite of Apex Legends? Speel dit gratis 2d battle royale io spel in je browser!"
   },
   "url": "surviv.io",
-  "version": "1.3.8",
-  "logo": "https://i.imgur.com/L5tTe5e.png",
+  "version": "1.3.9",
+  "logo": "https://i.imgur.com/85KSQGS.png",
   "thumbnail": "https://i.imgur.com/eTT4eEI.png",
   "color": "#83AF50",
   "tags": [

--- a/websites/T/TCRF/dist/metadata.json
+++ b/websites/T/TCRF/dist/metadata.json
@@ -10,9 +10,9 @@
     "nl": "The Cutting Room Floor is een site gewijd aan het opgraven en onderzoeken van ongebruikte en geknipte inhoud uit videogames."
   },
   "url": "tcrf.net",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "thumbnail": "https://i.imgur.com/Q1bzBtD.png",
-  "logo": "https://i.imgur.com/uyVNYME.png",
+  "logo": "https://i.imgur.com/huRGBxt.png",
   "color": "#D3D3D3",
   "tags": [
     "games",

--- a/websites/T/TV Tropes/dist/metadata.json
+++ b/websites/T/TV Tropes/dist/metadata.json
@@ -9,8 +9,8 @@
     "en": "TV Tropes, the all-devouring pop-culture wiki, catalogs and cross-references recurrent plot devices, archetypes, and tropes in all forms of media."
   },
   "url": "tvtropes.org",
-  "version": "1.0.3",
-  "logo": "https://i.imgur.com/XpiG2Uo.png",
+  "version": "1.0.4",
+  "logo": "https://i.imgur.com/Ms5CNEN.png",
   "thumbnail": "https://i.imgur.com/gNn3Ya7.png",
   "color": "#28323C",
   "tags": [

--- a/websites/T/Take B1nzy To Space/dist/metadata.json
+++ b/websites/T/Take B1nzy To Space/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Reis door de ruimte terwijl je naar geweldige muziek luistert op een website die is ontwikkeld door voormalige Discord-medewerkers en Senior Ratelimiter B1nzy!"
   },
   "service": "Take B1nzy To Space",
-  "version": "1.0.5",
-  "logo": "https://i.imgur.com/httSU0V.png",
+  "version": "1.0.6",
+  "logo": "https://i.imgur.com/ej5mly9.png",
   "thumbnail": "https://i.imgur.com/Zf7Dl4W.png",
   "color": "#060A22",
   "tags": [

--- a/websites/T/Teknobuk/dist/metadata.json
+++ b/websites/T/Teknobuk/dist/metadata.json
@@ -14,8 +14,8 @@
     "nl": "Teknobuk is een technologieblog, net als Webtekno ve ShiftDelete.Net."
   },
   "service": "Teknobuk",
-  "version": "1.2.9",
-  "logo": "https://i.imgur.com/MwXwxFr.png",
+  "version": "1.2.10",
+  "logo": "https://i.imgur.com/QK47Q4Y.png",
   "thumbnail": "https://i.imgur.com/CngdOQf.png",
   "color": "#FABD1B",
   "tags": [

--- a/websites/T/Tesla/dist/metadata.json
+++ b/websites/T/Tesla/dist/metadata.json
@@ -13,8 +13,8 @@
     "www.tesla.com",
     "shop.tesla.com"
   ],
-  "version": "1.0.8",
-  "logo": "https://i.imgur.com/8FrVa6D.png",
+  "version": "1.0.9",
+  "logo": "https://i.imgur.com/jUwWZz8.png",
   "thumbnail": "https://i.imgur.com/20F9yxy.png",
   "color": "#E82127",
   "category": "other",

--- a/websites/T/Tidal/dist/metadata.json
+++ b/websites/T/Tidal/dist/metadata.json
@@ -21,8 +21,8 @@
     "nl": "Tidal is een muziekstreamdienst met een zeer hoge geluidskwaliteit."
   },
   "service": "Tidal",
-  "version": "2.0.11",
-  "logo": "https://i.imgur.com/clJrylu.jpg",
+  "version": "2.0.12",
+  "logo": "https://i.imgur.com/iew4pmk.png",
   "thumbnail": "https://i.imgur.com/UXbP7qG.png",
   "color": "#000000",
   "tags": [

--- a/websites/T/Tokopedia/dist/metadata.json
+++ b/websites/T/Tokopedia/dist/metadata.json
@@ -13,8 +13,8 @@
     "www.tokopedia.com",
     "seller.tokopedia.com"
   ],
-  "version": "1.0.4",
-  "logo": "https://i.imgur.com/SS97GWA.png",
+  "version": "1.0.5",
+  "logo": "https://i.imgur.com/oR93cDm.png",
   "thumbnail": "https://i.imgur.com/ixO23A2.png",
   "color": "#90ee90",
   "tags": [

--- a/websites/T/TryHackMe/dist/metadata.json
+++ b/websites/T/TryHackMe/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "TryHackMe haalt de pijn uit het leren en onderwijzen van cyberbeveiliging."
   },
   "service": "TryHackMe",
-  "version": "1.1.8",
-  "logo": "https://i.imgur.com/nYQ4R2R.png",
+  "version": "1.1.9",
+  "logo": "https://i.imgur.com/gqL7pDD.png",
   "thumbnail": "https://i.imgur.com/jojxLOU.png",
   "color": "#343C42",
   "tags": [

--- a/websites/T/Tsuki Mangás/dist/metadata.json
+++ b/websites/T/Tsuki Mangás/dist/metadata.json
@@ -17,8 +17,8 @@
     "nl": "Tsuki Mangás is een Braziliaanse manga-lezer; lees je favoriete manga's op je smartphone, tablet, computer of een ander apparaat. Sla je favoriete personages op en volg de nieuwste releases."
   },
   "service": "Tsuki Mangás",
-  "version": "1.4.5",
-  "logo": "https://i.imgur.com/WlUqy7l.png",
+  "version": "1.4.6",
+  "logo": "https://i.imgur.com/QZ1gTNi.png",
   "thumbnail": "https://i.imgur.com/01bTk7A.png",
   "color": "#161616",
   "tags": [

--- a/websites/T/Tweakers/dist/metadata.json
+++ b/websites/T/Tweakers/dist/metadata.json
@@ -7,9 +7,9 @@
   },
   "regExp": "([a-z0-9-]+[.])*tweakers[.]net[/]",
   "category": "other",
-  "logo": "https://i.imgur.com/z0QlXZS.png",
+  "logo": "https://i.imgur.com/k1GDxDq.png",
   "thumbnail": "https://i.imgur.com/jYndPxq.png",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "color": "#a11a3a",
   "tags": [
     "tweakers",

--- a/websites/T/TwitLonger/dist/metadata.json
+++ b/websites/T/TwitLonger/dist/metadata.json
@@ -10,8 +10,8 @@
     "nl": "Als je teveel praat voor Twitter."
   },
   "url": "www.twitlonger.com",
-  "version": "1.0.6",
-  "logo": "https://i.imgur.com/cneOazG.png",
+  "version": "1.0.7",
+  "logo": "https://i.imgur.com/Sl7M64D.png",
   "thumbnail": "https://i.imgur.com/Fx8VNFk.png",
   "color": "#428BCA",
   "tags": [

--- a/websites/T/top.gg/dist/metadata.json
+++ b/websites/T/top.gg/dist/metadata.json
@@ -18,8 +18,8 @@
     "nl": "Rich Presence voor top.gg - De grootste Discord Bot-lijst en meer"
   },
   "url": "top.gg",
-  "version": "1.3.13",
-  "logo": "https://i.imgur.com/fu207UB.png",
+  "version": "1.3.14",
+  "logo": "https://i.imgur.com/KzHXCRG.png",
   "thumbnail": "https://i.imgur.com/6RKANLa.png",
   "color": "#7289DA",
   "tags": [

--- a/websites/U/Uncyclopedia/dist/metadata.json
+++ b/websites/U/Uncyclopedia/dist/metadata.json
@@ -94,8 +94,8 @@
     "uncyclopedia.ca",
     "desciclopedia.ws"
   ],
-  "version": "1.4.7",
-  "logo": "https://i.imgur.com/IHeSBUA.png",
+  "version": "1.4.8",
+  "logo": "https://i.imgur.com/e8b5Yvs.png",
   "thumbnail": "https://i.imgur.com/jpqBDOR.png",
   "color": "#A1825C",
   "tags": [

--- a/websites/V/VRChat/dist/metadata.json
+++ b/websites/V/VRChat/dist/metadata.json
@@ -15,8 +15,8 @@
     "ga_IE": "Is éard atá i VRChat ardán sóisialta réaltachta fíorúil il-imreora ar líne saor in aisce. Ligeann sé d’imreoirí idirghníomhú le daoine eile mar mhúnlaí carachtar 3D."
   },
   "service": "VRChat",
-  "version": "1.0.9",
-  "logo": "https://i.imgur.com/2DIL3Qq.png",
+  "version": "1.0.10",
+  "logo": "https://i.imgur.com/J54T2Wn.png",
   "thumbnail": "https://i.imgur.com/PdmE1EK.png",
   "color": "#0B5286",
   "tags": [

--- a/websites/V/VUDU/dist/metadata.json
+++ b/websites/V/VUDU/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "Vudu distribueert lange films en tv-programma's naar apparaten met internetverbinding in de Verenigde Staten van Amerika."
   },
   "service": "VUDU",
-  "version": "1.1.8",
-  "logo": "https://i.imgur.com/ialSC46.png",
+  "version": "1.1.9",
+  "logo": "https://i.imgur.com/8mVkCk3.png",
   "thumbnail": "https://i.imgur.com/4z07lus.png",
   "color": "#236cba",
   "tags": [

--- a/websites/V/Virgin Media/dist/metadata.json
+++ b/websites/V/Virgin Media/dist/metadata.json
@@ -14,8 +14,8 @@
     "virginmedia.com",
     "www.virginmedia.com"
   ],
-  "version": "1.3.8",
-  "logo": "https://i.imgur.com/ucmvNa5.png",
+  "version": "1.3.9",
+  "logo": "https://i.imgur.com/dQ4c4gs.png",
   "thumbnail": "https://i.imgur.com/SE5FQlo.png",
   "color": "#ed0000",
   "tags": [

--- a/websites/W/WIRED/dist/metadata.json
+++ b/websites/W/WIRED/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "Een Amerikaans tijdschrift over wetenschap en technologie en een website."
   },
   "url": "www.wired.com",
-  "version": "1.2.9",
-  "logo": "https://i.imgur.com/Qjzo1W1.png",
+  "version": "1.2.10",
+  "logo": "https://i.imgur.com/gRExMjS.png",
   "thumbnail": "https://i.imgur.com/YWSISdY.png",
   "color": "#ffffff",
   "tags": [

--- a/websites/W/Wikipedia/dist/metadata.json
+++ b/websites/W/Wikipedia/dist/metadata.json
@@ -22,8 +22,8 @@
     "ga_IE": "Ciclipéid ilteangach ar líne é Wikipedia, bunaithe ar chomhoibriú oscailte trí chóras eagarthóireachta ábhar bunaithe ar wiki."
   },
   "url": "wikipedia.org",
-  "version": "2.7.10",
-  "logo": "https://i.imgur.com/JyyHKLB.png",
+  "version": "2.7.11",
+  "logo": "https://i.imgur.com/4OX6OZi.png",
   "thumbnail": "https://i.imgur.com/vJiuzZy.png",
   "color": "#f9f9f9",
   "tags": [

--- a/websites/W/Wish/dist/metadata.json
+++ b/websites/W/Wish/dist/metadata.json
@@ -12,8 +12,8 @@
     "nl": "Koop veel producten met 80% korting."
   },
   "url": "www.wish.com",
-  "version": "1.4.10",
-  "logo": "https://i.imgur.com/XsZ2IOn.jpg",
+  "version": "1.4.11",
+  "logo": "https://i.imgur.com/SMaNfT2.png",
   "thumbnail": "https://i.imgur.com/R7AkWiP.png",
   "color": "#48c0eb",
   "tags": [

--- a/websites/W/WolframAlpha/dist/metadata.json
+++ b/websites/W/WolframAlpha/dist/metadata.json
@@ -14,8 +14,8 @@
     "www.wolframalpha.com",
     "products.wolframalpha.com"
   ],
-  "version": "1.0.4",
-  "logo": "https://i.imgur.com/blEGmMK.png",
+  "version": "1.0.5",
+  "logo": "https://i.imgur.com/vrmnHwZ.png",
   "thumbnail": "https://i.imgur.com/M8EhvsC.png",
   "color": "#c24802",
   "tags": [

--- a/websites/W/WoolyPooly/dist/metadata.json
+++ b/websites/W/WoolyPooly/dist/metadata.json
@@ -14,8 +14,8 @@
     "nl": "WoolyPooly is een van de meest winstgevende pools met onze focus op minimale commissiekosten voor PPLNS & SOLO-beloningssystemen."
   },
   "url": "woolypooly.com",
-  "version": "1.1.5",
-  "logo": "https://i.imgur.com/X2sf9rc.png",
+  "version": "1.1.6",
+  "logo": "https://i.imgur.com/l9DGMzK.png",
   "thumbnail": "https://i.imgur.com/RVtEVMf.png",
   "color": "#3d89f5",
   "tags": [

--- a/websites/X/XVideos/dist/metadata.json
+++ b/websites/X/XVideos/dist/metadata.json
@@ -15,8 +15,8 @@
     "ga_IE": "Is seirbhís óstála saor in aisce é XVideos le haghaidh físeáin porn."
   },
   "url": "www.xvideos.com",
-  "version": "2.3.9",
-  "logo": "https://i.imgur.com/MU1dCvM.png",
+  "version": "2.3.10",
+  "logo": "https://i.imgur.com/3NVSLWV.png",
   "thumbnail": "https://i.imgur.com/RVcVhQy.png",
   "color": "#d90e15",
   "tags": [

--- a/websites/X/Xero.gg/dist/metadata.json
+++ b/websites/X/Xero.gg/dist/metadata.json
@@ -11,8 +11,8 @@
     "nl": "xero.gg is een website Player- en Clan-database voor een privéserver van het spel S4 League."
   },
   "url": "xero.gg",
-  "version": "1.1.6",
-  "logo": "https://i.imgur.com/7GG8BKZ.png",
+  "version": "1.1.7",
+  "logo": "https://i.imgur.com/opZJy1Y.png",
   "thumbnail": "https://i.imgur.com/zQcNcIm.png",
   "color": "#428DE3",
   "tags": [

--- a/websites/Y/YAGPDB/dist/metadata.json
+++ b/websites/Y/YAGPDB/dist/metadata.json
@@ -15,8 +15,8 @@
     "yagpdb.xyz",
     "docs.yagpdb.xyz"
   ],
-  "version": "1.2.8",
-  "logo": "https://i.imgur.com/h7A6CAX.png",
+  "version": "1.2.9",
+  "logo": "https://i.imgur.com/yQShI1r.png",
   "thumbnail": "https://i.imgur.com/7vDKD0t.png",
   "color": "#ec7760",
   "tags": [

--- a/websites/Y/Yay Animes/dist/metadata.json
+++ b/websites/Y/Yay Animes/dist/metadata.json
@@ -13,8 +13,8 @@
     "nl": "Yay Animes is een Braziliaanse website die gratis anime biedt om te bekijken of te downloaden."
   },
   "url": "yayanimes.net",
-  "version": "1.2.9",
-  "logo": "https://i.imgur.com/x0qBIc9.png",
+  "version": "1.2.10",
+  "logo": "https://i.imgur.com/m98ne7Q.png",
   "thumbnail": "https://i.imgur.com/mbVdXbm.png",
   "color": "#1759e7",
   "tags": [

--- a/websites/Y/YouTube Music/dist/metadata.json
+++ b/websites/Y/YouTube Music/dist/metadata.json
@@ -18,8 +18,8 @@
     "ga_IE": "Seirbhís nua ceoil le halbaim oifigiúla, singles, físeáin, remixes, léirithe beo agus go leor eile do Android, iOS agus deasc. Tá sé ar fad anseo."
   },
   "url": "music.youtube.com",
-  "version": "2.5.19",
-  "logo": "https://i.imgur.com/cIZnPDy.png",
+  "version": "2.5.20",
+  "logo": "https://i.imgur.com/xfrJwb7.png",
   "thumbnail": "https://i.imgur.com/iQ8MA50.png",
   "color": "#E40813",
   "tags": [

--- a/websites/Y/YouTube/dist/metadata.json
+++ b/websites/Y/YouTube/dist/metadata.json
@@ -66,8 +66,8 @@
     "www.youtube.com",
     "studio.youtube.com"
   ],
-  "version": "5.1.9",
-  "logo": "https://i.imgur.com/C9ZEmge.png",
+  "version": "5.1.10",
+  "logo": "https://i.imgur.com/ep50ocn.png",
   "thumbnail": "https://i.imgur.com/3QfIc5v.jpg",
   "color": "#E40813",
   "tags": [

--- a/websites/Y/Yu-Gi-Oh Top Decks/dist/metadata.json
+++ b/websites/Y/Yu-Gi-Oh Top Decks/dist/metadata.json
@@ -16,8 +16,8 @@
     "ga_IE": "Is bunachar sonraí de na liostaí deic is fearr é deiceanna barr Yu-Gi-Oh."
   },
   "url": "yugiohtopdecks.com",
-  "version": "1.2.8",
-  "logo": "https://i.imgur.com/cLWPY5e.png",
+  "version": "1.2.9",
+  "logo": "https://i.imgur.com/RPjfGtz.png",
   "thumbnail": "https://i.imgur.com/tXU27kB.jpg",
   "color": "#FFD700",
   "tags": [

--- a/websites/Z/Zoom/dist/metadata.json
+++ b/websites/Z/Zoom/dist/metadata.json
@@ -11,8 +11,8 @@
     "ga_IE": "Fan ceangailte cibé áit a théann tú - tosaigh nó bí i do chruinniú slán le físeán agus fuaim gan locht, comhroinnt scáileáin láithreach, agus teachtaireachtaí meandaracha tras-ardán - saor in aisce!"
   },
   "url": "zoom.us",
-  "version": "1.1.4",
-  "logo": "https://i.imgur.com/R4guHwc.png",
+  "version": "1.1.5",
+  "logo": "https://i.imgur.com/K1OGlrP.png",
   "thumbnail": "https://i.imgur.com/MJptA60.jpg",
   "color": "#0e71eb",
   "tags": [


### PR DESCRIPTION
I've updated the logos of 148 presences to comply with [CONTRIBUTING](https://github.com/PreMiD/Presences/blob/master/.github/CONTRIBUTING.md) file.
- Every presence has logo with 1:1 aspect ratio and resolution >= 512x512px.
- I didn't upscale the logos to distort them (exceptions below). I found a larger alternative or kept it without scaling on 512x512.
- Some logos may be different from the original ones due to logo changes on websites. (I was unsure when searching logo for Anime Soul, but I found some logo on their CDN and it looked similar to their Discord server icon)
- I did the double check to make sure that I've bumped the version of every modified presence but code review is highly appreciated.
- Prambors Radio has an open PR (#4705) but I think that it will be merged later so I'm taking version 1.3.5.

**Upscaled Logos**
| Presence    | Result Logo                                  |
| ----------- | -------------------------------------------- |
| AniTürk     | ![AniTürk](https://i.imgur.com/xg4r7tMb.png)  |
| BugMeNot    | ![BugMeNot](https://i.imgur.com/wRt2BfLb.png) |
| RunoPW      | ![RunoPW](https://i.imgur.com/0ZL1dXIb.png)   |