### PR TITLE
Fixed issue #4998 and refactored, removed deprecated code

### DIFF
--- a/websites/S/Stadia/dist/metadata.json
+++ b/websites/S/Stadia/dist/metadata.json
@@ -4,6 +4,12 @@
     "name": "Alexx",
     "id": "604453403640463371"
   },
+  "contributors": [
+    {
+      "name": "Pjoottr",
+      "id": "906309000465903697"
+    }
+  ],
   "url": "stadia.google.com",
   "description": {
     "en": "Stadia is a cloud gaming service operated by Google. It is advertised to be capable of streaming video games up to 4K resolution at 60 frames per second with support for high-dynamic-range, to players via the company's numerous data centers across the globe, provided they are using a sufficiently high-speed internet connection. It is accessible through the Google Chrome web browser on desktop computers, Pixel smartphones, supported smartphones from Samsung, OnePlus, Razer and Asus, as well as Chrome OS tablets and Chromecast for TV support.",

--- a/websites/S/Stadia/dist/metadata.json
+++ b/websites/S/Stadia/dist/metadata.json
@@ -4,19 +4,13 @@
     "name": "Alexx",
     "id": "604453403640463371"
   },
-  "contributors": [
-    {
-      "name": "Pjoottr",
-      "id": "906309000465903697"
-    }
-  ],
   "url": "stadia.google.com",
   "description": {
     "en": "Stadia is a cloud gaming service operated by Google. It is advertised to be capable of streaming video games up to 4K resolution at 60 frames per second with support for high-dynamic-range, to players via the company's numerous data centers across the globe, provided they are using a sufficiently high-speed internet connection. It is accessible through the Google Chrome web browser on desktop computers, Pixel smartphones, supported smartphones from Samsung, OnePlus, Razer and Asus, as well as Chrome OS tablets and Chromecast for TV support.",
     "nl": "Stadia is een door Google geëxploiteerde cloudgamingdienst. Er wordt geadverteerd dat het videogames kan streamen tot 4K-resolutie bij 60 frames per seconde met ondersteuning voor high-dynamic-range, naar spelers via de talrijke datacenters van het bedrijf over de hele wereld, op voorwaarde dat ze een internetverbinding met voldoende hoge snelheid gebruiken. Het is toegankelijk via de Google Chrome-webbrowser op desktopcomputers, Pixel-smartphones, ondersteunde smartphones van Samsung, OnePlus, Razer en Asus, evenals Chrome OS-tablets en Chromecast voor tv-ondersteuning."
   },
   "service": "Stadia",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "logo": "https://i.imgur.com/beLx5ko.png",
   "thumbnail": "https://i.imgur.com/CyujQo7.png",
   "color": "#0081FF",

--- a/websites/S/Stadia/presence.ts
+++ b/websites/S/Stadia/presence.ts
@@ -10,7 +10,7 @@ let gameName: HTMLElement,
 presence.on("UpdateData", async () => {
   const presenceData: PresenceData = {
     largeImageKey: "logo",
-    startTimestamp: browsingStamp,
+    startTimestamp: browsingStamp
   };
 
   if (document.location.pathname.includes("home")) {

--- a/websites/S/Stadia/presence.ts
+++ b/websites/S/Stadia/presence.ts
@@ -10,10 +10,10 @@ let gameName: HTMLElement,
 presence.on("UpdateData", async () => {
   const presenceData: PresenceData = {
     largeImageKey: "logo",
-    startTimestamp: browsingStamp
+    startTimestamp: browsingStamp,
   };
 
-  if (document.location.pathname === "/home") {
+  if (document.location.pathname.includes("home")) {
     presenceData.details = "Viewing Stadia Home";
     userName = document.querySelector("span.VY8blf.fSorq");
     presenceData.smallImageText = userName.innerText;

--- a/websites/S/Stadia/presence.ts
+++ b/websites/S/Stadia/presence.ts
@@ -32,7 +32,6 @@ presence.on("UpdateData", async () => {
   else presenceData.details = "Can't read page";
 
   if (!presenceData.details) {
-    presence.setTrayTitle();
     presence.setActivity();
   } else presence.setActivity(presenceData);
 });

--- a/websites/S/Stadia/presence.ts
+++ b/websites/S/Stadia/presence.ts
@@ -31,7 +31,6 @@ presence.on("UpdateData", async () => {
     presenceData.details = "Viewing Stadia Pro";
   else presenceData.details = "Can't read page";
 
-  if (!presenceData.details) {
-    presence.setActivity();
-  } else presence.setActivity(presenceData);
+  if (presenceData.details) presence.setActivity(presenceData);
+  else presence.setActivity();
 });


### PR DESCRIPTION
If you entered the site being a second user the URL structure would switch, from `stadia.com/home` to `stadia.com/u/1/home`, fixed by checking if the URL included home, then expect the user was at the home page, rather than looking for an exact URL match.

Before:
![image](https://user-images.githubusercontent.com/93800318/145031698-3b4cf55f-2ef2-43c2-adae-4eea28add64c.png)

After:
![image](https://user-images.githubusercontent.com/93800318/145031752-9412506a-630d-49f1-bfcd-364df33b8785.png)
