### PR TITLE
feat(Tidal): album cover as `.largeImageKey` & privacy settings

### DIFF
--- a/websites/T/Tidal/dist/metadata.json
+++ b/websites/T/Tidal/dist/metadata.json
@@ -4,6 +4,12 @@
 		"name": "The Gamerzs",
 		"id": "730142125181894657"
 	},
+	"contributors": [
+		{
+			"name": "Kyrie",
+			"id": "368399721494216706"
+		}
+	],
 	"service": "Tidal",
 	"description": {
 		"tr": "Tidal yüksek ses kalitesi ve ucuz fiyatlarla hizmet sağlayan bir müzik sitesidir.",
@@ -12,23 +18,35 @@
 		"nl": "Tidal is een muziekstreamdienst met een zeer hoge geluidskwaliteit.",
 		"vi_VN": "Tidal là dịch vụ phát nhạc với chất lượng âm thanh rất cao."
 	},
-	"url": [
-		"listen.tidal.com",
-		"tidal.com"
-	],
-	"version": "3.0.5",
+	"url": ["listen.tidal.com", "tidal.com"],
+	"version": "3.1.0",
 	"logo": "https://i.imgur.com/i9pIvqR.png",
 	"thumbnail": "https://i.imgur.com/xNeJ8oq.png",
 	"color": "#000000",
 	"category": "music",
-	"tags": [
-		"tidal",
-		"music"
-	],
+	"tags": ["tidal", "music"],
 	"settings": [
 		{
 			"id": "lang",
 			"multiLanguage": true
+		},
+		{
+			"id": "timestamps",
+			"title": "Show Timestamps",
+			"icon": "fad fa-stopwatch",
+			"value": true
+		},
+		{
+			"id": "cover",
+			"title": "Show Cover",
+			"icon": "fad fa-images",
+			"value": true
+		},
+		{
+			"id": "buttons",
+			"title": "Show Buttons",
+			"icon": "fas fa-compress-arrows-alt",
+			"value": true
 		}
 	]
 }

--- a/websites/T/Tidal/presence.ts
+++ b/websites/T/Tidal/presence.ts
@@ -20,7 +20,12 @@ presence.on("UpdateData", async () => {
 	if (!document.querySelector("#footerPlayer"))
 		return presence.setActivity({ largeImageKey: "logo" });
 
-	const newLang = await presence.getSetting<string>("lang").catch(() => "en");
+	const [newLang, timestamps, cover, buttons] = await Promise.all([
+		presence.getSetting<string>("lang").catch(() => "en"),
+		presence.getSetting<boolean>("timestamps"),
+		presence.getSetting<boolean>("cover"),
+		presence.getSetting<boolean>("buttons")
+	]);
 
 	if (oldLang !== newLang || !strings) {
 		oldLang = newLang;
@@ -49,12 +54,15 @@ presence.on("UpdateData", async () => {
 			.querySelector(
 				'div[data-test="play-controls"] > button[data-test="repeat"]'
 			)
-			.getAttribute("aria-label");
+			.getAttribute("aria-label"),
+		coverArt = document.querySelector<HTMLImageElement>("#react-tabs-1 img");
 
 	presenceData.details = songTitle.textContent;
 	presenceData.state = document.querySelector(
 		'div[data-test="left-column-footer-player"] > div:nth-child(2) > div:nth-child(2) > span > span > span'
 	).textContent;
+
+	if (coverArt && cover) presenceData.largeImageKey = coverArt.src;
 
 	if (currentTimeSec > 0 || !paused) {
 		presenceData.endTimestamp =
@@ -81,13 +89,14 @@ presence.on("UpdateData", async () => {
 
 		delete presenceData.endTimestamp;
 	}
-
-	presenceData.buttons = [
-		{
-			label: (await strings).viewSong,
-			url: songTitle.href
-		}
-	];
-
+	if (buttons) {
+		presenceData.buttons = [
+			{
+				label: (await strings).viewSong,
+				url: songTitle.href
+			}
+		];
+	}
+	if (!timestamps) delete presenceData.endTimestamp;
 	presence.setActivity(presenceData);
 });


### PR DESCRIPTION
**Describe the changes in this pull request:**
Add option to show album art cover as `.largeImageKey` & other privacy settings
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<br>
<!-- Required when a presence has been added or modified --->
<!-- Attach screenshot(s) here --->

![image](https://user-images.githubusercontent.com/77577746/151375401-0e690a50-14af-4707-b20a-71fc373e55ed.png)
![image](https://user-images.githubusercontent.com/77577746/151373639-362651b8-99a2-4447-b93d-bd737c4458e5.png)
![image](https://user-images.githubusercontent.com/77577746/151373653-0db30d7d-bbdb-40bc-bd8a-3bae82199a3d.png)
![image](https://user-images.githubusercontent.com/77577746/151373665-92910f74-1217-4897-9e6e-a049bbadd035.png)
- Art cover settings disabled:
![image](https://user-images.githubusercontent.com/77577746/151373746-b48b50d1-3aa8-475f-99c5-ac879ea0f929.png)
- Timestamps settings disabled:
![image](https://user-images.githubusercontent.com/77577746/151373812-49dbe2d3-afe5-4594-b38e-50408f686927.png)
- Buttons settings disabled:
![image](https://user-images.githubusercontent.com/77577746/151373842-0e6e0ff4-78c1-43dd-b85b-26e8329f46a7.png)

</details>
