### PR TITLE
style: set editorconfig to use tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,5 +2,4 @@ root = true
 
 [*.ts]
 end_of_line = lf
-indent_style = space
-indent_size = 2
+indent_style = tab


### PR DESCRIPTION
**Describe the changes in this pull request:**

This PR fixes the .editorconfig file to use tabs instead of spaces.
Honestly, can't we just remove this?