### PR TITLE
Rewrite Duolingo from scratch

### DIFF
--- a/websites/D/Duolingo/dist/metadata.json
+++ b/websites/D/Duolingo/dist/metadata.json
@@ -1,31 +1,51 @@
 {
   "$schema": "https://schemas.premid.app/metadata/1.5",
+  "service": "Duolingo",
   "author": {
-    "name": "TheSlowly",
-    "id": "505071508851523599"
+    "name": "Luke",
+    "id": "279622919242514432"
+  },
+  "category": "other",
+  "logo": "https://i.imgur.com/YKAf42L.png",
+  "thumbnail": "https://i.imgur.com/gVq8HiS.png",
+  "version": "2.0.0",
+  "color": "#58cc02",
+  "tags": ["education", "games", "languages"],
+  "regExp": "(www|(\\w{2}-)?\\w{2})\\.duolingo\\.(com|cn)",
+  "url": "www.duolingo.com",
+  "description": {
+    "ar": "‏الطريقة الممتعة والفعّالة لتعلّم لغة جديدة!",
+    "cs": "Bezplatný, zábavný a účinný způsob, jak se naučit jazyk!",
+    "de": "Effektiv und kostenlos eine Sprache lernen – und dabei Spaß haben!",
+    "el": "Ο δωρεάν, διασκεδαστικός και αποτελεσματικός τρόπος να μάθεις μια ξένη γλώσσα!",
+    "en": "The free, fun, and effective way to learn a language!",
+    "es": "¡La forma divertida, efectiva y gratis de aprender un idioma!",
+    "fr": "La méthode amusante, gratuite et efficace pour apprendre une langue !",
+    "hi": "भाषा सीखने का मज़ेदार, मुफ़्त और असरदार तरीका!",
+    "hu": "Egy ingyenes, szórakoztató és hatékony módja a nyelvtanulásnak!",
+    "id": "Cara gratis, seru, dan efektif untuk belajar bahasa!",
+    "it": "Il metodo gratuito, divertente ed efficace per imparare le lingue!",
+    "ja": "無料で楽しく外国語を学ぼう",
+    "ko": "재미있고 효과적인 무료 언어 학습 방법!",
+    "nl": "De gratis, leuke en effectieve manier om een taal te leren!",
+    "pl": "Darmowy, ciekawy i skuteczny sposób na naukę języka!",
+    "pt": "O jeito grátis, divertido e eficaz de aprender um idioma!",
+    "ro": "Modul gratuit, amuzant și eficient de a învăța o limbă!",
+    "ru": "Учите языки бесплатно, весело и эффективно!",
+    "th": "วิธีการเรียนภาษาที่ฟรี สนุกและมีประสิทธิภาพ!",
+    "tr": "Ücretsiz, eğlenceli ve etkili dil öğrenme yolu!",
+    "uk": "Безкоштовний, веселий та ефективний спосіб вивчення мови!",
+    "vi": "Cách học ngôn ngữ miễn phí, vui nhộn và hiệu quả!",
+    "zh": "学习外语，寓教于乐"
   },
   "contributors": [
+    {
+      "name": "TheSlowly",
+      "id": "505071508851523599"
+    },
     {
       "name": "narpi",
       "id": "321665259842830336"
     }
-  ],
-  "service": "Duolingo",
-  "description": {
-    "en": "Languages can be learned in a playful way. Duolingo is 100% free, fun and scientifically proven.",
-    "de": "Sprachen können auf spielerische Weise erlernt werden. Duolingo ist 100% kostenlos, macht Spaß und ist wissenschaftlich belegt.",
-    "nl": "Talen kunnen op een speelse manier geleerd worden. Dit spel is 100% gratis, leuk en wetenschappelijk bewezen.",
-    "pt_BR": "As línguas podem ser aprendidas de forma lúdica. Duolingo é 100% grátis, divertido e cientificamente comprovado."
-  },
-  "url": "www.duolingo.com",
-  "version": "1.8.8",
-  "logo": "https://i.imgur.com/ETbwYrY.jpg",
-  "thumbnail": "https://i.imgur.com/rDHSj8L.png",
-  "color": "#8EE000",
-  "tags": [
-    "education",
-    "games",
-    "languages"
-  ],
-  "category": "other"
+  ]
 }

