### PR TITLE
chore: remove husky pre-commit lint hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-(yarn format || true)


### PR DESCRIPTION
**Describe the changes in this pull request:**
This PR removes the pre-commit hook from husky as it is way too slow for some contributors on some machines due to the amount of files this PR has. Husky is being kept simply for enforcing commitlint, however file linting will now be handled through CI only