### PR TITLE
fix(SoundCloud): fallback lang to en

### DIFF
--- a/websites/S/SoundCloud/dist/metadata.json
+++ b/websites/S/SoundCloud/dist/metadata.json
@@ -31,7 +31,7 @@
     "zh_TW": "SoundCloud是一個線上音樂分享平臺，它允許人們合作、交流和分享原創音樂錄音。"
   },
   "url": "soundcloud.com",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "logo": "https://i.imgur.com/KgOkfIz.png",
   "thumbnail": "https://i.imgur.com/eZyrvbS.jpg",
   "color": "#FF7E30",

--- a/websites/S/SoundCloud/presence.ts
+++ b/websites/S/SoundCloud/presence.ts
@@ -118,7 +118,7 @@ presence.on("UpdateData", async () => {
         presence.getSetting<boolean>("song"),
         presence.getSetting<boolean>("timestamp"),
         presence.getSetting<boolean>("cover"),
-        presence.getSetting<string>("lang")
+        presence.getSetting<string>("lang").catch(() => "en")
       ]),
     playing = Boolean(document.querySelector(".playControls__play.playing"));
 


### PR DESCRIPTION
**Describe the changes in this pull request:**
Fallback lang to English incase the language option isn't loaded

<details>
<summary> Proof to proving the creation/modification working </summary>
<br>
<!-- Required when a presence has been added or modified --->
<!-- Attach screenshot(s) here --->
</details>