### PR TITLE
Add Granblue Fantasy Wiki Presence

### DIFF
--- a/websites/G/Granblue Fantasy Wiki/dist/metadata.json
+++ b/websites/G/Granblue Fantasy Wiki/dist/metadata.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.5",
+  "author": {
+    "name": "Kyrie",
+    "id": "368399721494216706"
+  },
+  "service": "Granblue Fantasy Wiki",
+  "description": {
+    "en": "Granblue Fantasy Wiki!"
+  },
+  "url": "gbf.wiki",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/k5QiAPC.png",
+  "thumbnail": "https://i.imgur.com/3vIpCD7.png",
+  "color": "#2F4F7A",
+  "tags": [
+    "granblue",
+    "fantasy",
+    "gbf",
+    "wiki"
+  ],
+  "category": "anime"
+}

--- a/websites/G/Granblue Fantasy Wiki/dist/metadata.json
+++ b/websites/G/Granblue Fantasy Wiki/dist/metadata.json
@@ -6,7 +6,7 @@
   },
   "service": "Granblue Fantasy Wiki",
   "description": {
-    "en": "Granblue Fantasy Wiki!"
+    "en": "Granblue Fantasy Wiki"
   },
   "url": "gbf.wiki",
   "version": "1.0.0",

--- a/websites/G/Granblue Fantasy Wiki/presence.ts
+++ b/websites/G/Granblue Fantasy Wiki/presence.ts
@@ -1,0 +1,20 @@
+const presence = new Presence({
+    clientId: "914354609370329098"
+  }),
+  browsingStamp = Math.floor(Date.now() / 1000);
+
+presence.on("UpdateData", () => {
+  const presenceData: PresenceData = {
+    largeImageKey: "vyrnball"
+  };
+  presenceData.startTimestamp = browsingStamp;
+  
+  if (document.location.pathname === "/Main_Page")
+    presenceData.details = "Viewing Wiki home page";
+  else if (document.querySelector(".firstHeading") !== null) {
+    presenceData.details = "Viewing page:";
+    presenceData.state = document.querySelector(".firstHeading").textContent;
+  }
+
+  presence.setActivity(presenceData);
+});

--- a/websites/G/Granblue Fantasy Wiki/tsconfig.json
+++ b/websites/G/Granblue Fantasy Wiki/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/"
+  }
+}


### PR DESCRIPTION
I made a rich presence for the Granblue Fantasy Wiki (https://gbf.wiki/)  
Hope you can review the files and approve them
This presence was made thanks to Bas950's _Azur Lane Wiki_, and was modified for this page
Screenshots of the presence working:  
![image](https://user-images.githubusercontent.com/77577746/143765822-594a67d2-7d52-432f-82bb-cf6df05a81c4.png)
![image](https://user-images.githubusercontent.com/77577746/143765828-2ab7fa05-6c44-4d3b-a4eb-991440381c1d.png)

