### PR TITLE
Fix Pandora Presence

### DIFF
--- a/websites/P/Pandora/dist/metadata.json
+++ b/websites/P/Pandora/dist/metadata.json
@@ -21,7 +21,7 @@
     "nl": "Speel de nummers, albums, afspeellijsten en podcasts af die je leuk vindt op de geheel nieuwe Pandora."
   },
   "url": "www.pandora.com",
-  "version": "1.2.9",
+  "version": "2.0.0",
   "logo": "https://i.imgur.com/Tt7iIYq.png",
   "thumbnail": "https://i.imgur.com/fRQo8Vc.png",
   "color": "#224099",

--- a/websites/P/Pandora/dist/metadata.json
+++ b/websites/P/Pandora/dist/metadata.json
@@ -8,6 +8,10 @@
     {
       "name": "Alanexei ✔",
       "id": "163319338403627008"
+    },
+    {
+      "name": "FireController#1847",
+      "id": "112732946774962176"
     }
   ],
   "service": "Pandora",
@@ -18,7 +22,7 @@
   },
   "url": "www.pandora.com",
   "version": "1.2.9",
-  "logo": "https://i.imgur.com/vA52VTl.png",
+  "logo": "https://i.imgur.com/Tt7iIYq.png",
   "thumbnail": "https://i.imgur.com/fRQo8Vc.png",
   "color": "#224099",
   "tags": [

--- a/websites/P/Pandora/dist/metadata.json
+++ b/websites/P/Pandora/dist/metadata.json
@@ -10,7 +10,7 @@
       "id": "163319338403627008"
     },
     {
-      "name": "FireController#1847",
+      "name": "FireController1847",
       "id": "112732946774962176"
     }
   ],

--- a/websites/P/Pandora/presence.ts
+++ b/websites/P/Pandora/presence.ts
@@ -42,8 +42,7 @@ presence.on("UpdateData", async () => {
       // Set them to the presence
       data.details = stripText(title, "Title");
       data.state = stripText(artist, "Artist");
-    } else
-      presence.error("Title and artist are null!");
+    } else presence.error("Title and artist are null!");
     
 
     // Fetch play button
@@ -71,17 +70,15 @@ presence.on("UpdateData", async () => {
             presence.timestampFromFormat(stripText(timeElapsed, "Time Elapsed")),
             presence.timestampFromFormat(stripText(timeRemaining, "Time Remaining"))
           );
-        } else
-          presence.error("Timestamps are null!");
+        } else presence.error("Timestamps are null!");
         
       } else {
         data.smallImageKey = "pause";
         data.smallImageText = (await strings).pause;
       }
-    } else
-      presence.error("Play button is null!");
+    } else presence.error("Play button is null!");
     
   }
 
-  presence.setActivity(data, isPlaying);
+  presence.setActivity(data);
 });

