### PR TITLE
fix(UpBeatRadio): change query selector to get correct data

### DIFF
--- a/websites/U/UpBeatRadio/dist/metadata.json
+++ b/websites/U/UpBeatRadio/dist/metadata.json
@@ -11,7 +11,7 @@
 		"ga_IE": "Is raidió ar líne saor in aisce, faoi thiomáint ag an bpobal é UpBeat."
 	},
 	"url": "upbeatradio.net",
-	"version": "3.2.14",
+	"version": "3.2.15",
 	"logo": "https://i.imgur.com/xFz6AU3.png",
 	"thumbnail": "https://i.imgur.com/CvdIcM8.png",
 	"color": "#212121",

--- a/websites/U/UpBeatRadio/presence.ts
+++ b/websites/U/UpBeatRadio/presence.ts
@@ -76,10 +76,10 @@ presence.on("UpdateData", async () => {
 			}
 		} else if (document.location.pathname.includes("/News.Article")) {
 			presenceData.details = `Reading article: ${document
-				.querySelector(".title")
+				.querySelector("#newsTitle")
 				.textContent.trim()}`;
 			presenceData.state = `Written by: ${document
-				.querySelector(".info > a")
+				.querySelector("#newsInfo > a")
 				.textContent.trim()}`;
 			presenceData.smallImageKey = "reading";
 		} else if (document.location.pathname.includes("/Account.Profile")) {


### PR DESCRIPTION
The presence was showing incorrect data when viewing news articles previously, to combat this, we added some code on the website to make sure that the presence can get the correct data, by modifying the code on our articles page. I've edited the presence code accordingly, to make this show up properly on user's Discord profiles.