### PR TITLE
chore: run SE instead of lint on pre-commit

### DIFF
--- a/.github/workflows/SE.yml
+++ b/.github/workflows/SE.yml
@@ -1,7 +1,5 @@
 name: Syntax Enforcer
 on:
-  schedule:
-    - cron: 0 0 */3 * *
   workflow_dispatch:
 jobs:
   qa:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-(yarn lint || true) && git add .
+(yarn se || true) && git add .

--- a/util/tools/auto/syntaxEnforcer.ts
+++ b/util/tools/auto/syntaxEnforcer.ts
@@ -9,7 +9,7 @@ import debug from "debug";
 const log = debug("SyntaxEnforcer");
 debug.enable("SyntaxEnforcer*");
 /**
- * Executes a shell command and return it as a Promise.
+ * Executes a shell command
  * @param cmd {string[]}
  * @return Promise<string>
  */
@@ -80,12 +80,6 @@ const readFile = (path: string): string =>
 	},
 	// Main function that calls the other functions above
 	main = async (): Promise<void> => {
-		if (!process.env.GITHUB_ACTIONS) {
-			console.log(
-				"\nPlease note that this script is ONLY supposed to run on a CI environment\n"
-			);
-		}
-
 		log.extend("Lint")("Prettifying files");
 
 		await execShellCommand(["yarn", "lint"]);

--- a/websites/G/Granblue Fantasy/dist/metadata.json
+++ b/websites/G/Granblue Fantasy/dist/metadata.json
@@ -21,19 +21,26 @@
 		"vi_VN": "Trò chơi đóng vai Nhật Bản"
 	},
 	"url": "game.granbluefantasy.jp",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"logo": "https://i.imgur.com/XyHgDQX.png",
 	"thumbnail": "https://i.imgur.com/2GPNZM8.jpg",
 	"color": "#2F4F7A",
 	"category": "games",
-	"tags": ["grandblue-fanstasy", "game", "jrpg"],
+	"tags": [
+		"grandblue-fanstasy",
+		"game",
+		"jrpg"
+	],
 	"settings": [
 		{
 			"id": "health",
 			"title": "Health points",
 			"icon": "fad fa-heart",
 			"value": 0,
-			"values": ["Simple", "Detailed"]
+			"values": [
+				"Simple",
+				"Detailed"
+			]
 		},
 		{
 			"id": "djeeta",


### PR DESCRIPTION
- Add styling to SE to make it aligned with debug on the SE script
- Use `SE` instead of `lint` on pre-commit to prevent unnecessary modifications & syntax enforcement
- Remove `cron` schedule from SE as there ideally shouldn't be any errors pushed with the change of pre-commit, this can still be manually triggered using the `workflow_dispatch`
- Run Syntax Enforcer to enforce styling on the repo 
