### PR TITLE
feat(Prydwen Institute): Cover as largeImageKey

### DIFF
--- a/websites/P/Prydwen Institute/dist/metadata.json
+++ b/websites/P/Prydwen Institute/dist/metadata.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemas.premid.app/metadata/1.5",
+  "$schema": "https://schemas.premid.app/metadata/1.6",
   "author": {
     "name": "Kyrie",
     "id": "368399721494216706"

--- a/websites/P/Prydwen Institute/dist/metadata.json
+++ b/websites/P/Prydwen Institute/dist/metadata.json
@@ -9,7 +9,7 @@
     "en": "Prydwen Institute is a Counter Side tier list and database that contains information about employees, ships, operators, and skins available in both SEA and KR versions of the game."
   },
   "url": "www.prydwen.co",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "logo": "https://i.imgur.com/p3JfYMH.png",
   "thumbnail": "https://i.imgur.com/zsAl5W5.png",
   "color": "#161833",

--- a/websites/P/Prydwen Institute/dist/metadata.json
+++ b/websites/P/Prydwen Institute/dist/metadata.json
@@ -9,7 +9,7 @@
     "en": "Prydwen Institute is a Counter Side tier list and database that contains information about employees, ships, operators, and skins available in both SEA and KR versions of the game."
   },
   "url": "www.prydwen.co",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "logo": "https://i.imgur.com/p3JfYMH.png",
   "thumbnail": "https://i.imgur.com/zsAl5W5.png",
   "color": "#161833",

--- a/websites/P/Prydwen Institute/presence.ts
+++ b/websites/P/Prydwen Institute/presence.ts
@@ -100,6 +100,7 @@ presence.on("UpdateData", () => {
     presenceData.buttons = [{ label: "Read Guide", url: document.URL }];
   } else if (document.location.pathname === "/blog") {
     presenceData.details = "Finding blogs";
+    presenceData.largeImageKey = "ships";
     presenceData.smallImageKey = "blogs";
     presenceData.smallImageText = "Viewing blogs";
   } else if (document.location.pathname.startsWith("/blog")) {

--- a/websites/P/Prydwen Institute/presence.ts
+++ b/websites/P/Prydwen Institute/presence.ts
@@ -68,6 +68,7 @@ presence.on("UpdateData", () => {
           )
           .textContent.lastIndexOf("-") - 1
       );
+    presenceData.largeImageKey = "ships";
     presenceData.smallImageKey = "skins";
     presenceData.smallImageText = "Viewing skins";
   } else if (document.location.pathname === "/skins") {

--- a/websites/P/Prydwen Institute/presence.ts
+++ b/websites/P/Prydwen Institute/presence.ts
@@ -116,7 +116,9 @@ presence.on("UpdateData", () => {
   } else if (document.location.href === "https://www.prydwen.co/") {
     presenceData.details = "Viewing home page";
     presenceData.largeImageKey = "ships";
-  } else presenceData.details = "Browsing the wiki";
-
+  } else {
+    presenceData.details = "Browsing the wiki";
+    presenceData.largeImageKey = "ships";
+  }
   presence.setActivity(presenceData);
 });

