### PR TITLE
fix(HBO Go): Add PH/ID URL Support

### DIFF
--- a/websites/H/HBO GO/dist/metadata.json
+++ b/websites/H/HBO GO/dist/metadata.json
@@ -22,6 +22,7 @@
 		"hbogo.cz",
 		"hbogo.sk",
 		"www.hbogoasia.my",
+		"www.hbogoasia.id",
 		"www.hbogoasia.ph"
 	],
 	"version": "2.2.19",

--- a/websites/H/HBO GO/dist/metadata.json
+++ b/websites/H/HBO GO/dist/metadata.json
@@ -21,7 +21,8 @@
 		"hbogo.pl",
 		"hbogo.cz",
 		"hbogo.sk",
-		"www.hbogoasia.my"
+		"www.hbogoasia.my",
+		"www.hbogoasia.ph"
 	],
 	"version": "2.2.18",
 	"logo": "https://i.imgur.com/TTHQtBH.png",

--- a/websites/H/HBO GO/dist/metadata.json
+++ b/websites/H/HBO GO/dist/metadata.json
@@ -24,7 +24,7 @@
 		"www.hbogoasia.my",
 		"www.hbogoasia.ph"
 	],
-	"version": "2.2.18",
+	"version": "2.2.19",
 	"logo": "https://i.imgur.com/TTHQtBH.png",
 	"thumbnail": "https://i.imgur.com/vvAp3GI.png",
 	"color": "#011921",


### PR DESCRIPTION
Resolves #5732 
Resolves #5743 

<details>
<summary> Proof showing the creation/modification is working as expected </summary>
I am unable to test this as I do not reside in the Philippines, but I am 100% sure it will work as it is simply a URL addition and very similar to another site link included in the `metadata.json` file. 
<br>
</details>
