### PR TITLE
Update SiriusXM presence to fix channel name

### DIFF
--- a/websites/S/SiriusXM/dist/metadata.json
+++ b/websites/S/SiriusXM/dist/metadata.json
@@ -19,7 +19,7 @@
     "nl": "SiriusXM is iets wat je nog nooit gehoord hebt - het is een hele nieuwe wereld van radio. Stel je kanalen en kanalen voor van alles waar je naar wilt luisteren."
   },
   "service": "SiriusXM",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "logo": "https://i.imgur.com/WKHpLxp.jpg",
   "thumbnail": "https://i.imgur.com/kqez7xt.png",
   "color": "#0081FF",

--- a/websites/S/SiriusXM/presence.ts
+++ b/websites/S/SiriusXM/presence.ts
@@ -40,7 +40,7 @@ presence.on("UpdateData", async () => {
     const categoryTerm = document.querySelector("span.sxm-breadcrumb__text");
 
     presenceData.details = "Viewing Category: ";
-    presenceData.state = categoryTerm.TextContent;
+    presenceData.state = categoryTerm.textContent;
   } else presenceData.details = "Unknown page";
 
   if (document.querySelector(".sxm-player-controls.no-select")) {

--- a/websites/S/SiriusXM/presence.ts
+++ b/websites/S/SiriusXM/presence.ts
@@ -45,7 +45,7 @@ presence.on("UpdateData", async () => {
 
   if (document.querySelector(".sxm-player-controls.no-select")) {
     const data = {
-      channel: document.querySelector(".channel-number")?.textContent,
+      channel: document.querySelector(".channel-name")?.textContent,
       track: document.querySelector(".track-name")?.textContent ?? "Loading",
       artist: document.querySelector(".artist-name")?.textContent ?? "Loading"
     };


### PR DESCRIPTION
After the SiriusXM site updated, they moved channel name to a separate line.
This changed the channel name in Discord to the channel number which isn't very helpful.

Changing the target to ".channel-name" corrects this issue.