### PR TITLE
Fix Platzi UI Changes

### DIFF
--- a/websites/P/Platzi/dist/metadata.json
+++ b/websites/P/Platzi/dist/metadata.json
@@ -11,7 +11,7 @@
     "nl": "Platzi is een van de beste Spaanse online studieplatforms, het helpt je te verbeteren en op de hoogte te blijven van nieuwe trends in je carrière."
   },
   "url": "platzi.com",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "logo": "https://i.imgur.com/TmaFMhm.jpg",
   "thumbnail": "https://i.imgur.com/wVy2Pqc.png",
   "color": "#98CA3F",

--- a/websites/P/Platzi/presence.ts
+++ b/websites/P/Platzi/presence.ts
@@ -199,20 +199,17 @@ presence.on("UpdateData", async () => {
     const course: HTMLAnchorElement = document.querySelector(
         ".Header-course-info-content a"
       ),
-      episodeNameHTML: string = document.querySelector(
-        ".Header-class-title h2"
-      ).outerHTML,
+      title: HTMLHeadingElement = document.querySelector(
+        ".Header-class-title h1"
+      ),
+      episodes: HTMLSpanElement = document.querySelector(
+        ".Header-class-title span"
+      ),
       video: HTMLVideoElement = document.querySelector(".vjs-tech"),
-      checkPause: HTMLElement = document.querySelector(".VideoPlayer > div");
+      checkPause: HTMLElement = document.querySelector(".VideoPlayer > div"),
+      episodeName: string = title.textContent,
+      [actualEpisode, finalEpisode]: string[] = episodes.textContent.split("/");
     let timestamps: number[];
-
-    const episodeNameHTMLSplitted: string[] = episodeNameHTML.split(">"),
-      episodeName: string = episodeNameHTMLSplitted[1].replace("<span", ""),
-      actualEpisode: string = episodeNameHTMLSplitted[2].replace(/[<!-]/gi, ""),
-      finalEpisode: string = episodeNameHTMLSplitted[4].replace(
-        /[/<span]/gi,
-        ""
-      );
 
     presenceData.details = `${episodeName} [${actualEpisode}/ ${finalEpisode}]`;
     presenceData.state = `${course.children[0].textContent}`;


### PR DESCRIPTION
This PR fixes #4814 
The problem was that Platzi changed its UI and the query selectors returned null.

Screenshots of the Presence working fine:

When the video is paused:
![image](https://user-images.githubusercontent.com/75707587/138623709-8f10747e-2740-490f-83d1-ccd5f9f53cf6.png)

When the video is running: 
![image](https://user-images.githubusercontent.com/75707587/138623764-7ad59984-0960-4994-866b-ed75194348dd.png)
