### PR TITLE
feat(Google Podcasts): added new pages

### DIFF
--- a/websites/G/Google Podcasts/dist/metadata.json
+++ b/websites/G/Google Podcasts/dist/metadata.json
@@ -12,7 +12,7 @@
     "vi_VN": "Với Google Podcasts, bạn có thể tìm và lắng nghe các bản podcast trên thế giới miễn phí."
   },
   "url": "podcasts.google.com",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "logo": "https://i.imgur.com/OiPOkMA.png",
   "thumbnail": "https://i.imgur.com/iI3qc0M.jpg",
   "color": "#ffffff",
@@ -20,6 +20,7 @@
   "tags": [
     "google",
     "podcast",
+    "audio",
     "listen"
   ]
 }

--- a/websites/G/Google Podcasts/presence.ts
+++ b/websites/G/Google Podcasts/presence.ts
@@ -33,9 +33,9 @@ presence.on("UpdateData", async () => {
         elapsedSeconds;
     }
   } else if (document.location.pathname === "/")
-    presenceData.details = "Browsing Podcasts";
+    presenceData.details = "Browsing podcasts";
   else if (document.location.pathname.includes("feed/")) {
-    presenceData.details = "Viewing Podcast";
+    presenceData.details = "Viewing podcast";
     // It's quite tricky to locate the right podcast title because
     // website makes new element for each of them
     for (const element of document.getElementsByClassName("dbCu3e")) {
@@ -43,7 +43,13 @@ presence.on("UpdateData", async () => {
         presenceData.state = `${document.title} by ${element.children[1].textContent}`;
     }
   } else if (document.location.pathname.includes("/subscriptions"))
-    presenceData.details = "Browsing Subscriptions";
+    presenceData.details = "Browsing subscriptions";
+  else if (document.location.pathname.includes("/queue"))
+    presenceData.details = "Browsing queue";
+  else if (document.location.pathname.includes("/subscribe-by-rss-feed"))
+    presenceData.details = "Subscribing by RSS feed";
+  else if (document.location.pathname.includes("/settings"))
+    presenceData.details = "Browsing settings";
   else if (document.location.pathname.includes("search/")) {
     presenceData.details = "Searching for podcast";
     presenceData.state = document.location.pathname.replace("/search/", "");


### PR DESCRIPTION
**Describe the changes in this pull request:**
I have added the queue, subscribe by RSS feed, and settings pages to the Google Podcasts presence.
<details> 
<summary> Proof of the created/modified presence working </summary>
<br>

![queue](https://user-images.githubusercontent.com/95990495/148690234-e532eba3-4668-48c5-bc80-b516e24f9518.PNG)
![rssfeed](https://user-images.githubusercontent.com/95990495/148690238-3c146c4e-e5f3-4ac5-bf0c-3629b345eebe.PNG)
![settings](https://user-images.githubusercontent.com/95990495/148690244-99e39081-2fab-4c29-b801-7bd6710d5c44.PNG)
</details>