### PR TITLE
feat(Scripts): fix bugs and improve SV

### DIFF
--- a/util/tools/auto/schemaValidator.ts
+++ b/util/tools/auto/schemaValidator.ts
@@ -1,10 +1,11 @@
 import "source-map-support/register";
 
+import { readFileSync } from "node:fs";
 import axios from "axios";
 import { blue, green, red, yellow } from "chalk";
-import { readFileSync } from "fs";
 import ParseJSON, { ObjectNode } from "json-to-ast";
 import { validate } from "jsonschema";
+import { compare, diff } from "semver";
 
 const latestMetadataSchema = async (): Promise<string[]> => {
     const versions = (
@@ -26,18 +27,39 @@ const latestMetadataSchema = async (): Promise<string[]> => {
     validatedWithWarnings: 0,
     failedToValidate: 0
   },
-  isValidVersion = (oldVer: string, newVer: string): [boolean, string?] => {
+  versionBumpErrors = {
+    invalidVerNew: () => 'The version of a new presence must start at "1.0.0"',
+    versionNotBumped: (oldVersion: string, newVersion: string) =>
+      `The current version (${newVersion}) of the presence has not been bumped. The latest published version is ${oldVersion}`,
+    badVersionBump: (oldVersion: string, newVersion: string) =>
+      `The current version (${newVersion}) of the presence was incorrectly bumped. The latest published version is ${oldVersion}.`
+  },
+  isValidVersionBump = (newVer: string, oldVer?: string) => {
     if (!oldVer) {
-      if (newVer !== "1.0.0") return [false, "invalidVerNew"];
-      else return [true];
+      if (newVer !== "1.0.0") return "invalidVerNew";
+      else return true;
     } else {
-      const oldVerSplit = oldVer.split(".").map(Number),
-        newVerSplit = newVer.split(".").map(Number);
-      for (let i = 0; i < oldVerSplit.length; i++) {
-        if (newVerSplit[i] > oldVerSplit[i]) return [true];
-        if (newVerSplit[i] < oldVerSplit[i]) return [false];
+      const compared = compare(newVer, oldVer),
+        newVerSplit = newVer.split(".").map(Number),
+        oldVerSplit = oldVer.split(".").map(Number);
+      if (compared !== 1) return "versionNotBumped";
+      else {
+        switch (diff(newVer, oldVer)) {
+          case "major":
+            if (!newVer.endsWith(".0.0") || newVerSplit[0] - oldVerSplit[0] > 1)
+              return "badVersionBump";
+            else return true;
+          case "minor":
+            if (!newVer.endsWith(".0") || newVerSplit[1] - oldVerSplit[1] > 1)
+              return "badVersionBump";
+            else return true;
+          case "patch":
+            if (newVerSplit[2] - oldVerSplit[2] > 1) return "badVersionBump";
+            else return true;
+          default:
+            return true;
+        }
       }
-      return [false];
     }
   },
   validated = (service: string): void => {
@@ -72,9 +94,13 @@ const latestMetadataSchema = async (): Promise<string[]> => {
 
     return `::${params.type} ${input.join(",")}::${params.message}`;
   },
-  changedFiles = readFileSync("./file_changes.txt", "utf-8").trim().split("\n"),
-  metaFiles = [
-    ...new Set(changedFiles.filter(f => f.endsWith("metadata.json")))
+  changedMetaFiles = [
+    ...new Set(
+      readFileSync("./file_changes.txt", "utf-8")
+        .trim()
+        .split("\n")
+        .filter(f => f.endsWith("metadata.json"))
+    )
   ];
 
 (async (): Promise<void> => {
@@ -83,9 +109,9 @@ const latestMetadataSchema = async (): Promise<string[]> => {
   const [latestSchema, latestSchemaVersion] = await latestMetadataSchema(),
     schema = (await axios.get(latestSchema)).data;
 
-  console.log(blue(`Beginning validation of ${metaFiles.length} presences...`));
+  console.log(blue(`Beginning validation of ${changedMetaFiles.length} presences...`));
 
-  for (const metaFile of metaFiles) {
+  for (const metaFile of changedMetaFiles) {
     const meta = loadMetadata(metaFile),
       folder = metaFile.split("/")[2];
 
@@ -119,7 +145,8 @@ const latestMetadataSchema = async (): Promise<string[]> => {
       ).data.data,
       validLangs = langFiles.map(l => l.lang),
       oldVersion = presences[0]?.metadata.version,
-      invalidLangs: string[] = [];
+      invalidLangs: string[] = [],
+      versionCheck = isValidVersionBump(newVersion, oldVersion);
 
     Object.keys(meta.description).forEach(lang => {
       const index = validLangs.findIndex((l: string) => l === lang);
@@ -127,7 +154,7 @@ const latestMetadataSchema = async (): Promise<string[]> => {
     });
 
     if (
-      isValidVersion(oldVersion, newVersion)[0] &&
+      versionCheck === true &&
       folder === meta.service &&
       !invalidLangs.length &&
       result.valid
@@ -145,31 +172,18 @@ const latestMetadataSchema = async (): Promise<string[]> => {
         );
       } else validated(service);
     } else {
-      const errors: string[] = [],
-        versionCheck = isValidVersion(oldVersion, newVersion);
+      const errors: string[] = [];
 
-      if (!versionCheck[0]) {
-        if (!versionCheck[1]) {
-          errors.push(
-            createAnnotation({
-              type: "error",
-              file: metaFile,
-              line: getLine("version"),
-              title: "instance.version",
-              message: `The current version (${newVersion}) of the presence has not been bumped. The latest published version is ${oldVersion}`
-            })
-          );
-        } else {
-          errors.push(
-            createAnnotation({
-              type: "error",
-              file: metaFile,
-              line: getLine("version"),
-              title: "instance.version",
-              message: 'The version of a new presence must start at "1.0.0"'
-            })
-          );
-        }
+      if (typeof versionCheck === "string") {
+        errors.push(
+          createAnnotation({
+            type: "error",
+            file: metaFile,
+            line: getLine("version"),
+            title: "instance.version",
+            message: versionBumpErrors[versionCheck](oldVersion, newVersion)
+          })
+        );
       }
 
       if (folder !== service) {

--- a/util/tools/auto/syntaxEnforcer.ts
+++ b/util/tools/auto/syntaxEnforcer.ts
@@ -121,17 +121,16 @@ const readFile = (path: string): string =>
     );
 
     // Use Git to check what files have changed after TypeScript compilation
-    const listOfChangedFiles = await execShellCommand([
-        "git",
-        "--no-pager",
-        "diff",
-        "--name-only"
-      ]),
-      changedPresenceFiles = listOfChangedFiles
-        .split("\n")
-        .filter(
-          file => file.includes("presence.ts") || file.includes("iframe.ts")
-        );
+    const changedPresenceFiles = (
+      await execShellCommand(["git", "--no-pager", "diff", "--name-only"])
+    )
+      .split("\n")
+      .filter(
+        file =>
+          file.includes("presence.ts") ||
+          file.includes("iframe.ts") ||
+          file.includes("metadata.json")
+      );
 
     await increaseSemver(changedPresenceFiles);
 


### PR DESCRIPTION
**Describe the changes in this pull request:**
This PR brings you yet another improvement to the scripts

- Fixes a bug noticed in #5165 where a version wasn't bumped since the only change was done to the metadata file
- Improves SV to more strictly check version bumps: it now only allows you to bump 1 part of semver and you can't bump a version more than once. Examples of invalid bumps are 1.1.1 -> 1.1.3 and 1.1.1 -> 1.2.1.

<details>
<summary> Proof to proving the creation/modification working </summary>
<br>
<!-- Required when a presence has been added or modified --->
hell no
<!-- Attach screenshot(s) here --->
</details>