--- a/websites/D/Duolingo/dist/metadata.json
+++ b/websites/D/Duolingo/dist/metadata.json
@@ -14,19 +14,19 @@
   "regExp": "(www|(\\w{2}-)?\\w{2})\\.duolingo\\.(com|cn)",
   "url": "www.duolingo.com",
   "description": {
-    "ar": "‏الطريقة الممتعة والفعّالة لتعلّم لغة جديدة!",
-    "cs": "Bezplatný, zábavný a účinný způsob, jak se naučit jazyk!",
+    "ar_SA": "‏الطريقة الممتعة والفعّالة لتعلّم لغة جديدة!",
+    "cs_CZ": "Bezplatný, zábavný a účinný způsob, jak se naučit jazyk!",
     "de": "Effektiv und kostenlos eine Sprache lernen – und dabei Spaß haben!",
-    "el": "Ο δωρεάν, διασκεδαστικός και αποτελεσματικός τρόπος να μάθεις μια ξένη γλώσσα!",
+    "el_GR": "Ο δωρεάν, διασκεδαστικός και αποτελεσματικός τρόπος να μάθεις μια ξένη γλώσσα!",
     "en": "The free, fun, and effective way to learn a language!",
     "es": "¡La forma divertida, efectiva y gratis de aprender un idioma!",
     "fr": "La méthode amusante, gratuite et efficace pour apprendre une langue !",
-    "hi": "भाषा सीखने का मज़ेदार, मुफ़्त और असरदार तरीका!",
+    "hi_IN": "भाषा सीखने का मज़ेदार, मुफ़्त और असरदार तरीका!",
     "hu": "Egy ingyenes, szórakoztató és hatékony módja a nyelvtanulásnak!",
     "id": "Cara gratis, seru, dan efektif untuk belajar bahasa!",
     "it": "Il metodo gratuito, divertente ed efficace per imparare le lingue!",
-    "ja": "無料で楽しく外国語を学ぼう",
-    "ko": "재미있고 효과적인 무료 언어 학습 방법!",
+    "ja_JP": "無料で楽しく外国語を学ぼう",
+    "ko_KR": "재미있고 효과적인 무료 언어 학습 방법!",
     "nl": "De gratis, leuke en effectieve manier om een taal te leren!",
     "pl": "Darmowy, ciekawy i skuteczny sposób na naukę języka!",
     "pt": "O jeito grátis, divertido e eficaz de aprender um idioma!",
@@ -34,9 +34,9 @@
     "ru": "Учите языки бесплатно, весело и эффективно!",
     "th": "วิธีการเรียนภาษาที่ฟรี สนุกและมีประสิทธิภาพ!",
     "tr": "Ücretsiz, eğlenceli ve etkili dil öğrenme yolu!",
-    "uk": "Безкоштовний, веселий та ефективний спосіб вивчення мови!",
-    "vi": "Cách học ngôn ngữ miễn phí, vui nhộn và hiệu quả!",
-    "zh": "学习外语，寓教于乐"
+    "uk_UA": "Безкоштовний, веселий та ефективний спосіб вивчення мови!",
+    "vi_VN": "Cách học ngôn ngữ miễn phí, vui nhộn và hiệu quả!",
+    "zh_CN": "学习外语，寓教于乐"
   },
   "contributors": [
     {

--- a/websites/D/Duolingo/dist/metadata.json
+++ b/websites/D/Duolingo/dist/metadata.json
@@ -7,7 +7,7 @@
   },
   "category": "other",
   "logo": "https://i.imgur.com/YKAf42L.png",
-  "thumbnail": "https://i.imgur.com/gVq8HiS.png",
+  "thumbnail": "https://i.imgur.com/M3nbjZJ.png",
   "version": "2.0.0",
   "color": "#58cc02",
   "tags": ["education", "games", "languages"],

--- a/websites/D/Duolingo/presence.ts
+++ b/websites/D/Duolingo/presence.ts
@@ -95,29 +95,23 @@ function checkBasicPages(path: string[]): boolean {
     }
     presenceData.details = "Viewing the home page";
     return true;
-  }
-  if (INFO_PAGES.includes(path[0])) {
+  } else if (INFO_PAGES.includes(path[0])) {
     presenceData.details = `Viewing the ${path[0]} page`;
     return true;
-  }
-  if (path[0] === "courses") {
+  } else if (path[0] === "courses") {
     presenceData.details = "Viewing available courses";
     return true;
-  }
-  if (path[0] === "abc") {
+  } else if (path[0] === "abc") {
     presenceData.details = "Looking into Duolingo ABC";
     return true;
-  }
-  if (path[0] === "plus") {
+  } else if (path[0] === "plus") {
     presenceData.details = "Looking into Duolingo Plus";
     return true;
-  }
-  if (path[0] === "dictionary") {
+  } else if (path[0] === "dictionary") {
     presenceData.details = "Looking up a word";
     if (path.length >= 3) presenceData.state = `${path[1]}: ${path[2]}`;
     return true;
-  }
-  if (path[0] === "profile") {
+  } else if (path[0] === "profile") {
     if (path.length < 2) return true;
     presenceData.details = "Viewing a profile";
     [, presenceData.state] = path;
@@ -126,16 +120,13 @@ function checkBasicPages(path: string[]): boolean {
       presenceData.state += `'s ${path[2]}`;
     }
     return true;
-  }
-  if (path[0] === "friend-updates") {
+  } else if (path[0] === "friend-updates") {
     presenceData.details = "Viewing friend updates";
     return true;
-  }
-  if (path[0] === "user-search") {
+  } else if (path[0] === "user-search") {
     presenceData.details = "Searching for a user";
     return true;
-  }
-  if (path[0] === "settings") {
+  } else if (path[0] === "settings") {
     presenceData.details = "Adjusting settings";
     if (path.length >= 2) {
       let [, page] = path;
@@ -143,13 +134,11 @@ function checkBasicPages(path: string[]): boolean {
       presenceData.state = `Section: ${page}`;
     }
     return true;
-  }
-  if (document.title.startsWith("Error")) {
+  } else if (document.title.startsWith("Error")) {
     presenceData.details = "Watching Duo cry :(";
     presenceData.state = document.title;
     return true;
-  }
-  if (API_ENDPOINTS.includes(path[0])) {
+  } else if (API_ENDPOINTS.includes(path[0])) {
     presenceData.details = "Viewing an API response";
     presenceData.state = `Endpoint: /${path[0]}`;
     return true;
@@ -169,9 +158,9 @@ function checkLearningPages(path: string[]): boolean {
     // Update the language in case the user just logged in
     updateLanguage();
     return set("Choosing something to learn");
-  }
-  if (path[0] === "practice") return set("Practicing everything learned");
-  if (path[0] === "skill") {
+  } else if (path[0] === "practice")
+    return set("Practicing everything learned");
+  else if (path[0] === "skill") {
     if (path.length < 3) return;
 
     const lesson = path[2]
@@ -179,14 +168,13 @@ function checkLearningPages(path: string[]): boolean {
       .replace(/-(\d)/g, "$1");
     if (path.length >= 4) {
       if (path[3] === "tips") return set(`Reading tips for ${lesson}`);
-      if (path[3] === "practice") return set(`Practicing ${lesson}`);
-      if (path[3] === "test") return set(`Testing out of ${lesson}`);
+      else if (path[3] === "practice") return set(`Practicing ${lesson}`);
+      else if (path[3] === "test") return set(`Testing out of ${lesson}`);
     }
     return set(`In a lesson: ${lesson}`);
-  }
-  if (path[0] === "shop") return set("In the shop");
-  if (path[0] === "words") return set("Viewing all learned words");
-  if (path[0] === "stories") {
+  } else if (path[0] === "shop") return set("In the shop");
+  else if (path[0] === "words") return set("Viewing all learned words");
+  else if (path[0] === "stories") {
     if (path.length < 2) return set("Choosing a story to read");
 
     const selector = `body > ${"div > ".repeat(11)} .phrase`,
@@ -198,15 +186,15 @@ function checkLearningPages(path: string[]): boolean {
       return set(`Reading ${storyName}`);
     }
     return set("Reading a story");
-  }
-  if (path[0] === "mistakes-review") return set("Reviewing past mistakes");
-  if (path[0] === "checkpoint") {
+  } else if (path[0] === "mistakes-review")
+    return set("Reviewing past mistakes");
+  else if (path[0] === "checkpoint") {
     if (path.length < 4) return;
 
     const checkpoint = parseInt(path[2], 10) + 1;
     if (path[3] === "practice")
       return set(`Practicing Checkpoint ${checkpoint}`);
-    if (path[3] === "bigtest")
+    else if (path[3] === "bigtest")
       return set(`Taking the Checkpoint ${checkpoint} test`);
     return;
   }
@@ -222,16 +210,16 @@ function checkStartingPages(path: string[]): boolean {
   }
 
   if (path[0] === "register") return set("Choosing a language");
-  if (path[0] === "welcome") return set("Answering some questions");
-  if (path[0] === "placement") return set("Taking the placement test");
+  else if (path[0] === "welcome") return set("Answering some questions");
+  else if (path[0] === "placement") return set("Taking the placement test");
 
   return false;
 }
 
 function determineText(path: string[]) {
   if (checkBasicPages(path)) return;
-  if (checkLearningPages(path)) return;
-  if (checkStartingPages(path)) return;
+  else if (checkLearningPages(path)) return;
+  else if (checkStartingPages(path)) return;
 }
 
 presence.on("UpdateData", async () => {

--- a/websites/D/Duolingo/presence.ts
+++ b/websites/D/Duolingo/presence.ts
@@ -76,7 +76,7 @@ function checkBasicPages(path: string[]) {
         return;
     }
     if (path[0] === 'courses') {
-        presenceData.details = `Viewing available courses`;
+        presenceData.details = 'Viewing available courses';
         return;
     }
     if (path[0] === 'abc') {

--- a/websites/D/Duolingo/presence.ts
+++ b/websites/D/Duolingo/presence.ts
@@ -1,223 +1,232 @@
 const presence = new Presence({
     clientId: "909577563234508910"
-}),
-    FLAG_ICONS = [
-        "ar", "ca", "cs", "cy", "da", "de", "dn", "el",
-        "en", "eo", "es", "fr", "ga", "gn", "he", "hi",
-        "hu", "hv", "hw", "id", "it", "ja", "kl", "ko",
-        "nb", "nv", "pl", "pt", "ro", "ru", "sv", "sw",
-        "tr", "uk", "vi", "zs"
-    ],
-    INFO_PAGES = [
-        "approach",
-        "contact",
-        "efficacy",
-        "guidelines",
-        "info",
-        "mobile",
-        "privacy",
-        "team",
-        "terms"
-    ],
-    API_ENDPOINTS = [
-        "2017-06-30",
-        "api",
-        "friendships",
-        "login",
-        "switch_language",
-        "users",
-        "vocabulary"
-    ],
-    presenceData: PresenceData = {
-        largeImageKey: "icon",
-        startTimestamp: Math.floor(Date.now() / 1000)
-    },
-    language = { imageKey: "icon", name: "nothing (yet!)" };
+  }),
+  FLAG_ICONS = [
+    "ar",
+    "ca",
+    "cs",
+    "cy",
+    "da",
+    "de",
+    "dn",
+    "el",
+    "en",
+    "eo",
+    "es",
+    "fr",
+    "ga",
+    "gn",
+    "he",
+    "hi",
+    "hu",
+    "hv",
+    "hw",
+    "id",
+    "it",
+    "ja",
+    "kl",
+    "ko",
+    "nb",
+    "nv",
+    "pl",
+    "pt",
+    "ro",
+    "ru",
+    "sv",
+    "sw",
+    "tr",
+    "uk",
+    "vi",
+    "zs"
+  ],
+  INFO_PAGES = [
+    "approach",
+    "contact",
+    "efficacy",
+    "guidelines",
+    "info",
+    "mobile",
+    "privacy",
+    "team",
+    "terms"
+  ],
+  API_ENDPOINTS = [
+    "2017-06-30",
+    "api",
+    "friendships",
+    "login",
+    "switch_language",
+    "users",
+    "vocabulary"
+  ],
+  presenceData: PresenceData = {
+    largeImageKey: "icon",
+    startTimestamp: Math.floor(Date.now() / 1000)
+  },
+  language = { imageKey: "icon", name: "nothing (yet!)" };
 
 function updateLanguage() {
-    const state = JSON.parse(window.localStorage.getItem("duo.state")),
-        courseId = state?.user?.currentCourseId;
-    if (!courseId)
-        return;
+  const state = JSON.parse(window.localStorage.getItem("duo.state")),
+    courseId = state?.user?.currentCourseId;
+  if (!courseId) return;
 
-    const course = state.courses?.[courseId];
-    if (!course)
-        return;
+  const course = state.courses?.[courseId];
+  if (!course) return;
 
-    const languageId = course.learningLanguage;
-    if (FLAG_ICONS.includes(languageId))
-        language.imageKey = `flag_${languageId}`;
-    else if (languageId)
-        language.imageKey = "flag_unknown";
-    else
-        language.imageKey = "icon";
-    language.name = course.title ?? "nothing (yet!)";
+  const languageId = course.learningLanguage;
+  if (FLAG_ICONS.includes(languageId)) language.imageKey = `flag_${languageId}`;
+  else if (languageId) language.imageKey = "flag_unknown";
+  else language.imageKey = "icon";
+  language.name = course.title ?? "nothing (yet!)";
 }
 updateLanguage();
 setInterval(updateLanguage, 1000);
 
 function checkBasicPages(path: string[]) {
-    if (path.length === 0) {
-        const url = new URL(document.location.href);
-        if (url.searchParams.get("isLoggingIn") === "true") {
-            presenceData.details = "Logging in";
-            return;
-        }
-        presenceData.details = "Viewing the home page";
-        return;
+  if (path.length === 0) {
+    const url = new URL(document.location.href);
+    if (url.searchParams.get("isLoggingIn") === "true") {
+      presenceData.details = "Logging in";
+      return;
     }
-    if (INFO_PAGES.includes(path[0])) {
-        presenceData.details = `Viewing the ${path[0]} page`;
-        return;
+    presenceData.details = "Viewing the home page";
+    return;
+  }
+  if (INFO_PAGES.includes(path[0])) {
+    presenceData.details = `Viewing the ${path[0]} page`;
+    return;
+  }
+  if (path[0] === "courses") {
+    presenceData.details = "Viewing available courses";
+    return;
+  }
+  if (path[0] === "abc") {
+    presenceData.details = "Looking into Duolingo ABC";
+    return;
+  }
+  if (path[0] === "plus") {
+    presenceData.details = "Looking into Duolingo Plus";
+    return;
+  }
+  if (path[0] === "dictionary") {
+    presenceData.details = "Looking up a word";
+    if (path.length >= 3) presenceData.state = `${path[1]}: ${path[2]}`;
+    return;
+  }
+  if (path[0] === "profile") {
+    if (path.length < 2) return;
+    presenceData.details = "Viewing a profile";
+    [, presenceData.state] = path;
+    if (path.length >= 3) {
+      presenceData.details += " section";
+      presenceData.state += `'s ${path[2]}`;
     }
-    if (path[0] === "courses") {
-        presenceData.details = "Viewing available courses";
-        return;
+    return;
+  }
+  if (path[0] === "friend-updates") {
+    presenceData.details = "Viewing friend updates";
+    return;
+  }
+  if (path[0] === "user-search") {
+    presenceData.details = "Searching for a user";
+    return;
+  }
+  if (path[0] === "settings") {
+    presenceData.details = "Adjusting settings";
+    if (path.length >= 2) {
+      let [, page] = path;
+      page = page.charAt(0).toUpperCase() + page.slice(1);
+      presenceData.state = `Section: ${page}`;
     }
-    if (path[0] === "abc") {
-        presenceData.details = "Looking into Duolingo ABC";
-        return;
-    }
-    if (path[0] === "plus") {
-        presenceData.details = "Looking into Duolingo Plus";
-        return;
-    }
-    if (path[0] === "dictionary") {
-        presenceData.details = "Looking up a word";
-        if (path.length >= 3)
-            presenceData.state = `${path[1]}: ${path[2]}`;
-        return;
-    }
-    if (path[0] === "profile") {
-        if (path.length < 2)
-            return;
-        presenceData.details = "Viewing a profile";
-        [, presenceData.state] = path;
-        if (path.length >= 3) {
-            presenceData.details += " section";
-            presenceData.state += `'s ${path[2]}`;
-        }
-        return;
-    }
-    if (path[0] === "friend-updates") {
-        presenceData.details = "Viewing friend updates";
-        return;
-    }
-    if (path[0] === "user-search") {
-        presenceData.details = "Searching for a user";
-        return;
-    }
-    if (path[0] === "settings") {
-        presenceData.details = "Adjusting settings";
-        if (path.length >= 2) {
-            let [, page] = path;
-            page = page.charAt(0).toUpperCase() + page.slice(1);
-            presenceData.state = `Section: ${page}`;
-
-        }
-        return;
-    }
-    if (document.title.startsWith("Error")) {
-        presenceData.details = "Watching Duo cry :(";
-        presenceData.state = document.title;
-        return;
-    }
-    if (API_ENDPOINTS.includes(path[0])) {
-        presenceData.details = "Viewing an API response";
-        presenceData.state = `Endpoint: /${path[0]}`;
-        return;
-    }
+    return;
+  }
+  if (document.title.startsWith("Error")) {
+    presenceData.details = "Watching Duo cry :(";
+    presenceData.state = document.title;
+    return;
+  }
+  if (API_ENDPOINTS.includes(path[0])) {
+    presenceData.details = "Viewing an API response";
+    presenceData.state = `Endpoint: /${path[0]}`;
+    return;
+  }
 }
 
 function checkLearningPages(path: string[]) {
-    function set(details: string) {
-        presenceData.details = details;
-        presenceData.state = `Learning ${language.name}`;
-    }
+  function set(details: string) {
+    presenceData.details = details;
+    presenceData.state = `Learning ${language.name}`;
+  }
 
-    if (path[0] === "learn") {
-        // Update the language in case the user just logged in
-        updateLanguage();
-        return set("Choosing something to learn");
-    }
-    if (path[0] === "practice")
-        return set("Practicing everything learned");
-    if (path[0] === "skill") {
-        if (path.length < 3)
-            return;
+  if (path[0] === "learn") {
+    // Update the language in case the user just logged in
+    updateLanguage();
+    return set("Choosing something to learn");
+  }
+  if (path[0] === "practice") return set("Practicing everything learned");
+  if (path[0] === "skill") {
+    if (path.length < 3) return;
 
-        const lesson = path[2]
-            .replace(/([a-z]+)([A-Z]|-\d)/g, "$1 $2")
-            .replace(/-(\d)/g, "$1");
-        if (path.length >= 4) {
-            if (path[3] === "tips")
-                return set(`Reading tips for ${lesson}`);
-            if (path[3] === "practice")
-                return set(`Practicing ${lesson}`);
-            if (path[3] === "test")
-                return set(`Testing out of ${lesson}`);
-        }
-        return set(`In a lesson: ${lesson}`);
+    const lesson = path[2]
+      .replace(/([a-z]+)([A-Z]|-\d)/g, "$1 $2")
+      .replace(/-(\d)/g, "$1");
+    if (path.length >= 4) {
+      if (path[3] === "tips") return set(`Reading tips for ${lesson}`);
+      if (path[3] === "practice") return set(`Practicing ${lesson}`);
+      if (path[3] === "test") return set(`Testing out of ${lesson}`);
     }
-    if (path[0] === "shop")
-        return set("In the shop");
-    if (path[0] === "words")
-        return set("Viewing all learned words");
-    if (path[0] === "stories") {
-        if (path.length < 2)
-            return set("Choosing a story to read");
+    return set(`In a lesson: ${lesson}`);
+  }
+  if (path[0] === "shop") return set("In the shop");
+  if (path[0] === "words") return set("Viewing all learned words");
+  if (path[0] === "stories") {
+    if (path.length < 2) return set("Choosing a story to read");
 
-        const selector = `body > ${"div > ".repeat(11)} .phrase`,
-            phrases = document.querySelectorAll(selector);
-        let storyName = "";
-        if (phrases.length !== 0) {
-            for (const phrase of phrases)
-                storyName += phrase.textContent;
-            return set(`Reading ${storyName}`);
-        }
-        return set("Reading a story");
+    const selector = `body > ${"div > ".repeat(11)} .phrase`,
+      phrases = document.querySelectorAll(selector);
+    let storyName = "";
+    if (phrases.length !== 0) {
+      for (const phrase of phrases) storyName += phrase.textContent;
+      return set(`Reading ${storyName}`);
     }
-    if (path[0] === "mistakes-review")
-        return set("Reviewing past mistakes");
-    if (path[0] === "checkpoint") {
-        if (path.length < 4)
-            return;
+    return set("Reading a story");
+  }
+  if (path[0] === "mistakes-review") return set("Reviewing past mistakes");
+  if (path[0] === "checkpoint") {
+    if (path.length < 4) return;
 
-        const checkpoint = parseInt(path[2], 10) + 1;
-        if (path[3] === "practice")
-            return set(`Practicing Checkpoint ${checkpoint}`);
-        if (path[3] === "bigtest")
-            return set(`Taking the Checkpoint ${checkpoint} test`);
-        return;
-    }
+    const checkpoint = parseInt(path[2], 10) + 1;
+    if (path[3] === "practice")
+      return set(`Practicing Checkpoint ${checkpoint}`);
+    if (path[3] === "bigtest")
+      return set(`Taking the Checkpoint ${checkpoint} test`);
+    return;
+  }
 }
 
 function checkStartingPages(path: string[]) {
-    function set(state: string) {
-        presenceData.details = "Getting started";
-        presenceData.state = state;
-    }
+  function set(state: string) {
+    presenceData.details = "Getting started";
+    presenceData.state = state;
+  }
 
-    if (path[0] === "register")
-        return set("Choosing a language");
-    if (path[0] === "welcome")
-        return set("Answering some questions");
-    if (path[0] === "placement")
-        return set("Taking the placement test");
+  if (path[0] === "register") return set("Choosing a language");
+  if (path[0] === "welcome") return set("Answering some questions");
+  if (path[0] === "placement") return set("Taking the placement test");
 }
 
 presence.on("UpdateData", async () => {
-    presenceData.smallImageKey = language.imageKey;
-    presenceData.smallImageText = `Learning ${language.name}`;
-    delete presenceData.details;
-    delete presenceData.state;
+  presenceData.smallImageKey = language.imageKey;
+  presenceData.smallImageText = `Learning ${language.name}`;
+  delete presenceData.details;
+  delete presenceData.state;
 
-    let path = decodeURI(window.location.pathname).split("/");
-    path = path.filter(p => p !== "");
+  let path = decodeURI(window.location.pathname).split("/");
+  path = path.filter((p) => p !== "");
 
-    checkBasicPages(path);
-    checkLearningPages(path);
-    checkStartingPages(path);
+  checkBasicPages(path);
+  checkLearningPages(path);
+  checkStartingPages(path);
 
-    presence.setActivity(presenceData);
+  presence.setActivity(presenceData);
 });

--- a/websites/D/Duolingo/presence.ts
+++ b/websites/D/Duolingo/presence.ts
@@ -1,62 +1,57 @@
 const presence = new Presence({
-    clientId: '909577563234508910',
-});
+    clientId: "909577563234508910"
+}),
+    FLAG_ICONS = [
+        "ar", "ca", "cs", "cy", "da", "de", "dn", "el",
+        "en", "eo", "es", "fr", "ga", "gn", "he", "hi",
+        "hu", "hv", "hw", "id", "it", "ja", "kl", "ko",
+        "nb", "nv", "pl", "pt", "ro", "ru", "sv", "sw",
+        "tr", "uk", "vi", "zs"
+    ],
+    INFO_PAGES = [
+        "approach",
+        "contact",
+        "efficacy",
+        "guidelines",
+        "info",
+        "mobile",
+        "privacy",
+        "team",
+        "terms"
+    ],
+    API_ENDPOINTS = [
+        "2017-06-30",
+        "api",
+        "friendships",
+        "login",
+        "switch_language",
+        "users",
+        "vocabulary"
+    ],
+    presenceData: PresenceData = {
+        largeImageKey: "icon",
+        startTimestamp: Math.floor(Date.now() / 1000)
+    },
+    language = { imageKey: "icon", name: "nothing (yet!)" };
 
-const FLAG_ICONS = [
-    'ar', 'ca', 'cs', 'cy', 'da', 'de', 'dn', 'el',
-    'en', 'eo', 'es', 'fr', 'ga', 'gn', 'he', 'hi',
-    'hu', 'hv', 'hw', 'id', 'it', 'ja', 'kl', 'ko',
-    'nb', 'nv', 'pl', 'pt', 'ro', 'ru', 'sv', 'sw',
-    'tr', 'uk', 'vi', 'zs',
-];
-const INFO_PAGES = [
-    'approach',
-    'contact',
-    'efficacy',
-    'guidelines',
-    'info',
-    'mobile',
-    'privacy',
-    'team',
-    'terms',
-];
-const API_ENDPOINTS = [
-    '2017-06-30',
-    'api',
-    'friendships',
-    'login',
-    'switch_language',
-    'users',
-    'vocabulary',
-];
-
-const presenceData: PresenceData = {
-    largeImageKey: 'icon',
-    startTimestamp: Math.floor(Date.now() / 1000),
-};
-
-let language = { imageKey: 'icon', name: 'nothing (yet!)' };
 function updateLanguage() {
-    const state = JSON.parse(window.localStorage.getItem('duo.state'));
-    const courseId = state?.user?.currentCourseId;
-    if (!courseId) {
+    const state = JSON.parse(window.localStorage.getItem("duo.state")),
+        courseId = state?.user?.currentCourseId;
+    if (!courseId)
         return;
-    }
 
     const course = state.courses?.[courseId];
-    if (!course) {
+    if (!course)
         return;
-    }
 
     const languageId = course.learningLanguage;
-    if (FLAG_ICONS.includes(languageId)) {
+    if (FLAG_ICONS.includes(languageId))
         language.imageKey = `flag_${languageId}`;
-    } else if (languageId) {
-        language.imageKey = 'flag_unknown';
-    } else {
-        language.imageKey = 'icon';
-    }
-    language.name = course.title ?? 'nothing (yet!)';
+    else if (languageId)
+        language.imageKey = "flag_unknown";
+    else
+        language.imageKey = "icon";
+    language.name = course.title ?? "nothing (yet!)";
 }
 updateLanguage();
 setInterval(updateLanguage, 1000);
@@ -64,72 +59,71 @@ setInterval(updateLanguage, 1000);
 function checkBasicPages(path: string[]) {
     if (path.length === 0) {
         const url = new URL(document.location.href);
-        if (url.searchParams.get('isLoggingIn') === 'true') {
-            presenceData.details = 'Logging in';
+        if (url.searchParams.get("isLoggingIn") === "true") {
+            presenceData.details = "Logging in";
             return;
         }
-        presenceData.details = 'Viewing the home page';
+        presenceData.details = "Viewing the home page";
         return;
     }
     if (INFO_PAGES.includes(path[0])) {
         presenceData.details = `Viewing the ${path[0]} page`;
         return;
     }
-    if (path[0] === 'courses') {
-        presenceData.details = 'Viewing available courses';
+    if (path[0] === "courses") {
+        presenceData.details = "Viewing available courses";
         return;
     }
-    if (path[0] === 'abc') {
-        presenceData.details = 'Looking into Duolingo ABC';
+    if (path[0] === "abc") {
+        presenceData.details = "Looking into Duolingo ABC";
         return;
     }
-    if (path[0] === 'plus') {
-        presenceData.details = 'Looking into Duolingo Plus';
+    if (path[0] === "plus") {
+        presenceData.details = "Looking into Duolingo Plus";
         return;
     }
-    if (path[0] === 'dictionary') {
-        presenceData.details = 'Looking up a word';
-        if (path.length >= 3) {
+    if (path[0] === "dictionary") {
+        presenceData.details = "Looking up a word";
+        if (path.length >= 3)
             presenceData.state = `${path[1]}: ${path[2]}`;
-        }
         return;
     }
-    if (path[0] === 'profile') {
-        if (path.length < 2) {
+    if (path[0] === "profile") {
+        if (path.length < 2)
             return;
-        }
-        presenceData.details = 'Viewing a profile';
-        presenceData.state = path[1];
+        presenceData.details = "Viewing a profile";
+        [, presenceData.state] = path;
         if (path.length >= 3) {
-            presenceData.details += ' section';
+            presenceData.details += " section";
             presenceData.state += `'s ${path[2]}`;
         }
         return;
     }
-    if (path[0] === 'friend-updates') {
-        presenceData.details = 'Viewing friend updates';
+    if (path[0] === "friend-updates") {
+        presenceData.details = "Viewing friend updates";
         return;
     }
-    if (path[0] === 'user-search') {
-        presenceData.details = 'Searching for a user';
+    if (path[0] === "user-search") {
+        presenceData.details = "Searching for a user";
         return;
     }
-    if (path[0] === 'settings') {
-        presenceData.details = 'Adjusting settings';
+    if (path[0] === "settings") {
+        presenceData.details = "Adjusting settings";
         if (path.length >= 2) {
-            let page = path[1];
+            let [, page] = path;
             page = page.charAt(0).toUpperCase() + page.slice(1);
             presenceData.state = `Section: ${page}`;
+
         }
         return;
     }
-    if (document.title.startsWith('Error')) {
-        presenceData.details = 'Watching Duo cry :(';
+    if (document.title.startsWith("Error")) {
+        presenceData.details = "Watching Duo cry :(";
         presenceData.state = document.title;
         return;
     }
     if (API_ENDPOINTS.includes(path[0])) {
-        presenceData.details = 'Viewing an API response';
+        presenceData.details = "Viewing an API response";
         presenceData.state = `Endpoint: /${path[0]}`;
         return;
     }
@@ -141,101 +135,85 @@ function checkLearningPages(path: string[]) {
         presenceData.state = `Learning ${language.name}`;
     }
 
-    if (path[0] === 'learn') {
+    if (path[0] === "learn") {
         // Update the language in case the user just logged in
         updateLanguage();
-        return set('Choosing something to learn');
+        return set("Choosing something to learn");
     }
-    if (path[0] === 'practice') {
-        return set('Practicing everything learned');
-    }
-    if (path[0] === 'skill') {
-        if (path.length < 3) {
+    if (path[0] === "practice")
+        return set("Practicing everything learned");
+    if (path[0] === "skill") {
+        if (path.length < 3)
             return;
-        }
 
         const lesson = path[2]
-            .replace(/([a-z]+)([A-Z]|-\d)/g, '$1 $2')
-            .replace(/-(\d)/g, '$1');
+            .replace(/([a-z]+)([A-Z]|-\d)/g, "$1 $2")
+            .replace(/-(\d)/g, "$1");
         if (path.length >= 4) {
-            if (path[3] === 'tips') {
+            if (path[3] === "tips")
                 return set(`Reading tips for ${lesson}`);
-            }
-            if (path[3] === 'practice') {
+            if (path[3] === "practice")
                 return set(`Practicing ${lesson}`);
-            }
-            if (path[3] === 'test') {
+            if (path[3] === "test")
                 return set(`Testing out of ${lesson}`);
-            }
         }
         return set(`In a lesson: ${lesson}`);
     }
-    if (path[0] === 'shop') {
-        return set('In the shop');
-    }
-    if (path[0] === 'words') {
-        return set('Viewing all learned words');
-    }
-    if (path[0] === 'stories') {
-        if (path.length < 2) {
-            return set('Choosing a story to read');
-        }
+    if (path[0] === "shop")
+        return set("In the shop");
+    if (path[0] === "words")
+        return set("Viewing all learned words");
+    if (path[0] === "stories") {
+        if (path.length < 2)
+            return set("Choosing a story to read");
 
-        const selector = 'body > ' + 'div > '.repeat(11) + '.phrase';
-        const phrases = document.querySelectorAll(selector);
-        let storyName = '';
+        const selector = `body > ${"div > ".repeat(11)} .phrase`,
+            phrases = document.querySelectorAll(selector);
+        let storyName = "";
         if (phrases.length !== 0) {
-            for (const phrase of phrases) {
+            for (const phrase of phrases)
                 storyName += phrase.textContent;
-            }
             return set(`Reading ${storyName}`);
         }
-        return set('Reading a story');
+        return set("Reading a story");
     }
-    if (path[0] === 'mistakes-review') {
-        return set('Reviewing past mistakes');
-    }
-    if (path[0] === 'checkpoint') {
-        if (path.length < 4) {
+    if (path[0] === "mistakes-review")
+        return set("Reviewing past mistakes");
+    if (path[0] === "checkpoint") {
+        if (path.length < 4)
             return;
-        }
 
         const checkpoint = parseInt(path[2], 10) + 1;
-        if (path[3] === 'practice') {
+        if (path[3] === "practice")
             return set(`Practicing Checkpoint ${checkpoint}`);
-        }
-        if (path[3] === 'bigtest') {
+        if (path[3] === "bigtest")
             return set(`Taking the Checkpoint ${checkpoint} test`);
-        }
         return;
     }
 }
 
 function checkStartingPages(path: string[]) {
     function set(state: string) {
-        presenceData.details = 'Getting started';
+        presenceData.details = "Getting started";
         presenceData.state = state;
     }
 
-    if (path[0] === 'register') {
-        return set('Choosing a language');
-    }
-    if (path[0] === 'welcome') {
-        return set('Answering some questions');
-    }
-    if (path[0] === 'placement') {
-        return set('Taking the placement test');
-    }
+    if (path[0] === "register")
+        return set("Choosing a language");
+    if (path[0] === "welcome")
+        return set("Answering some questions");
+    if (path[0] === "placement")
+        return set("Taking the placement test");
 }
 
-presence.on('UpdateData', async () => {
+presence.on("UpdateData", async () => {
     presenceData.smallImageKey = language.imageKey;
     presenceData.smallImageText = `Learning ${language.name}`;
     delete presenceData.details;
     delete presenceData.state;
 
-    let path = decodeURI(window.location.pathname).split('/');
-    path = path.filter(p => p !== '');
+    let path = decodeURI(window.location.pathname).split("/");
+    path = path.filter(p => p !== "");
 
     checkBasicPages(path);
     checkLearningPages(path);

--- a/websites/D/Duolingo/presence.ts
+++ b/websites/D/Duolingo/presence.ts
@@ -63,7 +63,10 @@ const presence = new Presence({
     largeImageKey: "icon",
     startTimestamp: Math.floor(Date.now() / 1000)
   },
-  language = { imageKey: "icon", name: "nothing (yet!)" };
+  language = {
+    imageKey: null as string,
+    name: null as string
+  };
 
 function updateLanguage() {
   const state = JSON.parse(window.localStorage.getItem("duo.state")),
@@ -76,8 +79,8 @@ function updateLanguage() {
   const languageId = course.learningLanguage;
   if (FLAG_ICONS.includes(languageId)) language.imageKey = `flag_${languageId}`;
   else if (languageId) language.imageKey = "flag_unknown";
-  else language.imageKey = "icon";
-  language.name = course.title ?? "nothing (yet!)";
+  else language.imageKey = null;
+  language.name = course.title ?? null;
 }
 updateLanguage();
 setInterval(updateLanguage, 1000);
@@ -232,8 +235,13 @@ function determineText(path: string[]) {
 }
 
 presence.on("UpdateData", async () => {
-  presenceData.smallImageKey = language.imageKey;
-  presenceData.smallImageText = `Learning ${language.name}`;
+  if (!language.imageKey || !language.name) {
+    delete presenceData.smallImageKey;
+    delete presenceData.smallImageText;
+  } else {
+    presenceData.smallImageKey = language.imageKey;
+    presenceData.smallImageText = `Learning ${language.name}`;
+  }
   delete presenceData.details;
   delete presenceData.state;
 

--- a/websites/D/Duolingo/presence.ts
+++ b/websites/D/Duolingo/presence.ts
@@ -42,6 +42,7 @@ const presence = new Presence({
   INFO_PAGES = [
     "approach",
     "contact",
+    "cookies",
     "efficacy",
     "guidelines",
     "info",
@@ -84,6 +85,10 @@ function updateLanguage() {
 }
 updateLanguage();
 setInterval(updateLanguage, 1000);
+
+function capitalize(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
 
 function checkBasicPages(path: string[]): boolean {
   if (path.length === 0) {
@@ -129,9 +134,8 @@ function checkBasicPages(path: string[]): boolean {
   } else if (path[0] === "settings") {
     presenceData.details = "Adjusting settings";
     if (path.length >= 2) {
-      let [, page] = path;
-      page = page.charAt(0).toUpperCase() + page.slice(1);
-      presenceData.state = `Section: ${page}`;
+      const [, page] = path;
+      presenceData.state = `Section: ${capitalize(page)}`;
     }
     return true;
   } else if (document.title.startsWith("Error")) {
@@ -141,6 +145,20 @@ function checkBasicPages(path: string[]): boolean {
   } else if (API_ENDPOINTS.includes(path[0])) {
     presenceData.details = "Viewing an API response";
     presenceData.state = `Endpoint: /${path[0]}`;
+    return true;
+  } else if (path[0] === "log-in") {
+    presenceData.details = "Logging in";
+    return true;
+  } else if (["forgot_password", "reset_password"].includes(path[0])) {
+    presenceData.details = "Resetting their password";
+    return true;
+  } else if (path[0] === "course") {
+    presenceData.details = "Considering a course";
+    if (path.length < 4) return true;
+
+    const courseSplit = path[3].split("-");
+    if (courseSplit.length < 2) return true;
+    presenceData.state = capitalize(courseSplit[1]);
     return true;
   }
 

--- a/websites/D/Duolingo/presence.ts
+++ b/websites/D/Duolingo/presence.ts
@@ -1,92 +1,245 @@
 const presence = new Presence({
-    clientId: "612071822321647648"
-  }),
-  presenceData: PresenceData = {
-    largeImageKey: "logo"
-  },
-  pageData: PresenceData = {
-    largeImageKey: "logo"
-  },
-  lang = new Map();
-lang.set("de", "German");
-lang.set("es", "Spanish");
-lang.set("fr", "French");
-lang.set("ja", "Japanese");
-lang.set("it", "Italian");
-lang.set("ko", "Korean");
-lang.set("zs", "Chinese");
-lang.set("ru", "Russian");
-lang.set("pt", "Portuguese");
-lang.set("tr", "Turkish");
-lang.set("dn", "Dutch");
-lang.set("sv", "Swedish");
-lang.set("el", "Greek");
-lang.set("hi", "Hindi");
-lang.set("hv", "high valyrian");
-lang.set("ga", "Irish");
-lang.set("pl", "Polish");
-lang.set("he", "Hebrew");
-lang.set("nb", "Norwegian");
-lang.set("vi", "Vietnamese");
-lang.set("ar", "Arabic");
-lang.set("hw", "Hawaiian");
-lang.set("da", "Danish");
-lang.set("kl", "Klingon");
-lang.set("ro", "Romanian");
-lang.set("cs", "Czech");
-lang.set("sw", "Swahili");
-lang.set("cy", "Walsh");
-lang.set("id", "Indonesian");
-lang.set("hu", "Hungarian");
-lang.set("uk", "Ukrainian");
-lang.set("eo", "Esperanto");
-lang.set("nv", "Navajo");
-lang.set("en", "English");
+    clientId: '909577563234508910',
+});
 
-presence.on("UpdateData", async () => {
-  const path1 = document.location.pathname;
+const FLAG_ICONS = [
+    'ar', 'ca', 'cs', 'cy', 'da', 'de', 'dn', 'el',
+    'en', 'eo', 'es', 'fr', 'ga', 'gn', 'he', 'hi',
+    'hu', 'hv', 'hw', 'id', 'it', 'ja', 'kl', 'ko',
+    'nb', 'nv', 'pl', 'pt', 'ro', 'ru', 'sv', 'sw',
+    'tr', 'uk', 'vi', 'zs',
+];
+const INFO_PAGES = [
+    'approach',
+    'contact',
+    'efficacy',
+    'guidelines',
+    'info',
+    'mobile',
+    'privacy',
+    'team',
+    'terms',
+];
+const API_ENDPOINTS = [
+    '2017-06-30',
+    'api',
+    'friendships',
+    'login',
+    'switch_language',
+    'users',
+    'vocabulary',
+];
 
-  if (!path1.split("/")[2]) {
-    if (document.location.pathname.startsWith("/learn")) {
-      pageData.details = "Choosing level to learn..";
-      presence.setActivity(pageData);
-    } else if (document.location.pathname.startsWith("/shop")) {
-      pageData.details = "Browsing shop..";
-      presence.setActivity(pageData);
-    } else if (document.location.pathname.includes("/dictionary")) {
-      pageData.details = "Using dictionary..";
-      pageData.state = `Language: ${document.location.pathname.split("/")[2]}`;
-      presence.setActivity(pageData);
-    } else if (document.location.pathname.includes("/profile")) {
-      pageData.details = "Browsing profile..";
-      pageData.state = `Browsing: ${document.location.pathname.split("/")[2]}`;
-      presence.setActivity(pageData);
-    } else if (document.location.pathname.includes("/words")) {
-      presenceData.details = "Checking words...";
-      presenceData.largeImageKey = "logo";
-      presence.setActivity(presenceData);
-    } else if (
-      document.location.pathname === "/" ||
-      !document.location.pathname
-    )
-      presence.setActivity(pageData);
-  } else {
-    if (
-      path1.length > 1 &&
-      path1.split("/")[2] !== null &&
-      path1.split("/")[2].length === 2
-    ) {
-      let language: string;
-      for (const value of lang.keys()) {
-        if (path1.split("/")[2] === value) {
-          language = lang.get(value);
-          break;
-        }
-      }
-      presenceData.details = "Taking a lesson";
-      presenceData.state = `Language: ${language}`;
-      presenceData.largeImageKey = "logo";
-      presence.setActivity(presenceData);
+const presenceData: PresenceData = {
+    largeImageKey: 'icon',
+    startTimestamp: Math.floor(Date.now() / 1000),
+};
+
+let language = { imageKey: 'icon', name: 'nothing (yet!)' };
+function updateLanguage() {
+    const state = JSON.parse(window.localStorage.getItem('duo.state'));
+    const courseId = state?.user?.currentCourseId;
+    if (!courseId) {
+        return;
     }
-  }
+
+    const course = state.courses?.[courseId];
+    if (!course) {
+        return;
+    }
+
+    const languageId = course.learningLanguage;
+    if (FLAG_ICONS.includes(languageId)) {
+        language.imageKey = `flag_${languageId}`;
+    } else if (languageId) {
+        language.imageKey = 'flag_unknown';
+    } else {
+        language.imageKey = 'icon';
+    }
+    language.name = course.title ?? 'nothing (yet!)';
+}
+updateLanguage();
+setInterval(updateLanguage, 1000);
+
+function checkBasicPages(path: string[]) {
+    if (path.length === 0) {
+        const url = new URL(document.location.href);
+        if (url.searchParams.get('isLoggingIn') === 'true') {
+            presenceData.details = 'Logging in';
+            return;
+        }
+        presenceData.details = 'Viewing the home page';
+        return;
+    }
+    if (INFO_PAGES.includes(path[0])) {
+        presenceData.details = `Viewing the ${path[0]} page`;
+        return;
+    }
+    if (path[0] === 'courses') {
+        presenceData.details = `Viewing available courses`;
+        return;
+    }
+    if (path[0] === 'abc') {
+        presenceData.details = 'Looking into Duolingo ABC';
+        return;
+    }
+    if (path[0] === 'plus') {
+        presenceData.details = 'Looking into Duolingo Plus';
+        return;
+    }
+    if (path[0] === 'dictionary') {
+        presenceData.details = 'Looking up a word';
+        if (path.length >= 3) {
+            presenceData.state = `${path[1]}: ${path[2]}`;
+        }
+        return;
+    }
+    if (path[0] === 'profile') {
+        if (path.length < 2) {
+            return;
+        }
+        presenceData.details = 'Viewing a profile';
+        presenceData.state = path[1];
+        if (path.length >= 3) {
+            presenceData.details += ' section';
+            presenceData.state += `'s ${path[2]}`;
+        }
+        return;
+    }
+    if (path[0] === 'friend-updates') {
+        presenceData.details = 'Viewing friend updates';
+        return;
+    }
+    if (path[0] === 'user-search') {
+        presenceData.details = 'Searching for a user';
+        return;
+    }
+    if (path[0] === 'settings') {
+        presenceData.details = 'Adjusting settings';
+        if (path.length >= 2) {
+            let page = path[1];
+            page = page.charAt(0).toUpperCase() + page.slice(1);
+            presenceData.state = `Section: ${page}`;
+        }
+        return;
+    }
+    if (document.title.startsWith('Error')) {
+        presenceData.details = 'Watching Duo cry :(';
+        presenceData.state = document.title;
+        return;
+    }
+    if (API_ENDPOINTS.includes(path[0])) {
+        presenceData.details = 'Viewing an API response';
+        presenceData.state = `Endpoint: /${path[0]}`;
+        return;
+    }
+}
+
+function checkLearningPages(path: string[]) {
+    function set(details: string) {
+        presenceData.details = details;
+        presenceData.state = `Learning ${language.name}`;
+    }
+
+    if (path[0] === 'learn') {
+        // Update the language in case the user just logged in
+        updateLanguage();
+        return set('Choosing something to learn');
+    }
+    if (path[0] === 'practice') {
+        return set('Practicing everything learned');
+    }
+    if (path[0] === 'skill') {
+        if (path.length < 3) {
+            return;
+        }
+
+        const lesson = path[2]
+            .replace(/([a-z]+)([A-Z]|-\d)/g, '$1 $2')
+            .replace(/-(\d)/g, '$1');
+        if (path.length >= 4) {
+            if (path[3] === 'tips') {
+                return set(`Reading tips for ${lesson}`);
+            }
+            if (path[3] === 'practice') {
+                return set(`Practicing ${lesson}`);
+            }
+            if (path[3] === 'test') {
+                return set(`Testing out of ${lesson}`);
+            }
+        }
+        return set(`In a lesson: ${lesson}`);
+    }
+    if (path[0] === 'shop') {
+        return set('In the shop');
+    }
+    if (path[0] === 'words') {
+        return set('Viewing all learned words');
+    }
+    if (path[0] === 'stories') {
+        if (path.length < 2) {
+            return set('Choosing a story to read');
+        }
+
+        const selector = 'body > ' + 'div > '.repeat(11) + '.phrase';
+        const phrases = document.querySelectorAll(selector);
+        let storyName = '';
+        if (phrases.length !== 0) {
+            for (const phrase of phrases) {
+                storyName += phrase.textContent;
+            }
+            return set(`Reading ${storyName}`);
+        }
+        return set('Reading a story');
+    }
+    if (path[0] === 'mistakes-review') {
+        return set('Reviewing past mistakes');
+    }
+    if (path[0] === 'checkpoint') {
+        if (path.length < 4) {
+            return;
+        }
+
+        const checkpoint = parseInt(path[2]) + 1;
+        if (path[3] === 'practice') {
+            return set(`Practicing Checkpoint ${checkpoint}`);
+        }
+        if (path[3] === 'bigtest') {
+            return set(`Taking the Checkpoint ${checkpoint} test`);
+        }
+        return;
+    }
+}
+
+function checkStartingPages(path: string[]) {
+    function set(state: string) {
+        presenceData.details = 'Getting started';
+        presenceData.state = state;
+    }
+
+    if (path[0] === 'register') {
+        return set('Choosing a language');
+    }
+    if (path[0] === 'welcome') {
+        return set('Answering some questions');
+    }
+    if (path[0] === 'placement') {
+        return set('Taking the placement test');
+    }
+}
+
+presence.on('UpdateData', async () => {
+    presenceData.smallImageKey = language.imageKey;
+    presenceData.smallImageText = `Learning ${language.name}`;
+    delete presenceData.details;
+    delete presenceData.state;
+
+    let path = decodeURI(window.location.pathname).split('/');
+    path = path.filter(p => p !== '');
+
+    checkBasicPages(path);
+    checkLearningPages(path);
+    checkStartingPages(path);
+
+    presence.setActivity(presenceData);
 });

--- a/websites/D/Duolingo/presence.ts
+++ b/websites/D/Duolingo/presence.ts
@@ -200,7 +200,7 @@ function checkLearningPages(path: string[]) {
             return;
         }
 
-        const checkpoint = parseInt(path[2]) + 1;
+        const checkpoint = parseInt(path[2], 10) + 1;
         if (path[3] === 'practice') {
             return set(`Practicing Checkpoint ${checkpoint}`);
         }


### PR DESCRIPTION
Hello! I noticed that the Duolingo presence wasn't nearly as good as it possibly could be, so I rewrote it (excuse the sloppy Photoshop job):

![Before to After](https://user-images.githubusercontent.com/64972126/141926174-66a08d77-18d5-41e5-87d0-2b2fc7e0b0e7.png)
([Full-res](https://i.imgur.com/40eeSrI.png) | [With website screenshots](https://i.imgur.com/BnwOZb6.png))

Specifically, this new version adds the following:

- Support for **many** more pages (literally everything I could find, from the basics like lessons/stories/shop/settings to more obscure pages like error pages and API responses)
- More information for pages that were already supported
- Support for all current (40) and future languages supported by Duolingo, compared to only 34 set languages supported by the old one
- Many general improvements to neatness
- A small image with the flag of the language you're learning and the name of the language when you hover over it
- Improved metadata with an updated thumbnail and color, URL regex for non-English subdomains, and descriptions for all languages that Duolingo has descriptions for
- A start timestamp which the old one didn't set for some reason

Unfortunately, this rewrite would require an exception to one of the contributing guidelines, specifically the one that disallows the use of `window.localStorage`. This property is read from once per second in the `updateLanguage` function:

```js
function updateLanguage() {
    const state = JSON.parse(window.localStorage.getItem('duo.state'));
    const courseId = state?.user?.currentCourseId;
    // ...
    const course = state.courses?.[courseId];
    // ...
}
updateLanguage();
setInterval(updateLanguage, 1000);
```

I've tried everything I could to get around this, but it looks like it's impossible to get the current Duolingo language on all pages without doing it this way. **I do not expect this exception to be granted**, but I figured it was worth a shot anyway. Without this, it wouldn't be possible (as far as I'm aware) to support all future languages, display the current language on most pages, or have that small image with the flag.

Besides that, everything should adhere to all of the contributor guidelines as far as I can tell. :smile: