### PR TITLE
Add Stack Exchange Presence

### DIFF
--- a/websites/S/Stack Exchange/dist/metadata.json
+++ b/websites/S/Stack Exchange/dist/metadata.json
@@ -4,8 +4,8 @@
       "name": "AcidEpicice",
       "id": "249992970235936768"
     },
-    "url": ["stackexchange.com", "serverfault.com", "askubuntu.com", "superuser.com"],
-    "regExp": "(.*\\.)*(stackexchange\\.com|superuser\\.com|askubuntu\\.com|serverfault\\.com)",
+    "url": ["stackexchange.com", "serverfault.com", "superuser.com"],
+    "regExp": "(.*\\.)*(stackexchange\\.com|superuser\\.com|serverfault\\.com)",
     "description": {
       "en": "Stack Exchange is a network of question-and-answer websites on topics in diverse fields, each site covering a specific topic, where questions, answers, and users are subject to a reputation award process. The reputation system allows the sites to be self-moderating."
     },

--- a/websites/S/Stack Exchange/dist/metadata.json
+++ b/websites/S/Stack Exchange/dist/metadata.json
@@ -4,14 +4,14 @@
       "name": "AcidEpicice",
       "id": "249992970235936768"
     },
-    "url": "stackexchange.com",
-    "regExp": "(.*\\.)*stackexchange\\.com",
+    "url": ["stackexchange.com", "serverfault.com", "askubuntu.com", "superuser.com"],
+    "regExp": "(.*\\.)*stackexchange\\.com|superuser\\.com|askubuntu\\.com|serverfault\\.com",
     "description": {
       "en": "Stack Exchange is a network of question-and-answer websites on topics in diverse fields, each site covering a specific topic, where questions, answers, and users are subject to a reputation award process. The reputation system allows the sites to be self-moderating."
     },
     "service": "Stack Exchange",
     "version": "1.0.0",
-    "logo": "https://i.imgur.com/qHTJHmT.png",
+    "logo": "https://i.imgur.com/WCho2QO.png",
     "thumbnail": "https://i.imgur.com/Xax7CJQ.png",
     "color": "#1E5397",
     "tags": [

--- a/websites/S/Stack Exchange/dist/metadata.json
+++ b/websites/S/Stack Exchange/dist/metadata.json
@@ -5,7 +5,7 @@
       "id": "249992970235936768"
     },
     "url": ["stackexchange.com", "serverfault.com", "askubuntu.com", "superuser.com"],
-    "regExp": "(.*\\.)*stackexchange\\.com|superuser\\.com|askubuntu\\.com|serverfault\\.com",
+    "regExp": "(.*\\.)*(stackexchange\\.com|superuser\\.com|askubuntu\\.com|serverfault\\.com)",
     "description": {
       "en": "Stack Exchange is a network of question-and-answer websites on topics in diverse fields, each site covering a specific topic, where questions, answers, and users are subject to a reputation award process. The reputation system allows the sites to be self-moderating."
     },
@@ -14,6 +14,7 @@
     "logo": "https://i.imgur.com/WCho2QO.png",
     "thumbnail": "https://i.imgur.com/Xax7CJQ.png",
     "color": "#1E5397",
+    "category": "other",
     "tags": [
       "help",
       "community",
@@ -21,6 +22,5 @@
       "forum",
       "question",
       "answer"
-    ],
-    "category": "other"
+    ]
   }

--- a/websites/S/Stack Exchange/dist/metadata.json
+++ b/websites/S/Stack Exchange/dist/metadata.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://schemas.premid.app/metadata/1.5",
+    "author": {
+      "name": "AcidEpicice",
+      "id": "249992970235936768"
+    },
+    "url": "stackexchange.com",
+    "regExp": "(.*\\.)*stackexchange\\.com",
+    "description": {
+      "en": "Stack Exchange is a network of question-and-answer websites on topics in diverse fields, each site covering a specific topic, where questions, answers, and users are subject to a reputation award process. The reputation system allows the sites to be self-moderating."
+    },
+    "service": "Stack Exchange",
+    "version": "1.0.0",
+    "logo": "https://i.imgur.com/qHTJHmT.png",
+    "thumbnail": "https://i.imgur.com/Xax7CJQ.png",
+    "color": "#1E5397",
+    "tags": [
+      "help",
+      "community",
+      "discussion",
+      "forum",
+      "question",
+      "answer"
+    ],
+    "category": "other"
+  }