--- a/websites/P/Pandora/presence.ts
+++ b/websites/P/Pandora/presence.ts
@@ -20,69 +20,67 @@ function stripText(element: HTMLElement, id = "None", log = true) {
 
 presence.on("UpdateData", async () => {
   // Define presence data
-  const data: PresenceData = {};
-
-  // Set default data
-  data.details = "Browsing...";
-  data.largeImageKey = "pandora";
+  const data: PresenceData = {
+    details: "Browsing...",
+    largeImageKey: "pandora"
+  };
 
   // Define whether or not we're currently playing
-  const isPlaying = true,
+  let isPlaying = true;
 
   // Fetch audio bar
-   audioBar: HTMLElement = document.querySelector(".Tuner__Audio__NowPlayingHitArea");
+  const audioBar: HTMLElement = document.querySelector(".Tuner__Audio__NowPlayingHitArea");
   
   // If the audio bar exists, assume we're listening to something
-  if (audioBar !== null) {
+  if (audioBar) {
     // Fetch title and artist
     const title: HTMLElement = document.querySelector(".Tuner__Audio__TrackDetail__title"),
      artist: HTMLElement = document.querySelector(".Tuner__Audio__TrackDetail__artist");
 
-    // Return if either of them are null
-    if (title === null || artist === null) 
-      return;
-
-    // Set them to the presence
-    data.details = stripText(title, "Title");
-    data.state = stripText(artist, "Artist");
-
-    // Get duration control
-    const timeElapsed: HTMLElement = document.querySelector(".VolumeDurationControl__Duration [data-qa=elapsed_time]"),
-     timeRemaining: HTMLElement = document.querySelector(".VolumeDurationControl__Duration [data-qa=remaining_time]");
-
-    // Return if either are null
-    if (timeElapsed === null || timeRemaining === null) 
-      return;
+    // Only apply them to presence if they're not null
+    if (title !== null && artist !== null) {
+      // Set them to the presence
+      data.details = stripText(title, "Title");
+      data.state = stripText(artist, "Artist");
+    } else 
+      presence.error("Title and artist are null!");
+    
 
     // Fetch play button
     const playButton: HTMLElement = document.querySelector(".Tuner__Control__Play__Button");
 
     // Return if null
-    if (playButton === null) 
-      return;
+    if (playButton !== null) {
+      // Check if we're paused or playing
+      isPlaying = playButton.getAttribute("aria-checked") === "true";
 
-    // Check if we're paused or playing
-    const isPlaying = playButton.getAttribute("aria-checked") === "true";
+      // If we're not paused, set the small image to playing and fetch the timestamps
+      // Otherwise, set the small image to paused
+      if (isPlaying) {
+        data.smallImageKey = "play";
+        data.smallImageText = (await strings).play;
 
-    // If we're not paused, set the small image to playing and fetch the timestamps
-    // Otherwise, set the small image to paused
-    if (isPlaying) {
-      data.smallImageKey = "play";
-      data.smallImageText = (await strings).play;
+        // Get duration control
+        const timeElapsed: HTMLElement = document.querySelector(".VolumeDurationControl__Duration [data-qa=elapsed_time]"),
+              timeRemaining: HTMLElement = document.querySelector(".VolumeDurationControl__Duration [data-qa=remaining_time]");
 
-      // Get timestamps
-      const [startTime, endTime] = presence.getTimestamps(
-        presence.timestampFromFormat(stripText(timeElapsed, "Time Elapsed")),
-        presence.timestampFromFormat(stripText(timeRemaining, "Time Remaining"))
-      );
-
-      // Set timestamps
-      data.startTimestamp = startTime;
-      data.endTimestamp = endTime;
-    } else {
-      data.smallImageKey = "pause";
-      data.smallImageText = (await strings).pause;
-    }
+        // Return if either are null
+        if (timeElapsed !== null && timeRemaining !== null) {
+          // Get timestamps
+          [data.startTimestamp, data.endTimestamp] = presence.getTimestamps(
+            presence.timestampFromFormat(stripText(timeElapsed, "Time Elapsed")),
+            presence.timestampFromFormat(stripText(timeRemaining, "Time Remaining"))
+          );
+        } else 
+          presence.error("Timestamps are null!");
+        
+      } else {
+        data.smallImageKey = "pause";
+        data.smallImageText = (await strings).pause;
+      }
+    } else 
+      presence.error("Play button is null!");
+    
   }
 
   presence.setActivity(data, isPlaying);

--- a/websites/P/Pandora/presence.ts
+++ b/websites/P/Pandora/presence.ts
@@ -44,7 +44,6 @@ presence.on("UpdateData", async () => {
       data.state = stripText(artist, "Artist");
     } else presence.error("Title and artist are null!");
     
-
     // Fetch play button
     const playButton: HTMLElement = document.querySelector(".Tuner__Control__Play__Button");
 
@@ -71,13 +70,11 @@ presence.on("UpdateData", async () => {
             presence.timestampFromFormat(stripText(timeRemaining, "Time Remaining"))
           );
         } else presence.error("Timestamps are null!");
-        
       } else {
         data.smallImageKey = "pause";
         data.smallImageText = (await strings).pause;
       }
     } else presence.error("Play button is null!");
-    
   }
 
   presence.setActivity(data);

--- a/websites/P/Pandora/presence.ts
+++ b/websites/P/Pandora/presence.ts
@@ -42,7 +42,7 @@ presence.on("UpdateData", async () => {
       // Set them to the presence
       data.details = stripText(title, "Title");
       data.state = stripText(artist, "Artist");
-    } else 
+    } else
       presence.error("Title and artist are null!");
     
 
@@ -71,14 +71,14 @@ presence.on("UpdateData", async () => {
             presence.timestampFromFormat(stripText(timeElapsed, "Time Elapsed")),
             presence.timestampFromFormat(stripText(timeRemaining, "Time Remaining"))
           );
-        } else 
+        } else
           presence.error("Timestamps are null!");
         
       } else {
         data.smallImageKey = "pause";
         data.smallImageText = (await strings).pause;
       }
-    } else 
+    } else
       presence.error("Play button is null!");
     
   }

--- a/websites/P/Pandora/presence.ts
+++ b/websites/P/Pandora/presence.ts
@@ -18,8 +18,6 @@ function stripText(element: HTMLElement, id = "None", log = true) {
   }
 }
 
