### PR TITLE
feat(Jet Set Radio Live): New domain/stations

### DIFF
--- a/websites/J/Jet Set Radio Live/dist/metadata.json
+++ b/websites/J/Jet Set Radio Live/dist/metadata.json
@@ -15,8 +15,8 @@
 		"en": "Yo! You've heard about Jet Set Radio, right? It's only the hottest radio station straight outta Tokyo-to! Tune in. Turn on. Jet Set Radiooo!!!",
 		"nl": "Yo! Je hebt toch van Jet Set Radio gehoord? Het is alleen het populairste radiostation dat rechtstreeks uit Tokio komt! Stem af. Zet aan. Jetset Radiooo !!!"
 	},
-	"url": "jetsetradio.live",
-	"version": "2.1.9",
+	"url": ["jetsetradio.live", "jetsetradiofuture.live"],
+	"version": "2.2.0",
 	"logo": "https://i.imgur.com/ZiIN6t9.png",
 	"thumbnail": "https://i.imgur.com/TmgNbn4.jpg",
 	"color": "#FFE222",

--- a/websites/J/Jet Set Radio Live/presence.ts
+++ b/websites/J/Jet Set Radio Live/presence.ts
@@ -75,7 +75,10 @@ presence.on("UpdateData", async () => {
 		) {
 			if (await presence.getSetting<boolean>("song"))
 				presenceData.details = songName.textContent;
-			if (await presence.getSetting<boolean>("timestamp") && isFinite(audio.duration)) {
+			if (
+				(await presence.getSetting<boolean>("timestamp")) &&
+				isFinite(audio.duration)
+			) {
 				[presenceData.startTimestamp, presenceData.endTimestamp] =
 					presence.getTimestampsfromMedia(audio);
 			}

--- a/websites/J/Jet Set Radio Live/presence.ts
+++ b/websites/J/Jet Set Radio Live/presence.ts
@@ -5,14 +5,10 @@ const presence = new Presence({
 		play: "presence.playback.playing",
 		pause: "presence.playback.paused"
 	}),
-	getTimestamps = (videoTime: number, videoDuration: number): number[] => {
-		const startTime = Date.now();
-		return [
-			Math.floor(startTime / 1000),
-			Math.floor(startTime / 1000) - videoTime + videoDuration
-		];
-	},
 	stationIDMap: { [key: string]: string } = {
+		olliolliworld: "OlliOlli World",
+		spacechannel5: "Space Channel 5",
+		live: "Jet Set Radio Live",
 		outerspace: "Outer Space",
 		classic: "Classic",
 		future: "Future",
@@ -36,11 +32,14 @@ const presence = new Presence({
 		silvagunner: "SilvaGunner x JSR",
 		futuregeneration: "Future Generation",
 		jetmashradio: "Jet Mash Radio",
+		memoriesoftokyoto: "Memories of Tokyo-to",
+		tokyotofuture: "Sounds of Tokyo-to Future",
 		crazytaxi: "Crazy Taxi",
 		ollieking: "Ollie King",
 		toejamandearl: "Toe Jam & Earl",
 		hover: "Hover",
 		butterflies: "Butterflies",
+		lethalleagueblaze: "Lethal League Blace",
 		bonafidebloom: "BonafideBloom",
 		djchidow: "DJ Chidow",
 		verafx: "VeraFX",
@@ -76,12 +75,9 @@ presence.on("UpdateData", async () => {
 		) {
 			if (await presence.getSetting<boolean>("song"))
 				presenceData.details = songName.textContent;
-			if (await presence.getSetting<boolean>("timestamp")) {
+			if (await presence.getSetting<boolean>("timestamp") && isFinite(audio.duration)) {
 				[presenceData.startTimestamp, presenceData.endTimestamp] =
-					getTimestamps(
-						Math.floor(audio.currentTime),
-						Math.floor(audio.duration)
-					);
+					presence.getTimestampsfromMedia(audio);
 			}
 			presenceData.smallImageKey = "play";
 			presenceData.smallImageText = (await strings).play;


### PR DESCRIPTION
This PR adds updates to the Jet Set Radio Live presence:
- Uses `presence.getTimestampsfromMedia` in timestamps
- Added https://jetsetradiolivefuture.live as a URL for the presence
- Fixed bug where `audio.duration` can be infinite
- Added 6 new station names/images

<details>
<summary>Presence Screenshot</summary>

![image](https://user-images.githubusercontent.com/7025343/153780900-cd0c8b3c-645c-49c0-81ec-d29824e54264.png)

</details>
