### PR TITLE
chore(bug_report): improve template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,8 +6,8 @@ body:
   - type: markdown
     attributes:
       value:
-        Before submitting a bug report ensure your bug hasn't already been
-        mentioned. If it has, reply accordingly to the thread.
+        Before submitting a new issue, ensure your bug hasn't already been
+        reported. If it has, reply to the open issue instead.
   - type: textarea
     validations:
       required: true
@@ -21,22 +21,29 @@ body:
       label: Steps to Reproduce
       description:
         Provide clear and unambiguous steps on how to reproduce the bug
-      value: |
-        1.
-        2.
-        3.
-  - type: textarea
-    validations:
-      required: true
-    attributes:
-      label: Expected Behavior
-      description: Describe what was expected to happen
+      placeholder: |
+        1. go here
+        2. do this
+        3. do that
+        4. see this incorrect behavior
   - type: textarea
     validations:
       required: false
     attributes:
       label: "Screenshots"
       description: "Optionally add some screenshots to reinforce your point"
+  - type: input
+    validations:
+      required: true
+    attributes:
+      label: Expected Behavior
+      description: Describe what you expected to happen
+  - type: input
+    validations:
+      required: true
+    attributes:
+      label: Actual Behavior
+      description: Describe what actually happened
   - type: input
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,10 +22,9 @@ body:
       description:
         Provide clear and unambiguous steps on how to reproduce the bug
       placeholder: |
-        1. go here
-        2. do this
-        3. do that
-        4. see this incorrect behavior
+        1. Go to this link
+        2. Click on this
+        3. Observe that
   - type: textarea
     validations:
       required: false


### PR DESCRIPTION
This PR improves the bug report template by replacing the steps to reproduce preset value with a placeholder (grey text that disappears once you start writing), makes the "Expected behavior" section an input instead of textarea, adds "Actual behavior" and moves "Screenshots" above these two