### PR TITLE
feat(REYFM): added track cover image

### DIFF
--- a/websites/R/REYFM/dist/metadata.json
+++ b/websites/R/REYFM/dist/metadata.json
@@ -14,7 +14,7 @@
 		"www.reyfm.de",
 		"status.reyfm.de"
 	],
-	"version": "1.2.9",
+	"version": "1.2.10",
 	"logo": "https://i.imgur.com/hNoHWQK.png",
 	"thumbnail": "https://i.imgur.com/G9lihv1.png",
 	"color": "#cd6ef4",

--- a/websites/R/REYFM/dist/metadata.json
+++ b/websites/R/REYFM/dist/metadata.json
@@ -14,7 +14,7 @@
 		"www.reyfm.de",
 		"status.reyfm.de"
 	],
-	"version": "1.2.10",
+	"version": "1.3.0",
 	"logo": "https://i.imgur.com/hNoHWQK.png",
 	"thumbnail": "https://i.imgur.com/G9lihv1.png",
 	"color": "#cd6ef4",

--- a/websites/R/REYFM/presence.ts
+++ b/websites/R/REYFM/presence.ts
@@ -3,6 +3,7 @@ interface Channel {
 	name: string;
 	track: string;
 	artist: string;
+	cover: string;
 	listeners: number;
 	timeStart: string;
 	timeEnd: string;
@@ -29,6 +30,7 @@ function newStats(): void {
 					name: "",
 					track: "",
 					artist: "",
+					cover: "",
 					listeners: 0,
 					timeStart: "",
 					timeEnd: ""
@@ -40,6 +42,7 @@ function newStats(): void {
 				channel.listeners = channelData.listeners;
 				channel.track = channelData.now.title;
 				channel.artist = channelData.now.artist;
+				channel.cover = channelData.now.cover_urls["500x500"];
 				channel.timeStart = channelData.now.time.start;
 				channel.timeEnd = channelData.now.time.end;
 			}
@@ -154,13 +157,13 @@ presence.on("UpdateData", async () => {
 				.querySelector<HTMLImageElement>("#miniplayer-play")
 				.src.includes("play.png");
 
-			let track: string, artist: string;
+			let track: string, artist: string, cover: string;
 
 			if (!paused) {
 				const channelID = findChannel();
 				if (channelID !== "YOU FAILED") {
 					const channel = channels.find(channel => channel.id === channelID);
-					({ track, artist } = channel);
+					({ track, artist, cover } = channel);
 
 					presenceData.smallImageKey = "play";
 					presenceData.smallImageText = format3
@@ -179,6 +182,11 @@ presence.on("UpdateData", async () => {
 					track = document.querySelector(
 						"#player > div.wrapper > div.current > span.title"
 					).textContent;
+					cover = document
+						.querySelector(
+							"#player > div.wrapper > div.cover > img#player-coverart"
+						)
+						.getAttribute("src");
 					presenceData.smallImageKey = "play";
 					presenceData.smallImageText = "Loading statistics...";
 				}
@@ -189,6 +197,11 @@ presence.on("UpdateData", async () => {
 				track = document.querySelector(
 					"#player > div.wrapper > div.current > span.title"
 				).textContent;
+				cover = document
+					.querySelector(
+						"#player > div.wrapper > div.cover > img#player-coverart"
+					)
+					.getAttribute("src");
 				presenceData.smallImageKey = "pause";
 				presenceData.smallImageText = `Total Listeners: ${totalListeners}`;
 				delete presenceData.startTimestamp;
@@ -200,6 +213,7 @@ presence.on("UpdateData", async () => {
 			presenceData.state = format2
 				.replace("%title%", track)
 				.replace("%artist%", artist);
+			presenceData.largeImageKey = cover;
 		}
 	} else if (
 		document.location.hostname === "www.reyfm.de" &&
@@ -227,6 +241,8 @@ presence.on("UpdateData", async () => {
 		presenceData.smallImageText = format3
 			.replace("%listeners%", `${channel.listeners}`)
 			.replace("%totalListeners%", `${totalListeners}`);
+
+		presenceData.largeImageKey = channel.cover;
 
 		showFormat3 = true;
 


### PR DESCRIPTION
**Describe the changes in this pull request:**
During a playback, largeImageKey now displays the current track cover.

<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<br>

![b25de619d4ec64a558f631fec55ce561](https://user-images.githubusercontent.com/20924469/156169904-e7d6d6a6-d609-4e07-82f0-8f6262baef17.png)

</details>