-let state;
-
 presence.on("UpdateData", async () => {
   // Define presence data
   const data: PresenceData = {};

--- a/websites/P/Pandora/presence.ts
+++ b/websites/P/Pandora/presence.ts
@@ -41,7 +41,6 @@ presence.on("UpdateData", async () => {
     // Return if either of them are null
     if (title === null || artist === null) 
       return;
-    
 
     // Set them to the presence
     data.details = stripText(title, "Title");
@@ -54,7 +53,6 @@ presence.on("UpdateData", async () => {
     // Return if either are null
     if (timeElapsed === null || timeRemaining === null) 
       return;
-    
 
     // Fetch play button
     const playButton: HTMLElement = document.querySelector(".Tuner__Control__Play__Button");
@@ -62,7 +60,6 @@ presence.on("UpdateData", async () => {
     // Return if null
     if (playButton === null) 
       return;
-    
 
     // Check if we're paused or playing
     const isPlaying = playButton.getAttribute("aria-checked") === "true";

--- a/websites/P/Pandora/presence.ts
+++ b/websites/P/Pandora/presence.ts
@@ -22,52 +22,52 @@ let state;
 
 presence.on("UpdateData", async () => {
   // Define presence data
-  let data: PresenceData = {};
+  const data: PresenceData = {};
 
   // Set default data
-  data.details = "Browsing..."
+  data.details = "Browsing...";
   data.largeImageKey = "pandora";
 
   // Define whether or not we're currently playing
-  let isPlaying: boolean = true;
+  const isPlaying = true,
 
   // Fetch audio bar
-  let audioBar: HTMLElement = document.querySelector(".Tuner__Audio__NowPlayingHitArea");
+   audioBar: HTMLElement = document.querySelector(".Tuner__Audio__NowPlayingHitArea");
   
   // If the audio bar exists, assume we're listening to something
   if (audioBar !== null) {
     // Fetch title and artist
-    let title: HTMLElement = document.querySelector(".Tuner__Audio__TrackDetail__title");
-    let artist: HTMLElement =  document.querySelector(".Tuner__Audio__TrackDetail__artist");
+    const title: HTMLElement = document.querySelector(".Tuner__Audio__TrackDetail__title"),
+     artist: HTMLElement = document.querySelector(".Tuner__Audio__TrackDetail__artist");
 
     // Return if either of them are null
-    if (title === null || artist === null) {
+    if (title === null || artist === null) 
       return;
-    }
+    
 
     // Set them to the presence
     data.details = stripText(title, "Title");
     data.state = stripText(artist, "Artist");
 
     // Get duration control
-    let timeElapsed: HTMLElement = document.querySelector(".VolumeDurationControl__Duration [data-qa=elapsed_time]");
-    let timeRemaining: HTMLElement = document.querySelector(".VolumeDurationControl__Duration [data-qa=remaining_time]");
+    const timeElapsed: HTMLElement = document.querySelector(".VolumeDurationControl__Duration [data-qa=elapsed_time]"),
+     timeRemaining: HTMLElement = document.querySelector(".VolumeDurationControl__Duration [data-qa=remaining_time]");
 
     // Return if either are null
-    if (timeElapsed == null || timeRemaining == null) {
+    if (timeElapsed === null || timeRemaining === null) 
       return;
-    }
+    
 
     // Fetch play button
-    let playButton: HTMLElement = document.querySelector(".Tuner__Control__Play__Button");
+    const playButton: HTMLElement = document.querySelector(".Tuner__Control__Play__Button");
 
     // Return if null
-    if (playButton === null) {
+    if (playButton === null) 
       return;
-    }
+    
 
     // Check if we're paused or playing
-    let isPlaying = playButton.getAttribute("aria-checked") === "true";
+    const isPlaying = playButton.getAttribute("aria-checked") === "true";
 
     // If we're not paused, set the small image to playing and fetch the timestamps
     // Otherwise, set the small image to paused
@@ -76,7 +76,7 @@ presence.on("UpdateData", async () => {
       data.smallImageText = (await strings).play;
 
       // Get timestamps
-      let [startTime, endTime] = presence.getTimestamps(
+      const [startTime, endTime] = presence.getTimestamps(
         presence.timestampFromFormat(stripText(timeElapsed, "Time Elapsed")),
         presence.timestampFromFormat(stripText(timeRemaining, "Time Remaining"))
       );

--- a/websites/P/Pandora/presence.ts
+++ b/websites/P/Pandora/presence.ts
@@ -11,7 +11,7 @@ function stripText(element: HTMLElement, id = "None", log = true) {
   else {
     if (log) {
       presence.error(
-        `An error occurred while stripping data off the page. Please contact Alanexei on the PreMiD Discord server, and send him a screenshot of this error. ID: ${id}`
+        `An error occurred while stripping data off the page. Please contact FireController1847 on the PreMiD Discord server, and send him a screenshot of this error. ID: ${id}`
       );
     }
     return null;
@@ -26,7 +26,7 @@ presence.on("UpdateData", async () => {
   };
 
   // Define whether or not we're currently playing
-  let isPlaying = true;
+  let isPlaying = false;
 
   // Fetch audio bar
   const audioBar: HTMLElement = document.querySelector(".Tuner__Audio__NowPlayingHitArea");


### PR DESCRIPTION
There have been many a' update since the Pandora presence was created, from the logo having changed to the way data is handled. In particular, I have Pandora Premium and noticed the presence was very incompatible with it (presuming the original creator did not have premium, so they couldn't test with it).

Previously, the presence would fetch an audio source off of the webpage and use that to fetch various pieces of information. The problem is, Pandora now obfuscates, encodes, and streams audio sources differently if you're not listening from a station but a playlist. So, I removed the dependency on the audio source entirely and instead made it entirely rely on the audio bar, of which the title and artist were already being fetched.

I love Pandora so I'm glad I was able to contribute to this, hopefully I rewrote it to an acceptable standard. Let me know if there's anything I can change.