### PR TITLE
fix(Rabbit's BS Viewer): Show only currently selected difficulty

### DIFF
--- a/websites/R/Rabbit's BS Viewer/dist/metadata.json
+++ b/websites/R/Rabbit's BS Viewer/dist/metadata.json
@@ -10,7 +10,7 @@
     "nl": "Bekijk aangepaste Beat Saber levels in je browser"
   },
   "url": "skystudioapps.com",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "logo": "https://i.imgur.com/FDP38pa.png",
   "thumbnail": "https://i.imgur.com/wseLQzZ.png",
   "color": "#232325",

--- a/websites/R/Rabbit's BS Viewer/presence.ts
+++ b/websites/R/Rabbit's BS Viewer/presence.ts
@@ -22,7 +22,7 @@ presence.on("UpdateData", async () => {
       } ${document.querySelector("#songsubname").textContent}`;
       presenceData.state = `${(
         document.getElementById("difficultyselect") as HTMLSelectElement
-      ).textContent.replace("Plus", "+")} (${
+      ).value.replace("Plus", "+")} (${
         (
           document.getElementById("difficultyselect") as HTMLSelectElement
         ).selectedOptions.item(0).textContent


### PR DESCRIPTION
**Describe the changes in this pull request:**
Show only currently selected difficulty
<details>
<summary> Proof to proving the creation/modification working </summary>
<br>
<!-- Required when a presence has been added or modified --->
<!-- Attach screenshot(s) here --->

![Discord_uy88A3UuJC](https://user-images.githubusercontent.com/44418429/147405843-f4de7289-ec02-4954-9064-d7629262a5ee.png)

</details>