### PR TITLE
fix(Explain xkcd): Add url, fix issue with long texts

### DIFF
--- a/websites/E/Explain xkcd/dist/metadata.json
+++ b/websites/E/Explain xkcd/dist/metadata.json
@@ -8,8 +8,11 @@
 	"description": {
 		"en": "Explain xkcd is a wiki dedicated to explaining the webcomic xkcd. Go figure."
 	},
-	"url": "www.explainxkcd.com",
-	"version": "1.0.0",
+	"url": [
+		"www.explainxkcd.com",
+		"explainxkcd.com"
+	],
+	"version": "1.0.1",
 	"logo": "https://i.imgur.com/mZSiamM.png",
 	"thumbnail": "https://i.imgur.com/MUuSnky.png",
 	"color": "#ffffff",

--- a/websites/E/Explain xkcd/presence.ts
+++ b/websites/E/Explain xkcd/presence.ts
@@ -17,7 +17,7 @@ function getTitleText() {
 	let text = document
 		.querySelector(".image + br + span")
 		.textContent.substring(12);
-	if (text.length > 100) text = `${text.substring(0, 100)}...`;
+	if (text.length > 127) text = `${text.substring(0, 124)}...`;
 
 	return text;
 }

--- a/websites/E/Explain xkcd/presence.ts
+++ b/websites/E/Explain xkcd/presence.ts
@@ -14,7 +14,12 @@ function getComicName() {
 }
 
 function getTitleText() {
-	return document.querySelector(".image + br + span").textContent.substring(12);
+	let text = document
+		.querySelector(".image + br + span")
+		.textContent.substring(12);
+	if (text.length > 100) text = `${text.substring(0, 100)}...`;
+
+	return text;
 }
 
 presence.on("UpdateData", () => {


### PR DESCRIPTION
**Describe the changes in this pull request:**
Adds `explainxkcd.com` to the URLs of this Presence.
Fixes a small issue with long `smallImageText`s

<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<br>
<!-- Required when a presence has been added or modified --->
<!-- Attach screenshot(s) here --->
<img width="220" alt="2022-03-26 09_33_53 - Discord" src="https://user-images.githubusercontent.com/32113157/160248935-e7ac29dc-8d8d-40b3-b023-6fd20ec8fcd7.png">
</details>
