### PR TITLE
feat(util): add and improve scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,18 +6,12 @@
   "scripts": {
     "lint": "eslint --fix . && prettier --write **/*.ts **/{metadata,tsconfig}.json",
     "lint:ci": "eslint . && prettier **/*.ts **/{metadata,tsconfig}.json",
-    "inc": "npm run inc:compile && node ./util/tools/massVer.js",
-    "inc:compile": "tsc -p ./util/configs/tsconfig.massVer.json",
-    "su": "npm run su:compile && node ./util/tools/schemaUpdater.js",
-    "su:compile": "tsc -p ./util/configs/tsconfig.schemaUpdater.json",
-    "se": "npm run se:compile && node ./util/tools/auto/syntaxEnforcer.js",
-    "se:compile": "tsc -p ./util/configs/tsconfig.auto.syntaxEnforcer.json",
-    "sv": "npm run sv:compile && node ./util/tools/auto/schemaValidator.js",
-    "sv:compile": "tsc -p ./util/configs/tsconfig.auto.schemaValidator.json",
-    "pu": "npm run pu:compile && node ./util/tools/auto/presenceUpdater.js",
-    "pu:compile": "tsc -p ./util/configs/tsconfig.auto.presenceUpdater.json",
-    "translator": "npm run translator:compile && node ./util/tools/translator.js",
-    "translator:compile": "tsc -p ./util/configs/tsconfig.translator.json"
+    "inc": "tsc -p ./util/configs/tsconfig.massVer.json && node ./util/tools/massVer.js",
+    "su": "tsc -p ./util/configs/tsconfig.schemaUpdater.json && node ./util/tools/schemaUpdater.js",
+    "se": "tsc -p ./util/configs/tsconfig.auto.syntaxEnforcer.json && node ./util/tools/auto/syntaxEnforcer.js",
+    "sv": "tsc -p ./util/configs/tsconfig.auto.schemaValidator.json && node ./util/tools/auto/schemaValidator.js",
+    "pu": "tsc -p ./util/configs/tsconfig.auto.presenceUpdater.json && node ./util/tools/auto/presenceUpdater.js",
+    "translator": "tsc -p ./util/configs/tsconfig.translator.json && node ./util/tools/translator.js"
   },
   "devDependencies": {
     "@babel/core": "^7.15.5",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "se": "tsc -p ./util/configs/tsconfig.auto.syntaxEnforcer.json && node ./util/tools/auto/syntaxEnforcer.js",
     "sv": "tsc -p ./util/configs/tsconfig.auto.schemaValidator.json && node ./util/tools/auto/schemaValidator.js",
     "pu": "tsc -p ./util/configs/tsconfig.auto.presenceUpdater.json && node ./util/tools/auto/presenceUpdater.js",
+    "ms": "tsc -p ./util/configs/tsconfig.metadataSorter.json && node ./util/tools/metadataSorter.js",
     "mc": "tsc -p ./util/configs/tsconfig.massCompile.json && node ./util/tools/massCompile.js",
     "translator": "tsc -p ./util/configs/tsconfig.translator.json && node ./util/tools/translator.js"
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "se": "tsc -p ./util/configs/tsconfig.auto.syntaxEnforcer.json && node ./util/tools/auto/syntaxEnforcer.js",
     "sv": "tsc -p ./util/configs/tsconfig.auto.schemaValidator.json && node ./util/tools/auto/schemaValidator.js",
     "pu": "tsc -p ./util/configs/tsconfig.auto.presenceUpdater.json && node ./util/tools/auto/presenceUpdater.js",
+    "mc": "tsc -p ./util/configs/tsconfig.massCompile.json && node ./util/tools/massCompile.js",
     "translator": "tsc -p ./util/configs/tsconfig.translator.json && node ./util/tools/translator.js"
   },
   "devDependencies": {

--- a/util/configs/tsconfig.massCompile.json
+++ b/util/configs/tsconfig.massCompile.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tools/auto/tsconfig.auto.json",
+  "files": ["../tools/massCompile.ts"]
+}

--- a/util/configs/tsconfig.metadataSorter.json
+++ b/util/configs/tsconfig.metadataSorter.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tools/auto/tsconfig.auto.json",
+  "files": ["../tools/metadataSorter.ts"]
+}

