### PR TITLE
Fix "valid code detection" for Vukkybox

### DIFF
--- a/websites/V/Vukkybox/dist/metadata.json
+++ b/websites/V/Vukkybox/dist/metadata.json
@@ -8,7 +8,7 @@
     "category": "games",
     "logo": "https://i.imgur.com/dIpE7wX.png",
     "thumbnail": "https://i.imgur.com/uS5AFMi.png",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "color": "#5ea1c0",
     "tags": ["gacha", "game", "vukky", "vukkybox", "box", "litdevs", "vukkies"],
     "url": "vukkybox.com",

--- a/websites/V/Vukkybox/presence.ts
+++ b/websites/V/Vukkybox/presence.ts
@@ -63,9 +63,9 @@ presence.on("UpdateData", async () => {
     } to spend!`;
   } else if (document.location.pathname.includes("/redeem")) {
     presenceData.details = "Redeeming a coupon!";
-    if (document.getElementsByTagName("h1")[0].innerText.includes("sussy"))
-      presenceData.state = "Uh oh, the coupon is invalid!";
-    else presenceData.state = "Yay, its a valid coupon!";
+    if (document.body.style.backgroundImage == 'url("https://i.imgur.com/NlGok01.png")')
+      presenceData.state = "Yay, it's a valid coupon!";
+    else presenceData.state = "Uh oh, the coupon is invalid!";
   }
   if (presenceData.details) presence.setActivity(presenceData);
   else presence.setActivity();


### PR DESCRIPTION
Hi, Vukkybox developer here! We actually have multiple different pages for codes that are invalid in some way. The current presence only checks if the user tried to use a code that *they already claimed.* If you were to go to a code that never existed, or a limited-use code that has been "used up", it would say it's valid...?

![image](https://user-images.githubusercontent.com/46850780/145707777-5924040a-a613-45c4-93d1-12c6dc82dbfe.png)
![image](https://user-images.githubusercontent.com/46850780/145707780-a8cd0812-2e00-4d61-8a0d-2e41663adf99.png)


I've fixed this in the PR, thanks!