### PR TITLE
ci: remove actions/cache

### DIFF
--- a/.github/workflows/SE.yml
+++ b/.github/workflows/SE.yml
@@ -14,11 +14,7 @@ jobs:
         uses: actions/setup-node@v2.4.1
         with:
           node-version: 16
-      - name: Restore CI Cache
-        uses: actions/cache@v2.1.6
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-12-${{ hashFiles('**/yarn.lock') }}
+          cache: "yarn"
       - name: Prep SE
         run: yarn
       - name: Start SE

--- a/.github/workflows/SV.yml
+++ b/.github/workflows/SV.yml
@@ -22,11 +22,7 @@ jobs:
         uses: actions/setup-node@v2.4.1
         with:
           node-version: 16
-      - name: Restore CI Cache
-        uses: actions/cache@v2.1.6
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-12-${{ hashFiles('**/yarn.lock') }}
+          cache: "yarn"
       - name: Prep SV
         run: yarn
       - name: Find Changed Files (direct push)


### PR DESCRIPTION
Closes #4950. This PR uses the cache feature built-in the setup-node action instead of a different action just for caching