### PR TITLE
chore(Monkeytype): update logo and thumbnail

### DIFF
--- a/websites/M/Monkeytype/dist/metadata.json
+++ b/websites/M/Monkeytype/dist/metadata.json
@@ -20,8 +20,8 @@
 		"monkeytype.com"
 	],
 	"version": "2.0.9",
-	"logo": "https://i.imgur.com/OnkMhFB.png",
-	"thumbnail": "https://i.imgur.com/HH1UVqD.png",
+	"logo": "https://i.imgur.com/IgXEro3.png",
+	"thumbnail": "https://i.imgur.com/PsuyFRC.png",
 	"color": "#383200",
 	"category": "games",
 	"tags": [

--- a/websites/M/Monkeytype/dist/metadata.json
+++ b/websites/M/Monkeytype/dist/metadata.json
@@ -19,7 +19,7 @@
 		"www.monkeytype.com",
 		"monkeytype.com"
 	],
-	"version": "2.0.9",
+	"version": "2.0.10",
 	"logo": "https://i.imgur.com/IgXEro3.png",
 	"thumbnail": "https://i.imgur.com/PsuyFRC.png",
 	"color": "#383200",


### PR DESCRIPTION
Monkeytype has changed its logo a while ago. Just realised the presence still has the old images.

This PR updates the imgur links.

new logo
![new logo](https://i.imgur.com/IgXEro3.png)

new thumbnail
![new thumbnail](https://i.imgur.com/PsuyFRC.png)