### PR TITLE
fix(YouTube Music): timestamp not working on firefox

### DIFF
--- a/websites/Y/YouTube Music/dist/metadata.json
+++ b/websites/Y/YouTube Music/dist/metadata.json
@@ -18,7 +18,7 @@
     "ga_IE": "Seirbhís nua ceoil le halbaim oifigiúla, singles, físeáin, remixes, léirithe beo agus go leor eile do Android, iOS agus deasc. Tá sé ar fad anseo."
   },
   "url": "music.youtube.com",
-  "version": "2.5.21",
+  "version": "2.6.0",
   "logo": "https://i.imgur.com/31gvH2b.png",
   "thumbnail": "https://i.imgur.com/iQ8MA50.png",
   "color": "#E40813",

--- a/websites/Y/YouTube Music/presence.ts
+++ b/websites/Y/YouTube Music/presence.ts
@@ -77,8 +77,8 @@ presence.on("UpdateData", async () => {
     time = await presence.getSetting("time");
   if (title !== "" && !isNaN(video.duration)) {
     const remainingLength =
-        Number(progressBar.ariaValueMax) * 1000 -
-        Number(progressBar.ariaValueNow) * 1000,
+        Number(progressBar.getAttribute("aria-valuemax")) * 1000 -
+        Number(progressBar.getAttribute("value")) * 1000,
       endTimestamp = Date.now() + remainingLength,
       [, watchID] = document
         .querySelector<HTMLAnchorElement>("a.ytp-title-link.yt-uix-sessionlink")


### PR DESCRIPTION
I've as well tested this on **Edge**.

## Before:
![image](https://user-images.githubusercontent.com/54318514/138039142-9bfc6c34-45ca-4d69-bec5-3448a8d3d98d.png)

## After:
![image](https://user-images.githubusercontent.com/54318514/138039150-5b196cba-0e1b-4081-abc7-e9ec6714bc25.png)
