### PR TITLE
fix(Letterboxd): presence not working

### DIFF
--- a/websites/L/Letterboxd/dist/metadata.json
+++ b/websites/L/Letterboxd/dist/metadata.json
@@ -9,7 +9,7 @@
 		"en": "The social network for film lovers."
 	},
 	"url": "letterboxd.com",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"logo": "https://i.imgur.com/nbvB9cV.png",
 	"thumbnail": "https://i.imgur.com/Mx9K2lU.png",
 	"color": "#202830",

--- a/websites/L/Letterboxd/presence.ts
+++ b/websites/L/Letterboxd/presence.ts
@@ -3,7 +3,7 @@ const presence = new Presence({
 	}),
 	user = document.cookie
 		.split(";")
-		.find(val => val.startsWith("letterboxd"))
+		.find(val => val.trim().startsWith("letterboxd"))
 		.split("=")[1],
 	browsingTimestamp = Math.floor(Date.now() / 1000);
 


### PR DESCRIPTION
**Describe the changes in this pull request:**
Resolves #5793 

In my browser, the cookie required to retrieve the username was being stored with a preceding space. This caused the entire presence to fail, even when on the homepage. I'm not sure how the cookies are stored on other browsers, but some extra string sanitation never hurts.
![image](https://user-images.githubusercontent.com/35435704/153787517-34f4cbcb-d387-4ca8-b7f8-ada35a8c4c79.png)
![image](https://user-images.githubusercontent.com/35435704/153787540-3a241fab-05bb-4de9-8ed5-612e753ba454.png)


<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<br>
<!-- Required when a presence has been added or modified --->
<!-- Attach screenshot(s) here --->
<img src="https://user-images.githubusercontent.com/35435704/153787303-ebd9b810-23a1-4e80-bb61-633d101803a4.png">

</details>
