### PR TITLE
fix(SoundCloud): translation strings could be undefined

### DIFF
--- a/websites/S/SoundCloud/dist/metadata.json
+++ b/websites/S/SoundCloud/dist/metadata.json
@@ -32,7 +32,7 @@
     "vi_VN": "SoundCloud là nền tảng phát nhạc và podcast trực tuyến nơi bạn có thể nghe hàng triệu bài hát từ khắp thế giới, hoặc tự đăng tải tác phẩm của riêng mình."
   },
   "url": "soundcloud.com",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "logo": "https://i.imgur.com/KgOkfIz.png",
   "thumbnail": "https://i.imgur.com/eZyrvbS.jpg",
   "color": "#FF7E30",

--- a/websites/S/SoundCloud/presence.ts
+++ b/websites/S/SoundCloud/presence.ts
@@ -122,7 +122,7 @@ presence.on("UpdateData", async () => {
       ]),
     playing = Boolean(document.querySelector(".playControls__play.playing"));
 
-  if (oldLang !== newLang) {
+  if (oldLang !== newLang || !strings) {
     oldLang = newLang;
     strings = await getStrings();
   }


### PR DESCRIPTION
**Describe the changes in this pull request:**
Fixing an error where the translation strings wouldn't be initialized.
![image](https://user-images.githubusercontent.com/43505515/149366356-e04ca9de-d4ff-4d93-aae1-6c1e0197b14f.png)