--- a/websites/S/Stack Exchange/presence.ts
+++ b/websites/S/Stack Exchange/presence.ts
@@ -1,69 +1,75 @@
 const presence = new Presence({
-    clientId: "919817726195814431",
+    clientId: "919817726195814431"
   }),
   startTimestamp = Math.floor(Date.now() / 1000);
 
 presence.on("UpdateData", async () => {
   const presenceData: PresenceData = {
       largeImageKey: "stackexchange",
-      startTimestamp,
+      startTimestamp
     },
     { pathname, hostname } = window.location;
 
-  if (hostname == "stackexchange.com") {
-    presenceData.details = "Browsing";
-  } else if (hostname == "serverfault.com") {
+  if (hostname === "stackexchange.com") presenceData.details = "Browsing";
+  else if (hostname === "serverfault.com") {
     presenceData.largeImageKey = "serverfault";
     presenceData.details = "Server Fault";
-  } else if (hostname == "meta.serverfault.com") {
+  } else if (hostname === "meta.serverfault.com") {
     presenceData.largeImageKey = "serverfault";
     presenceData.details = "Server Fault Meta";
-  } else if (hostname == "askubuntu.com") {
+  } else if (hostname === "askubuntu.com") {
     presenceData.largeImageKey = "askubuntu";
     presenceData.details = "Ask Ubuntu";
-  } else if (hostname == "meta.askubuntu.com") {
+  } else if (hostname === "meta.askubuntu.com") {
     presenceData.largeImageKey = "askubuntu";
     presenceData.details = "Ask Ubuntu Meta";
-  } else if (hostname == "superuser.com") {
+  } else if (hostname === "superuser.com") {
     presenceData.largeImageKey = "superuser";
     presenceData.details = "Super User";
-  } else if (hostname == "meta.superuser.com") {
+  } else if (hostname === "meta.superuser.com") {
     presenceData.largeImageKey = "superuser";
     presenceData.details = "Super User Meta";
   } else {
     const subStack = document.querySelector("meta[property='og:site_name']"),
       imageKey = hostname.replace(".stackexchange.com", "");
-    if (imageKey == "meta") {
-      presenceData.smallImageKey = imageKey;
-    } else {
-      presenceData.smallImageKey = imageKey.replace(".meta", "");
-    }
+    if (imageKey === "meta") presenceData.smallImageKey = imageKey;
+    else presenceData.smallImageKey = imageKey.replace(".meta", "");
+
     presenceData.smallImageText = subStack
       .getAttribute("content")
       .replace("Stack Exchange", "");
-    if (pathname.includes("/questions")) {
+    if (pathname.includes("/questions"))
       presenceData.details = "Reading a question";
-    }
   }
 
-  if (pathname == "/") {
+  if (pathname === "/") {
     if (
-      ["serverfault.com", "meta.serverfault.com", "superuser.com", "meta.superuser.com", "askubuntu.com", "meta.askubuntu.com"].includes(hostname)
-    ) {
+      [
+        "serverfault.com",
+        "meta.serverfault.com",
+        "superuser.com",
+        "meta.superuser.com",
+        "askubuntu.com",
+        "meta.askubuntu.com"
+      ].includes(hostname)
+    )
       presenceData.state = "Main Page";
-    } else {
-      presenceData.details = "Main Page";
-    }
+    else presenceData.details = "Main Page";
   } else if (pathname.includes("/questions")) {
     const titleElem = document.querySelector(".question-hyperlink");
     presenceData.state = titleElem.textContent;
   } else if (
-    ["serverfault.com", "meta.serverfault.com", "superuser.com", "meta.superuser.com", "askubuntu.com", "meta.askubuntu.com"].includes(hostname)
-  ) {
+    [
+      "serverfault.com",
+      "meta.serverfault.com",
+      "superuser.com",
+      "meta.superuser.com",
+      "askubuntu.com",
+      "meta.askubuntu.com"
+    ].includes(hostname)
+  )
     presenceData.state = "Browsing";
-  } else {
-    presenceData.details = "Browsing";
-  }
+  else presenceData.details = "Browsing";
 
   if (presenceData.details) presence.setActivity(presenceData);
   else presence.setActivity();

--- a/websites/S/Stack Exchange/presence.ts
+++ b/websites/S/Stack Exchange/presence.ts
@@ -1,12 +1,12 @@
 const presence = new Presence({
     clientId: "919817726195814431"
   }),
-  startTimestamp = Math.floor(Date.now() / 1000);
+  browsingTimestamp = Math.floor(Date.now() / 1000);
 
 presence.on("UpdateData", async () => {
   const presenceData: PresenceData = {
       largeImageKey: "stackexchange",
-      startTimestamp
+      startTimestamp: browsingTimestamp
     },
     { pathname, hostname } = window.location;
 
@@ -30,12 +30,11 @@ presence.on("UpdateData", async () => {
     presenceData.largeImageKey = "superuser";
     presenceData.details = "Super User Meta";
   } else {
-    const subStack = document.querySelector("meta[property='og:site_name']"),
-      imageKey = hostname.replace(".stackexchange.com", "");
+    const imageKey = hostname.replace(".stackexchange.com", "");
     if (imageKey === "meta") presenceData.smallImageKey = imageKey;
     else presenceData.smallImageKey = imageKey.replace(".meta", "");
 
-    presenceData.smallImageText = subStack
+    presenceData.smallImageText = document.querySelector("meta[property='og:site_name']")
       .getAttribute("content")
       .replace("Stack Exchange", "");
     if (pathname.includes("/questions"))
@@ -56,8 +55,7 @@ presence.on("UpdateData", async () => {
       presenceData.state = "Main Page";
     else presenceData.details = "Main Page";
   } else if (pathname.includes("/questions")) {
-    const titleElem = document.querySelector(".question-hyperlink");
-    presenceData.state = titleElem.textContent;
+    presenceData.state = document.querySelector(".question-hyperlink").textContent;
   } else if (
     [
       "serverfault.com",

--- a/websites/S/Stack Exchange/presence.ts
+++ b/websites/S/Stack Exchange/presence.ts
@@ -1,0 +1,30 @@
+const presence = new Presence({
+    clientId: "919817726195814431"
+  }),
+  startTimestamp = Math.floor(Date.now() / 1000);
+
+presence.on("UpdateData", async () => {
+  const presenceData: PresenceData = {
+      largeImageKey: "stackexchange",
+      startTimestamp
+    },
+    { pathname, hostname } = window.location;
+
+    console.log(pathname);
+
+    if (hostname == "stackexchange.com") {
+      presenceData.details = "Stack Exchange";
+    } else {
+      const subStack = document.querySelector("meta[property='og:site_name']");
+      presenceData.details = subStack.getAttribute("content");
+    }
+
+    if (pathname.includes("/questions")) {
+      const titleElem = document.querySelector(".question-hyperlink");
+      presenceData.state = titleElem.textContent;
+    }
+    
+
+  if (presenceData.details) presence.setActivity(presenceData);
+  else presence.setActivity();
+});

--- a/websites/S/Stack Exchange/presence.ts
+++ b/websites/S/Stack Exchange/presence.ts
@@ -1,29 +1,69 @@
 const presence = new Presence({
-    clientId: "919817726195814431"
+    clientId: "919817726195814431",
   }),
   startTimestamp = Math.floor(Date.now() / 1000);
 
 presence.on("UpdateData", async () => {
   const presenceData: PresenceData = {
       largeImageKey: "stackexchange",
-      startTimestamp
+      startTimestamp,
     },
     { pathname, hostname } = window.location;
 
-    console.log(pathname);
-
-    if (hostname == "stackexchange.com") {
-      presenceData.details = "Stack Exchange";
+  if (hostname == "stackexchange.com") {
+    presenceData.details = "Browsing";
+  } else if (hostname == "serverfault.com") {
+    presenceData.largeImageKey = "serverfault";
+    presenceData.details = "Server Fault";
+  } else if (hostname == "meta.serverfault.com") {
+    presenceData.largeImageKey = "serverfault";
+    presenceData.details = "Server Fault Meta";
+  } else if (hostname == "askubuntu.com") {
+    presenceData.largeImageKey = "askubuntu";
+    presenceData.details = "Ask Ubuntu";
+  } else if (hostname == "meta.askubuntu.com") {
+    presenceData.largeImageKey = "askubuntu";
+    presenceData.details = "Ask Ubuntu Meta";
+  } else if (hostname == "superuser.com") {
+    presenceData.largeImageKey = "superuser";
+    presenceData.details = "Super User";
+  } else if (hostname == "meta.superuser.com") {
+    presenceData.largeImageKey = "superuser";
+    presenceData.details = "Super User Meta";
+  } else {
+    const subStack = document.querySelector("meta[property='og:site_name']"),
+      imageKey = hostname.replace(".stackexchange.com", "");
+    if (imageKey == "meta") {
+      presenceData.smallImageKey = imageKey;
     } else {
-      const subStack = document.querySelector("meta[property='og:site_name']");
-      presenceData.details = subStack.getAttribute("content");
+      presenceData.smallImageKey = imageKey.replace(".meta", "");
     }
-
+    presenceData.smallImageText = subStack
+      .getAttribute("content")
+      .replace("Stack Exchange", "");
     if (pathname.includes("/questions")) {
-      const titleElem = document.querySelector(".question-hyperlink");
-      presenceData.state = titleElem.textContent;
+      presenceData.details = "Reading a question";
     }
-    
+  }
+
+  if (pathname == "/") {
+    if (
+      ["serverfault.com", "meta.serverfault.com", "superuser.com", "meta.superuser.com", "askubuntu.com", "meta.askubuntu.com"].includes(hostname)
+    ) {
+      presenceData.state = "Main Page";
+    } else {
+      presenceData.details = "Main Page";
+    }
+  } else if (pathname.includes("/questions")) {
+    const titleElem = document.querySelector(".question-hyperlink");
+    presenceData.state = titleElem.textContent;
+  } else if (
+    ["serverfault.com", "meta.serverfault.com", "superuser.com", "meta.superuser.com", "askubuntu.com", "meta.askubuntu.com"].includes(hostname)
+  ) {
+    presenceData.state = "Browsing";
+  } else {
+    presenceData.details = "Browsing";
+  }
 
   if (presenceData.details) presence.setActivity(presenceData);
   else presence.setActivity();

--- a/websites/S/Stack Exchange/presence.ts
+++ b/websites/S/Stack Exchange/presence.ts
@@ -17,12 +17,6 @@ presence.on("UpdateData", async () => {
   } else if (hostname === "meta.serverfault.com") {
     presenceData.largeImageKey = "serverfault";
     presenceData.details = "Server Fault Meta";
-  } else if (hostname === "askubuntu.com") {
-    presenceData.largeImageKey = "askubuntu";
-    presenceData.details = "Ask Ubuntu";
-  } else if (hostname === "meta.askubuntu.com") {
-    presenceData.largeImageKey = "askubuntu";
-    presenceData.details = "Ask Ubuntu Meta";
   } else if (hostname === "superuser.com") {
     presenceData.largeImageKey = "superuser";
     presenceData.details = "Super User";
@@ -47,9 +41,7 @@ presence.on("UpdateData", async () => {
         "serverfault.com",
         "meta.serverfault.com",
         "superuser.com",
-        "meta.superuser.com",
-        "askubuntu.com",
-        "meta.askubuntu.com"
+        "meta.superuser.com"
       ].includes(hostname)
     )
       presenceData.state = "Main Page";
@@ -61,9 +53,7 @@ presence.on("UpdateData", async () => {
       "serverfault.com",
       "meta.serverfault.com",
       "superuser.com",
-      "meta.superuser.com",
-      "askubuntu.com",
-      "meta.askubuntu.com"
+      "meta.superuser.com"
     ].includes(hostname)
   )
     presenceData.state = "Browsing";

--- a/websites/S/Stack Exchange/tsconfig.json
+++ b/websites/S/Stack Exchange/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "./dist/"
+    }
+}


### PR DESCRIPTION
Creating a presence for Stack Exchange and all of its subdomains and all the domains superuser.com, askubuntu.com, and serverfault.com, all of which are sites under Stack Exchange's network. Did NOT add support for Stack Overflow, as it already has a standalone presence.
![image](https://user-images.githubusercontent.com/38502391/145966324-08916be7-ea9a-4079-ab96-19a0901b434b.png)
![image](https://user-images.githubusercontent.com/38502391/145966708-867734d1-af3d-4f5c-86ca-08e89f5c95a7.png)
![image](https://user-images.githubusercontent.com/38502391/145967115-bfe64be1-5fb5-448d-a39f-35858425bf8d.png)

