### PR TITLE
ci(Lint): remove pretty from lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "author": "Timeraa",
   "license": "MPL-2.0",
   "scripts": {
-    "lint": "eslint --fix . && prettier --write **/*.ts **/{metadata,tsconfig}.json",
-    "lint:ci": "eslint . && prettier **/*.ts **/{metadata,tsconfig}.json",
+    "lint": "eslint --fix .",
+    "lint:ci": "eslint .",
     "inc": "tsc -p ./util/configs/tsconfig.massVer.json && node ./util/tools/massVer.js",
     "se": "tsc -p ./util/configs/tsconfig.auto.syntaxEnforcer.json && node ./util/tools/auto/syntaxEnforcer.js",
     "sv": "tsc -p ./util/configs/tsconfig.auto.schemaValidator.json && node ./util/tools/auto/schemaValidator.js",


### PR DESCRIPTION
**Describe the changes in this pull request:**
This pull requests removes Prettier from the `lint:ci` script as it is unneeded - `prettier/prettier` on ESLint handles these errors, and by removing prettier it will speed up the time it takes to run the script. 