### PR TITLE
feat(SOAP2DAY): add support for more URLs

### DIFF
--- a/websites/S/SOAP2DAY/dist/metadata.json
+++ b/websites/S/SOAP2DAY/dist/metadata.json
@@ -20,7 +20,6 @@
     "s2dfree.nl",
     "secretlink.xyz"
   ],
-  "regExp": "([a-z0-9]+[.])*(soap2day|s2dfree)([.][a-z]+)",
   "version": "1.1.0",
   "logo": "https://i.imgur.com/WAOvAe6.png",
   "thumbnail": "https://i.imgur.com/AEHBaRS.png",

--- a/websites/S/SOAP2DAY/dist/metadata.json
+++ b/websites/S/SOAP2DAY/dist/metadata.json
@@ -8,9 +8,20 @@
   "description": {
     "en": "You can watch all videos without logging in or registration. Soap2day is free all the time, but there are few ads on videoplayer page."
   },
-  "url": "soap2day.to",
+  "url": [
+    "soap2day.to",
+    "soap2day.ac",
+    "soap2day.sh",
+    "soap2day.cx",
+    "s2dfree.to",
+    "s2dfree.cc",
+    "s2dfree.de",
+    "s2dfree.is",
+    "s2dfree.nl",
+    "secretlink.xyz"
+  ],
   "regExp": "([a-z0-9]+[.])*(soap2day|s2dfree)([.][a-z]+)",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "logo": "https://i.imgur.com/WAOvAe6.png",
   "thumbnail": "https://i.imgur.com/AEHBaRS.png",
   "color": "#9eeae7",


### PR DESCRIPTION
**Describe the changes in this pull request:**

This PR adds support for these URLs: https://soapgate.org/domain.html + a secret one. Website structure is the same so code doesn't need to be updated

<details>
<summary> Proof to proving the creation/modification working </summary>
<br>
<!-- Required when a presence has been added or modified --->
<!-- Attach screenshot(s) here --->
don't tell me what to do I am an independent woman
</details>