### PR TITLE
fix(Tidal): incorrect album cover

### DIFF
--- a/websites/T/Tidal/dist/metadata.json
+++ b/websites/T/Tidal/dist/metadata.json
@@ -18,19 +18,13 @@
 		"nl": "Tidal is een muziekstreamdienst met een zeer hoge geluidskwaliteit.",
 		"vi_VN": "Tidal là dịch vụ phát nhạc với chất lượng âm thanh rất cao."
 	},
-	"url": [
-		"listen.tidal.com",
-		"tidal.com"
-	],
-	"version": "3.1.1",
+	"url": ["listen.tidal.com", "tidal.com"],
+	"version": "3.1.2",
 	"logo": "https://i.imgur.com/i9pIvqR.png",
 	"thumbnail": "https://i.imgur.com/xNeJ8oq.png",
 	"color": "#000000",
 	"category": "music",
-	"tags": [
-		"tidal",
-		"music"
-	],
+	"tags": ["tidal", "music"],
 	"settings": [
 		{
 			"id": "lang",

--- a/websites/T/Tidal/presence.ts
+++ b/websites/T/Tidal/presence.ts
@@ -54,16 +54,20 @@ presence.on("UpdateData", async () => {
 			.querySelector(
 				'div[data-test="play-controls"] > button[data-test="repeat"]'
 			)
-			.getAttribute("aria-label"),
-		coverArt = document.querySelector<HTMLImageElement>("#react-tabs-1 img");
+			.getAttribute("aria-label");
 
 	presenceData.details = songTitle.textContent;
 	presenceData.state = document.querySelector(
 		'div[data-test="left-column-footer-player"] > div:nth-child(2) > div:nth-child(2) > span > span > span'
 	).textContent;
 
-	if (coverArt && cover) presenceData.largeImageKey = coverArt.src;
-
+	if (cover) {
+		presenceData.largeImageKey =
+			navigator.mediaSession.metadata.artwork[0].src.replace(
+				"160x160",
+				"640x640"
+			);
+	}
 	if (currentTimeSec > 0 || !paused) {
 		presenceData.endTimestamp =
 			Date.now() +


### PR DESCRIPTION
**Describe the changes in this pull request:**
Uses `mediaSession` to grab album cover instead of assets on page for accuracy
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<br>
<!-- Required when a presence has been added or modified --->
<!-- Attach screenshot(s) here --->

![image](https://user-images.githubusercontent.com/77577746/151903709-8bde3842-8027-44d7-9420-4632bc95deaa.png)
![image](https://user-images.githubusercontent.com/77577746/151903712-77a7655a-db6e-4ab0-9478-ba480c147ae4.png)

</details>
