### PR TITLE
Improve input field selector for Google

### DIFF
--- a/websites/G/Google/dist/metadata.json
+++ b/websites/G/Google/dist/metadata.json
@@ -12,7 +12,7 @@
     "nl": "Google is een zoekmachine waarmee gebruikers een breed scala aan informatie zoals websites, afbeeldingen en kaarten kunnen vinden."
   },
   "url": "www.google.com",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "logo": "https://i.imgur.com/ZZvx6Dq.png",
   "thumbnail": "https://i.imgur.com/8Ayu4Re.png",
   "color": "#ffffff",

--- a/websites/G/Google/presence.ts
+++ b/websites/G/Google/presence.ts
@@ -4,7 +4,7 @@ const presence = new Presence({
   browsingStamp = Math.floor(Date.now() / 1000),
   pageInput: HTMLInputElement = document.querySelector("#lst-ib"),
   homepageInput: HTMLInputElement = document.querySelector(
-    "#tsf > div:nth-child(1) > div.A8SBwf > div.RNNXgb > div > div.a4bIc > input"
+    "input[name=\"q\"]"
   ),
   homepageImage: HTMLElement = document.querySelector("#hplogo"),
   imgInput: HTMLInputElement = document.querySelector("#REsRA");


### PR DESCRIPTION
Current input field selector is complex and unreliable due to autogenerated class names that Google uses (for example, the presence doesn't work for me due to homepageInput being null, spamming my console with the error). Instead, let's use input field's constant properties.