### PR TITLE
Update Facebook presence

### DIFF
--- a/websites/F/Facebook/dist/metadata.json
+++ b/websites/F/Facebook/dist/metadata.json
@@ -21,7 +21,7 @@
     "zh_CN": "与朋友、家人和其他你认识的人联系。分享照片和视频、发送消息和获取更新。"
   },
   "url": "www.facebook.com",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "logo": "https://i.imgur.com/jWYZLvY.png",
   "thumbnail": "https://i.imgur.com/WcKmon0.png",
   "color": "#4267B2",

--- a/websites/F/Facebook/presence.ts
+++ b/websites/F/Facebook/presence.ts
@@ -414,10 +414,7 @@ presence.on("UpdateData", async () => {
     }
   } else if (
     document.querySelector(
-      "span.a8c37x1j.ni8dbmo4.stjgntxs.l9j0dhe7.ltmttdrg.g0qnabr5.ojkyduve"
-    ) ||
-    document.querySelector(
-      "span.d2edcug0.hpfvmrgz.qv66sw1b.c1et5uql.lr9zc1uh.a8c37x1j.keod5gw0.nxhoafnm.aigsh9s9.fe6kdd0r.mau55g9w.c8b282yb.embtmqzv.hrzyx87i.m6dqt4wy.h7mekvxk.hnhda86s.oo9gr5id.hzawbc8m > span"
+      "h2.gmql0nx0.l94mrbxd.p1ri9a11.lzcic4wl.d2edcug0.hpfvmrgz span.d2edcug0.hpfvmrgz.qv66sw1b.c1et5uql.lr9zc1uh.a8c37x1j.keod5gw0.nxhoafnm.aigsh9s9.fe6kdd0r.mau55g9w.c8b282yb.embtmqzv.hrzyx87i.m6dqt4wy.h7mekvxk.hnhda86s.oo9gr5id.hzawbc8m > span"
     ) ||
     document.querySelector(
       "span.d2edcug0.hpfvmrgz.qv66sw1b.c1et5uql.lr9zc1uh.a8c37x1j.keod5gw0.nxhoafnm.aigsh9s9.fe6kdd0r.mau55g9w.c8b282yb.l1jc4y16.rwim8176.mhxlubs3.p5u9llcw.hnhda86s.oo9gr5id.hzawbc8m > h1"
@@ -435,11 +432,13 @@ presence.on("UpdateData", async () => {
     if (!hasCommentInput)
       name = document
         .querySelector(
-          "span.d2edcug0.hpfvmrgz.qv66sw1b.c1et5uql.lr9zc1uh.a8c37x1j.keod5gw0.nxhoafnm.aigsh9s9.fe6kdd0r.mau55g9w.c8b282yb.embtmqzv.hrzyx87i.m6dqt4wy.h7mekvxk.hnhda86s.oo9gr5id.hzawbc8m > span"
+          "h2.gmql0nx0.l94mrbxd.p1ri9a11.lzcic4wl.d2edcug0.hpfvmrgz span.d2edcug0.hpfvmrgz.qv66sw1b.c1et5uql.lr9zc1uh.a8c37x1j.keod5gw0.nxhoafnm.aigsh9s9.fe6kdd0r.mau55g9w.c8b282yb.embtmqzv.hrzyx87i.m6dqt4wy.h7mekvxk.hnhda86s.oo9gr5id.hzawbc8m > span"
         )
         ?.textContent.trim();
 
-    presenceData.details = `Viewing ${hasCommentInput ? "user" : "page"}${privacyMode ? "" : ":"}`;
+    presenceData.details = `Viewing ${hasCommentInput ? "user" : "page"}${
+      privacyMode ? "" : ":"
+    }`;
     if (!privacyMode) presenceData.state = name || "Unknown";
   } else if (document.location.pathname.includes("/settings"))
     presenceData.details = "Settings";


### PR DESCRIPTION
The now removed query selector for the span element is also used for sponsored posts, which caused the error.

<details>
<summary>Proof</summary>
<img src="https://user-images.githubusercontent.com/53608074/146403955-bf9c1db0-1e09-4a4b-960e-c21a00bd74fd.png">
<br>Before:<br>
<img src="https://user-images.githubusercontent.com/53608074/146404047-0023a0c2-0d5d-4cb1-8cbb-4294b2e328d5.png">
<br>After:<br>
<img src="https://user-images.githubusercontent.com/53608074/146404000-0eef69b0-87e2-492e-b8cf-bf2b4aea1a56.png">
</details>