--- a/websites/P/Prydwen Institute/presence.ts
+++ b/websites/P/Prydwen Institute/presence.ts
@@ -21,7 +21,7 @@ presence.on("UpdateData", () => {
       "#gatsby-focus-wrapper > div > main > div > div > div > div.unit-header.align-items-center.d-flex.flex-wrap > div:nth-child(1) > span > a > div > div > picture > img"
     ).src;
     presenceData.smallImageKey = "ships";
-    presenceData.smallImageText = "Prydwen Institude";
+    presenceData.smallImageText = "Prydwen Institute";
     presenceData.buttons = [{ label: "View Employee", url: document.URL }];
   } else if (document.location.pathname === "/operators") {
     presenceData.details = "Viewing operators";

--- a/websites/P/Prydwen Institute/presence.ts
+++ b/websites/P/Prydwen Institute/presence.ts
@@ -5,42 +5,56 @@ const presence = new Presence({
 
 presence.on("UpdateData", () => {
   const presenceData: PresenceData = {
-      largeImageKey: "ships",
       startTimestamp: browsingTimestamp
     },
     [shortTitle] = document.title.split(/[|/]/, 1);
 
   if (document.location.pathname === "/employees") {
     presenceData.details = "Viewing employees";
+    presenceData.largeImageKey = "ships";
     presenceData.smallImageKey = "employees";
     presenceData.smallImageText = "Viewing employees";
   } else if (document.location.pathname.startsWith("/employees")) {
     presenceData.details = "Looking into an employee's profile";
     presenceData.state = shortTitle;
-    presenceData.smallImageKey = "employees";
-    presenceData.smallImageText = "Viewing employees";
+    presenceData.largeImageKey = document.querySelector<HTMLImageElement>(
+      "#gatsby-focus-wrapper > div > main > div > div > div > div.unit-header.align-items-center.d-flex.flex-wrap > div:nth-child(1) > span > a > div > div > picture > img"
+    ).src;
+    presenceData.smallImageKey = "ships";
+    presenceData.smallImageText = "Prydwen Institude";
     presenceData.buttons = [{ label: "View Employee", url: document.URL }];
   } else if (document.location.pathname === "/operators") {
     presenceData.details = "Viewing operators";
+    presenceData.largeImageKey = "ships";
     presenceData.smallImageKey = "operators";
     presenceData.smallImageText = "Viewing operators";
   } else if (document.location.pathname.startsWith("/operators")) {
     presenceData.details = "Looking into an operator's profile";
     presenceData.state = shortTitle;
-    presenceData.smallImageKey = "operators";
-    presenceData.smallImageText = "Viewing operators";
+    presenceData.largeImageKey = document.querySelector<HTMLImageElement>(
+      "#gatsby-focus-wrapper > div > main > div > div > div.unit-page.operator > div.unit-header.align-items-center.d-flex.flex-wrap > div:nth-child(1) > span > a > div > div > picture > img"
+    ).src;
+    presenceData.smallImageKey = "ships";
+    presenceData.smallImageText = "Prydwen Institute";
     presenceData.buttons = [{ label: "View Operator", url: document.URL }];
   } else if (document.location.pathname === "/ships") {
     presenceData.details = "Viewing ships";
+    presenceData.largeImageKey = "ships";
     presenceData.smallImageKey = "ships";
     presenceData.smallImageText = "Viewing ships";
   } else if (document.location.pathname.startsWith("/ships")) {
     presenceData.details = "Viewing a ship";
     presenceData.state = shortTitle;
+    presenceData.largeImageKey = document.querySelector<HTMLImageElement>(
+      "#gatsby-focus-wrapper > div > main > div > div > div.unit-page.ship > div.unit-header.align-items-center.d-flex.flex-wrap > div:nth-child(1) > span > a > div > div > picture > img"
+    ).src;
     presenceData.smallImageKey = "ships";
     presenceData.smallImageText = "Viewing ships";
     presenceData.buttons = [{ label: "View Ship", url: document.URL }];
-  } else if (document.querySelector("body > div.fade.modal-backdrop.show")) {
+  } else if (
+    document.querySelector("body > div.fade.modal-backdrop.show") &&
+    document.location.href.indexOf("skins") > -1
+  ) {
     presenceData.details = "Viewing skin";
     presenceData.state = document
       .querySelector(
@@ -58,25 +72,30 @@ presence.on("UpdateData", () => {
     presenceData.smallImageText = "Viewing skins";
   } else if (document.location.pathname === "/skins") {
     presenceData.details = "Viewing skins";
+    presenceData.largeImageKey = "ships";
     presenceData.smallImageKey = "skins";
     presenceData.smallImageText = "Viewing skins";
   } else if (document.location.pathname === "/stats") {
     presenceData.details = "Viewing stats";
+    presenceData.largeImageKey = "ships";
     presenceData.smallImageKey = "stats";
     presenceData.smallImageText = "Viewing stats";
   } else if (document.location.pathname === "/tier-list") {
     presenceData.details = "Viewing the tier list";
+    presenceData.largeImageKey = "ships";
     presenceData.smallImageKey = "tierlist";
     presenceData.smallImageText = "Viewing tier list";
   } else if (document.location.pathname === "/guides") {
     presenceData.details = "Finding guides";
+    presenceData.largeImageKey = "ships";
     presenceData.smallImageKey = "guide";
     presenceData.smallImageText = "Viewing guides";
   } else if (document.location.pathname.startsWith("/guides")) {
     presenceData.details = "Reading a guide:";
     presenceData.state = shortTitle;
-    presenceData.smallImageKey = "guide";
-    presenceData.smallImageText = "Reading a guide";
+    presenceData.largeImageKey = "guide";
+    presenceData.smallImageKey = "ships";
+    presenceData.smallImageText = "Prydwen Institute";
     presenceData.buttons = [{ label: "Read Guide", url: document.URL }];
   } else if (document.location.pathname === "/blog") {
     presenceData.details = "Finding blogs";
@@ -85,16 +104,19 @@ presence.on("UpdateData", () => {
   } else if (document.location.pathname.startsWith("/blog")) {
     presenceData.details = "Reading a blog:";
     presenceData.state = shortTitle;
-    presenceData.smallImageKey = "blogs";
-    presenceData.smallImageText = "Viewing blogs";
+    presenceData.largeImageKey = "blogs";
+    presenceData.smallImageKey = "ships";
+    presenceData.smallImageText = "Prydwen Institute";
     presenceData.buttons = [{ label: "Read Blog", url: document.URL }];
   } else if (document.location.href.indexOf("gear-builder") > -1) {
     presenceData.details = "Making a Gear Builder template";
+    presenceData.largeImageKey = "ships";
     presenceData.smallImageKey = "gearbuilder";
     presenceData.smallImageText = "Gear building";
-  } else if (document.location.href === "https://www.prydwen.co/")
+  } else if (document.location.href === "https://www.prydwen.co/") {
     presenceData.details = "Viewing home page";
-  else presenceData.details = "Browsing the wiki";
+    presenceData.largeImageKey = "ships";
+  } else presenceData.details = "Browsing the wiki";
 
   presence.setActivity(presenceData);
 });


### PR DESCRIPTION
#### Modifications:
- Uses `src` from `HTMLImageElement` as large image instead of image keys from application when viewing specific pages
<details>
  <summary>Examples:</summary>

![image](https://user-images.githubusercontent.com/77577746/147170613-7b14eb3a-f521-4a58-8cc2-7a15bc9be5d6.png)
![image](https://user-images.githubusercontent.com/77577746/147170637-fb5fa337-44f9-45e2-b7d8-141dfce28dfb.png)
![image](https://user-images.githubusercontent.com/77577746/147170657-3035d130-69a4-4d77-9461-e52c05d6da28.png)
</details>

- Swapping `largeImage` and `smallImage` when entering specific pages
<details>
  <summary>Examples:</summary>

![image](https://user-images.githubusercontent.com/77577746/147171009-74f79b80-5a75-45c7-9785-ad718703058d.png)
![image](https://user-images.githubusercontent.com/77577746/147171042-f1ce041b-df9d-497d-9e3d-bbf4be5c49e8.png)
</details>

#### Patches:
- Added condition that users has to be in `skins` page for the `Viewing skin` presence to work in case of conflicting with similar features