### PR TITLE
feat(Manga Plus): patch presence & add settings

### DIFF
--- a/websites/M/Manga Plus/dist/metadata.json
+++ b/websites/M/Manga Plus/dist/metadata.json
@@ -9,7 +9,7 @@
 		"en": "MANGA Plus by SHUEISHA is the official manga reader from Shueisha Inc., and is globally available. We publish the greatest manga in the world such as Naruto, Dragon Ball, One Piece, Bleach and more. You can read the latest chapters of the best manga for FREE, DAILY, and SIMULTANEOUSLY with its release in Japan."
 	},
 	"url": "mangaplus.shueisha.co.jp",
-	"version": "1.0.3",
+	"version": "1.1.0",
 	"logo": "https://i.imgur.com/W3vFfFi.png",
 	"thumbnail": "https://i.imgur.com/9LDiYWc.png",
 	"color": "#E83608",
@@ -19,5 +19,13 @@
 		"plus",
 		"suieisha",
 		"anime"
+	],
+	"settings": [
+		{
+			"id": "buttons",
+			"title": "Show Buttons",
+			"icon": "fas fa-compress-arrows-alt",
+			"value": true
+		}
 	]
 }

--- a/websites/M/Manga Plus/presence.ts
+++ b/websites/M/Manga Plus/presence.ts
@@ -2,26 +2,41 @@ const presence = new Presence({
 		clientId: "923893773048619008"
 	}),
 	browsingTimestamp = Math.floor(Date.now() / 1000);
+let cacheMangaURL: string, cacheMangaChapter: string;
 
