### PR TITLE
AnimeSuge | Update URL and fix homepage not showing up on presence

### DIFF
--- a/websites/A/AnimeSuge/dist/metadata.json
+++ b/websites/A/AnimeSuge/dist/metadata.json
@@ -9,7 +9,7 @@
     "en": "AnimeSuge is a free streaming anime website that allows you to watch anime online in English subbed and dubbed."
   },
   "url": "animesuge.to",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "logo": "https://i.imgur.com/TQPRXrN.png",
   "thumbnail": "https://i.imgur.com/stBappT.png",
   "color": "#161616",

--- a/websites/A/AnimeSuge/dist/metadata.json
+++ b/websites/A/AnimeSuge/dist/metadata.json
@@ -8,8 +8,8 @@
   "description": {
     "en": "AnimeSuge is a free streaming anime website that allows you to watch anime online in English subbed and dubbed."
   },
-  "url": "animesuge.io",
-  "version": "1.0.3",
+  "url": "animesuge.to",
+  "version": "1.0.4",
   "logo": "https://i.imgur.com/TQPRXrN.png",
   "thumbnail": "https://i.imgur.com/stBappT.png",
   "color": "#161616",

--- a/websites/A/AnimeSuge/presence.ts
+++ b/websites/A/AnimeSuge/presence.ts
@@ -9,9 +9,7 @@ const presence = new Presence({
     "/contact": "Reading the contacts",
     "/user/settings": "Changing the settings",
     "/user/watchlist": "Looking at their watchlist",
-    "/user/import": "Importing their MAL list to Animesuge!"
-  },
-  pagesSearching: { [k: string]: string } = {
+    "/user/import": "Importing their MAL list to Animesuge!",
     "/": "At the homepage",
     "/newest": "Searching for the newest animes",
     "/updated": "Searching for recently updated animes",
@@ -50,7 +48,7 @@ presence.on("UpdateData", async () => {
       document.location.search.substring(1)
     ),
     timestamps = presence.getTimestamps(currentTime, timeEnd);
-  if (page in pagesSearching) {
+  if (page in pages) {
     data.details = pages[page];
     data.state = "Searching animes";
   } else if (page.includes("/anime")) {
@@ -71,7 +69,7 @@ presence.on("UpdateData", async () => {
     data.buttons = [
       {
         label: "Watch Episode",
-        url: `http://animesuge.io${page}`
+        url: `http://animesuge.to${page}`
       }
     ];
   } else if (page.includes("/genre")) {
@@ -106,5 +104,12 @@ presence.on("UpdateData", async () => {
     data.details = "Looking at an unknown page";
     data.state = "Unknown";
   }
-  if (data.details && data.state) presence.setActivity(data);
+  if (data.details && data.state)
+    presence.setActivity(data);
+  else 
+    presence.setActivity({
+      largeImageKey: "animesuge",
+      state: "aba",
+      details: "oba"
+    })
 });

--- a/websites/A/AnimeSuge/presence.ts
+++ b/websites/A/AnimeSuge/presence.ts
@@ -106,10 +106,4 @@ presence.on("UpdateData", async () => {
   }
   if (data.details && data.state)
     presence.setActivity(data);
-  else 
-    presence.setActivity({
-      largeImageKey: "animesuge",
-      state: "aba",
-      details: "oba"
-    })
 });


### PR DESCRIPTION
The AnimeSuge website changed it's URL to [animesuge.to](http://animesuge.to)
(Sorry for last commit, forgot to remove the code that i used to see what was causing the homepage to not show up on the presence)

Proof
![ezgif com-gif-maker (11)](https://user-images.githubusercontent.com/34542949/144708033-a19876d4-5f7b-4e0b-a7aa-a3bd4d6fbdf7.gif)