--- a/util/tools/auto/syntaxEnforcer.ts
+++ b/util/tools/auto/syntaxEnforcer.ts
@@ -96,6 +96,19 @@ const readFile = (path: string): string =>
 
     await execShellCommand(["yarn", "lint"]);
 
+    // A clear splitter before metadata sorting
+    console.log(
+      yellow(
+        [
+          "|-----------------------------------|",
+          "| PROCEEDING TO SORT METADATA FILES |",
+          "|-----------------------------------|"
+        ].join("\n")
+      )
+    )
+
+    await execShellCommand(["yarn", "ms"]);
+
     // A clear splitter between TypeScript compilation and semver bumps
     console.log(
       yellow(

--- a/util/tools/massCompile.ts
+++ b/util/tools/massCompile.ts
@@ -1,0 +1,84 @@
+import "source-map-support/register";
+
+import { exec as processExec } from "node:child_process";
+import { readFileSync as readFile, writeFileSync as writeFile } from "node:fs";
+import { promisify } from "node:util";
+import { green, red } from "chalk";
+import { sync as glob } from "glob";
+
+const exec = promisify(processExec);
+
+/*  NOTE: THIS IS A TOOL THAT IS ONLY MEANT TO BE USED
+    BY THE DEVS AND REVIEWERS FOR DEPLOYMENT PURPOSES,
+    PLEASE DON'T COMPILE OR RUN IT BEFORE MAKING A PULL
+    REQUEST UNLESS YOU'VE BEEN EXPLICITLY INSTRUCTED BY
+    A DEV TO DO SO, WHICH WILL MOST LIKELY NEVER HAPPEN.  */
+
+export const read = (path: string): string =>
+    readFile(path, { encoding: "utf8" }),
+  write = (path: string, code: Metadata): void =>
+    writeFile(path, JSON.stringify(code, null, 2), {
+      encoding: "utf8",
+      flag: "w"
+    });
+
+export const allFolders = glob("./{websites,programs}/*/*/*")
+  .filter(f => f.endsWith("dist"))
+  .map(f => f.replace("/dist", ""));
+
+async function main() {
+  const errors: { [key: string]: string } = {};
+  async function compileFile(i: number): Promise<void> {
+    if (!allFolders[i]) return;
+    return new Promise(async (resolve, reject): Promise<void> => {
+      exec("tsc --noEmit", { cwd: allFolders[i] }).then(resolve).catch(reject);
+    })
+      .then(async () => {
+        console.log(
+          green(`✔ Successfully compiled ${allFolders[i].split("/").at(-1)}`)
+        );
+        return await compileFile(i + 1);
+      })
+      .catch(async err => {
+        errors[allFolders[i].split("/").at(-1)] =
+          err.stdout || err.stderr || "Couldn't find error";
+
+        console.error(
+          red(`✘ Error on ${allFolders[i].split("/").at(-1)}:\n`),
+          err.stdout || err.stderr || "Couldn't find error"
+        );
+        return await compileFile(i + 1);
+      });
+  }
+  await compileFile(0)
+    .then(async () => {
+      console.log(
+        green(`✔ Successfully compiled ${allFolders[0].split("/").at(-1)}`)
+      );
+    })
+    .catch(async (err: Error & { stdout: string; stderr: string }) => {
+      errors[allFolders[0].split("/").at(-1)] =
+        err.stdout || err.stderr || "Couldn't find error";
+
+      console.error(
+        red(`✘ Error on ${allFolders[0].split("/").at(-1)}:\n`),
+        err.stdout || err.stderr || "Couldn't find error"
+      );
+      return await compileFile(1);
+    });
+  const presenceErrors = Object.keys(errors).length;
+  if (presenceErrors)
+    console.log(
+      red(
+        `You got errors in ${presenceErrors} presence${
+          presenceErrors === 1 ? "" : "s"
+        }! Check them out:\n`
+      ),
+      Object.entries(errors)
+        .map(([key, value]) => `${green(key)}:\n ${value}`)
+        .join("\n")
+    );
+  else console.log(green("✔ All presences compiled successfully!"));
+}
+
+main();

--- a/util/tools/massVer.ts
+++ b/util/tools/massVer.ts
@@ -4,9 +4,11 @@ import {
   existsSync as exists,
   readFileSync as readFile,
   writeFileSync as writeFile
-} from "fs";
+} from "node:fs";
 import { sync as glob } from "glob";
 import { coerce, inc, valid } from "semver";
+
+import type { Metadata } from "./metadataSorter";
 
 /*  NOTE: THIS IS A TOOL THAT IS ONLY MEANT TO BE USED
     BY THE DEVS AND REVIEWERS FOR DEPLOYMENT PURPOSES,
@@ -29,60 +31,56 @@ const read = (path: string): string => readFile(path, { encoding: "utf8" }),
       encoding: "utf8",
       flag: "w"
     }),
-  main = async (): Promise<void> => {
-    const missingMetadata: string[] = glob("./{websites,programs}/*/*/").filter(
-        (pF) => !exists(`${pF}/dist/metadata.json`)
-      ),
-      allmeta: Array<[Metadata, string]> = glob(
-        "./{websites,programs}/*/*/*/metadata.json"
-      ).map((pF) => {
-        const file = read(pF);
-        if (isValidJSON(file)) return [JSON.parse(file), pF];
-        else {
-          console.error(
-            `Error. ${pF} is not a valid metadata file, skipping...`
-          );
-          return null;
-        }
-      });
-
-    if (missingMetadata && missingMetadata.length > 0) {
-      console.log(
-        `\nThe following presence${
-          missingMetadata.length > 1 ? "s don't" : "doesn't"
-        } include a metadata file :\n${missingMetadata.join(", ")}\n`
-      );
+  missingMetadata: string[] = glob("./{websites,programs}/*/*/").filter(
+    (pF) => !exists(`${pF}/dist/metadata.json`)
+  ),
+  allmeta: Array<[Metadata, string]> = glob(
+    "./{websites,programs}/*/*/*/metadata.json"
+  ).map((pF) => {
+    const file = read(pF);
+    if (isValidJSON(file)) return [JSON.parse(file), pF];
+    else {
+      console.error(`Error. ${pF} is not a valid metadata file, skipping...`);
+      return null;
     }
+  });
 
-    for (const metadata of allmeta) {
-      if (metadata) {
-        const newData = metadata[0];
-        if (newData.version && valid(coerce(newData.version))) {
-          newData.version = inc(valid(coerce(newData.version)), "patch");
+function main() {
+  if (missingMetadata && missingMetadata.length > 0) {
+    console.log(
+      `\nThe following presence${
+        missingMetadata.length > 1 ? "s don't" : "doesn't"
+      } include a metadata file :\n${missingMetadata.join(", ")}\n`
+    );
+  }
+
+  for (const metadata of allmeta) {
+    if (metadata) {
+      const newData = metadata[0];
+      if (newData.version && valid(coerce(newData.version))) {
+        newData.version = inc(
+          valid(coerce(newData.version)),
+          "patch"
+        ) as Metadata["version"];
+        write(metadata[1], newData);
+      } else {
+        console.log(
+          `Error. ${
+            metadata[0].service && metadata[0].service.length > 0
+              ? metadata[0].service
+              : metadata[1]
+          } does not include a valid metadata version, trying to overwrite...\n`
+        );
+        try {
+          newData.version = "1.0.0";
           write(metadata[1], newData);
-        } else {
-          console.log(
-            `Error. ${
-              metadata[0].service && metadata[0].service.length > 0
-                ? metadata[0].service
-                : metadata[1]
-            } does not include a valid metadata version, trying to overwrite...\n`
-          );
-          try {
-            newData.version = "1.0.0";
-            write(metadata[1], newData);
-          } catch (err) {
-            console.log(err);
-            continue;
-          }
+        } catch (err) {
+          console.log(err);
+          continue;
         }
       }
     }
-  };
+  }
+}
 
 main();
-
-interface Metadata {
-  service: string;
-  version: string;
-}

--- a/util/tools/metadataSorter.ts
+++ b/util/tools/metadataSorter.ts
@@ -1,0 +1,140 @@
+import "source-map-support/register";
+
+import {
+  existsSync as exists,
+  readFileSync as readFile,
+  writeFileSync as writeFile
+} from "node:fs";
+import { sync as glob } from "glob";
+
+export function isValidJSON(text: string): boolean {
+  try {
+    JSON.parse(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export const read = (path: string): string =>
+    readFile(path, { encoding: "utf8" }),
+  write = (path: string, code: Metadata): void =>
+    writeFile(path, JSON.stringify(code, null, 2), {
+      encoding: "utf8",
+      flag: "w"
+    });
+
+export const missingMetadata: string[] = glob(
+    "./{websites,programs}/*/*/"
+  ).filter(pF => !exists(`${pF}/dist/metadata.json`)),
+  allmeta: Array<[Metadata, string]> = glob(
+    "./{websites,programs}/*/*/*/metadata.json"
+  ).map(pF => {
+    const file = read(pF);
+    if (isValidJSON(file)) return [JSON.parse(file), pF];
+    else {
+      console.error(`Error. ${pF} is not a valid metadata file, skipping...`);
+      return null;
+    }
+  });
+
+if (missingMetadata?.length > 0)
+  console.log(
+    `\nThe following presence${
+      missingMetadata.length > 1 ? "s don't" : "doesn't"
+    } include a metadata file :\n${missingMetadata.join(", ")}\n`
+  );
+
+for (const metadata of allmeta) {
+  if (metadata) {
+    const newData: Metadata = {
+      $schema: "https://schemas.premid.app/metadata/1.5",
+      author: metadata[0].author,
+      contributors: metadata[0].contributors,
+      service: metadata[0].service,
+      altnames: metadata[0].altnames,
+      description: metadata[0].description,
+      url: metadata[0].url,
+      regExp: metadata[0].regExp,
+      version: metadata[0].version,
+      logo: metadata[0].logo,
+      thumbnail: metadata[0].thumbnail,
+      color: metadata[0].color,
+      category: metadata[0].category,
+      tags: metadata[0].tags,
+      iframe: metadata[0].iframe,
+      iFrameRegExp: metadata[0].iFrameRegExp,
+      readLogs: metadata[0].readLogs,
+      settings: metadata[0].settings
+    };
+
+    for (const key in newData) {
+      //@ts-ignore
+      if (typeof newData[key] === "undefined") delete newData[key];
+    }
+    write(metadata[1], newData);
+  }
+}
+
+export interface Metadata {
+  $schema: `https://schemas.premid.app/metadata/${number}.${number}`;
+  author: Contributor;
+  contributors?: Contributor[];
+  service: string;
+  altnames: string[];
+  description: { [lang: string]: string };
+  url: `${string}.${string}`;
+  regExp?: string;
+  version: `${number}.${number}.${number}`;
+  logo: `https://i.imgur.com/${string}.${"png" | "jpeg" | "jpg" | "gif"}`;
+  thumbnail: `https://i.imgur.com/${string}.${"png" | "jpeg" | "jpg" | "gif"}`;
+  color: `#${string}`;
+  tags: string | string[];
+  category: string;
+  iframe?: boolean;
+  iFrameRegExp?: string;
+  readLogs?: boolean;
+  settings?:
+    | Setting
+    | MultiLanguageSetting
+    | StringSetting
+    | ValueSetting
+    | ValuesSetting;
+}
+
+interface Contributor {
+  name: string;
+  id: `${bigint}`;
+}
+
+interface BaseSetting {
+  id: string;
+}
+
+interface MultiLanguageSetting extends BaseSetting {
+  multiLanguage: true | string | string[];
+}
+
+interface Setting extends BaseSetting {
+  title: string;
+  icon: string;
+  if?: {
+    [key: string]: Value;
+  };
+}
+
+interface StringSetting extends Setting {
+  value: string;
+  placeholder: string;
+}
+
+interface ValueSetting extends Setting {
+  value: boolean;
+}
+
+interface ValuesSetting extends Setting {
+  value: number;
+  values: Value[];
+}
+
+type Value = string | number | boolean;


### PR DESCRIPTION
This PR adds 2 new scripts and improves existing ones to use them.

- Refactored the package.json file to remove the :compile scripts and move them to their original script as they weren't used anywhere else anymore
- Updated SV to check if all Presences were bumped correctly. This currently has a flaw due to how the script was originally made which is that it will not produce an error if the PR didn't change the metadata file at all. This could be improved in the future.
- Added a script to compile all presences 1 by 1. This wasn't added to any CI so it can only be ran by maintainers when needed as it takes a long time to run. The script **must** compile each presence after the other, otherwise your computer will catch on fire
- Added script to sort metadata files according to the order on the docs and updated SE to run this as well.
- Did a small refactor on MV to remove the main function as it was redundant, everything else stays the same