-presence.on("UpdateData", () => {
+presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
+			details: "Browsing",
 			largeImageKey: "logo",
 			startTimestamp: browsingTimestamp
 		},
-		path = document.location.pathname;
-	if (path.startsWith("/updates"))
+		{ pathname } = document.location,
+		MangaURL = document.querySelector<HTMLAnchorElement>(
+			"#app div.Navigation-module_detailContainer_1aDk8 > a"
+		),
+		MangaChapter = document.querySelector<HTMLParagraphElement>(
+			"#app > div > div > div > div > div > div > p"
+		),
+		buttons = await presence.getSetting<boolean>("buttons");
+
+	// So that the script would stop throwing errors when the navigator collapses
+	if (MangaURL?.href !== cacheMangaURL) cacheMangaURL = MangaURL.href;
+	if (MangaChapter?.textContent !== cacheMangaChapter)
+		cacheMangaChapter = MangaChapter.textContent;
+
+	if (pathname.startsWith("/updates"))
 		presenceData.details = "Browsing lastest updates";
-	else if (path.startsWith("/featured"))
+	else if (pathname.startsWith("/featured"))
 		presenceData.details = "Browsing featured mangas";
-	else if (path.startsWith("/manga_list")) {
-		if (path.includes("all")) presenceData.details = "Browsing all mangas";
-		else if (path.includes("hot"))
+	else if (pathname.startsWith("/manga_list")) {
+		if (pathname.includes("all")) presenceData.details = "Browsing all mangas";
+		else if (pathname.includes("hot"))
 			presenceData.details = "Browsing hottest mangas";
-		else if (path.includes("updated"))
+		else if (pathname.includes("updated"))
 			presenceData.details = "Browsing updated mangas";
-	} else if (path.startsWith("/favorited"))
+	} else if (pathname.startsWith("/favorited"))
 		presenceData.details = "Viewing favorited mangas";
-	else if (path.startsWith("/titles")) {
+	else if (pathname.startsWith("/titles")) {
 		presenceData.details = `Viewing: ${document.title.substring(
 			0,
 			document.title.lastIndexOf("-") - 1
@@ -31,26 +46,19 @@ presence.on("UpdateData", () => {
 			document.title.lastIndexOf("|") - 1
 		);
 		presenceData.buttons = [{ label: "View series", url: document.URL }];
-	} else if (path.startsWith("/viewer")) {
+	} else if (pathname.startsWith("/viewer")) {
 		presenceData.details = `Reading: ${
-			document.querySelector<HTMLHeadingElement>(
-				"#app > div:nth-child(2) > div.Viewer-module_wrapper_11OpA > div:nth-child(3) > div.Navigation-module_header_37C_9.Navigation-module_appear_30FBL > div.Navigation-module_detailContainer_1aDk8 > a > h1"
-			).textContent
+			document.querySelector<HTMLHeadingElement>("#app a > h1").textContent
 		}`;
-		presenceData.state = `Chapter ${
-			document.querySelector<HTMLParagraphElement>(
-				"#app > div:nth-child(2) > div.Viewer-module_wrapper_11OpA > div:nth-child(3) > div.Navigation-module_header_37C_9.Navigation-module_appear_30FBL > div.Navigation-module_detailContainer_1aDk8 > div > p"
-			).textContent
-		}`;
+		presenceData.state = `Chapter ${cacheMangaChapter}`;
 		presenceData.buttons = [
 			{ label: "Read chapter", url: document.URL },
 			{
 				label: "View series",
-				url: document.querySelector<HTMLAnchorElement>(
-					"#app > div:nth-child(2) > div.Viewer-module_wrapper_11OpA > div:nth-child(3) > div.Navigation-module_header_37C_9.Navigation-module_appear_30FBL > div.Navigation-module_detailContainer_1aDk8 > a"
-				).href
+				url: cacheMangaURL
 			}
 		];
-	} else presenceData.details = "Browsing";
+	}
+	if (!buttons) delete presenceData.buttons;
 	presence.setActivity(presenceData);
 });

--- a/websites/M/Manga Plus/presence.ts
+++ b/websites/M/Manga Plus/presence.ts
@@ -11,18 +11,18 @@ presence.on("UpdateData", async () => {
 			startTimestamp: browsingTimestamp
 		},
 		{ pathname } = document.location,
-		MangaURL = document.querySelector<HTMLAnchorElement>(
+		mangaURL = document.querySelector<HTMLAnchorElement>(
 			"#app div.Navigation-module_detailContainer_1aDk8 > a"
 		),
-		MangaChapter = document.querySelector<HTMLParagraphElement>(
+		mangaChapter = document.querySelector<HTMLParagraphElement>(
 			"#app > div > div > div > div > div > div > p"
 		),
 		buttons = await presence.getSetting<boolean>("buttons");
 
 	// So that the script would stop throwing errors when the navigator collapses
-	if (MangaURL?.href !== cacheMangaURL) cacheMangaURL = MangaURL.href;
-	if (MangaChapter?.textContent !== cacheMangaChapter)
-		cacheMangaChapter = MangaChapter.textContent;
+	if (mangaURL?.href !== cacheMangaURL) cacheMangaURL = mangaURL.href;
+	if (mangaChapter?.textContent !== cacheMangaChapter)
+		cacheMangaChapter = mangaChapter.textContent;
 
 	if (pathname.startsWith("/updates"))
 		presenceData.details = "Browsing lastest updates";


### PR DESCRIPTION
**Describe the changes in this pull request:**
Caches some elements of the page so that the script would stop throwing errors when the navigator collapses & add Settings to show/hide buttons
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<br>
<!-- Required when a presence has been added or modified --->
<!-- Attach screenshot(s) here --->

![image](https://user-images.githubusercontent.com/77577746/155927478-868a0b71-b1fe-4f91-be8d-f5e4559a46d5.png)
![image](https://user-images.githubusercontent.com/77577746/155927481-ab79cb7c-425b-412c-b47a-5e4ec43ffd8f.png)
![image](https://user-images.githubusercontent.com/77577746/155927484-3c40e4a4-c0ac-4e85-bcc4-368c4c80e072.png)

</details>
