### PR TITLE
fix(MangaLivre): manga showing wrong title

### DIFF
--- a/websites/M/Manga Livre/dist/metadata.json
+++ b/websites/M/Manga Livre/dist/metadata.json
@@ -17,7 +17,7 @@
     "pt_BR": "Leia online e organize suas leituras aqui. Leia em português (PT-BR) os mangás mais lidos como Naruto, Fairy Tail, One Piece e outros!"
   },
   "url": "mangalivre.net",
-  "version": "1.3.9",
+  "version": "1.4.0",
   "logo": "https://i.imgur.com/It14Tbn.png",
   "thumbnail": "https://i.imgur.com/frsAsls.png",
   "color": "#b4ad9d",

--- a/websites/M/Manga Livre/dist/metadata.json
+++ b/websites/M/Manga Livre/dist/metadata.json
@@ -4,12 +4,6 @@
     "name": "Bas950",
     "id": "241278257335500811"
   },
-  "contributors": [
-    {
-      "name": "Aya",
-      "id": "256422547556401152"
-    }
-  ],
   "service": "Manga Livre",
   "description": {
     "en": "Read online and organize your readings here. Read in Portuguese (PT-BR) the most read manga like Naruto, Fairy Tail, One Piece and more!",

--- a/websites/M/Manga Livre/dist/metadata.json
+++ b/websites/M/Manga Livre/dist/metadata.json
@@ -4,6 +4,12 @@
     "name": "Bas950",
     "id": "241278257335500811"
   },
+  "contributors": [
+    {
+      "name": "Aya",
+      "id": "256422547556401152"
+    }
+  ],
   "service": "Manga Livre",
   "description": {
     "en": "Read online and organize your readings here. Read in Portuguese (PT-BR) the most read manga like Naruto, Fairy Tail, One Piece and more!",

--- a/websites/M/Manga Livre/dist/metadata.json
+++ b/websites/M/Manga Livre/dist/metadata.json
@@ -17,7 +17,7 @@
     "pt_BR": "Leia online e organize suas leituras aqui. Leia em português (PT-BR) os mangás mais lidos como Naruto, Fairy Tail, One Piece e outros!"
   },
   "url": "mangalivre.net",
-  "version": "1.4.0",
+  "version": "1.3.10",
   "logo": "https://i.imgur.com/It14Tbn.png",
   "thumbnail": "https://i.imgur.com/frsAsls.png",
   "color": "#b4ad9d",

--- a/websites/M/Manga Livre/presence.ts
+++ b/websites/M/Manga Livre/presence.ts
@@ -21,7 +21,7 @@ presence.on("UpdateData", async () => {
       }'`;
       presenceData.state = `Chapter ${document
         .querySelector(".current-chapter")
-        .textContent.replace("Chap ", "")} - Page ${
+        .textContent.replace("Cap ", "")} - Page ${
         document.querySelector(".page-navigation > span > em:nth-child(1)")
           .textContent
       }`;

--- a/websites/M/Manga Livre/presence.ts
+++ b/websites/M/Manga Livre/presence.ts
@@ -17,7 +17,7 @@ presence.on("UpdateData", async () => {
       null
     ) {
       presenceData.details = `Reading '${
-        document.querySelector(".title").textContent
+        document.querySelector("div.series-title > span.title").textContent
       }'`;
       presenceData.state = `Chapter ${document
         .querySelector(".current-chapter")


### PR DESCRIPTION
this PR fixes two things, the title showing wrong manga name when logged in the website and wrong replace "Chap"

Closes #5126
<details>
<br>
<!-- Required when a presence has been added or modified --->
<!-- Attach screenshot(s) here --->

![image](https://user-images.githubusercontent.com/39977285/147396977-9e742706-9d8e-4648-b1b1-5f117439d120.png)

</details>