### PR TITLE
feat(Google Colab): add presence

### DIFF
--- a/websites/G/Google Colab/dist/metadata.json
+++ b/websites/G/Google Colab/dist/metadata.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.7",
+	"author": {
+		"name": "theusaf",
+		"id": "193714715631812608"
+	},
+	"service": "Google Colab",
+	"description": {
+		"en": "Colab, or \"Colaboratory\", allows you to write and execute Python in your browser, with zero configuration required, access to GPUs free of charge, and easy sharing"
+	},
+	"url": "colab.research.google.com",
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/2B69cLb.png",
+	"thumbnail": "https://i.imgur.com/qvR0PDm.png",
+	"color": "#f9ab00",
+	"category": "other",
+	"tags": ["colaboratory", "programming", "notebook", "juypter", "markdown"]
+}

--- a/websites/G/Google Colab/presence.ts
+++ b/websites/G/Google Colab/presence.ts
@@ -8,23 +8,80 @@ presence.on("UpdateData", () => {
 			largeImageKey: "logo",
 			startTimestamp: browsingTimestamp
 		},
-		notebookTitle = document.querySelector<HTMLInputElement>("#doc-name").value,
-		selected = document.querySelector(".cell.focused");
+		notebookTitle =
+			document.querySelector<HTMLInputElement>("#doc-name")?.value,
+		selected = document.querySelector(".cell.focused"),
+		{ pathname } = location;
 
-	if (
-		document
-			.querySelector("colab-last-saved-indicator")
-			.getAttribute("command") === "save"
-	)
-		presenceData.details = `Viewing ${notebookTitle}`;
-	else presenceData.details = `Editing ${notebookTitle}`;
+	if (pathname === "/diff") {
+		presenceData.details = "Viewing a diff";
+		if (document.querySelector(".diff-raw[aria-checked=true]"))
+			presenceData.state = "Raw diff";
+		else if (document.querySelector(".diff-inline[aria-checked=true]")) {
+			const [diff1, diff2] = document.querySelectorAll(".view-zones");
+			presenceData.state = `${
+				diff1.querySelector(".view-line").textContent
+			} vs ${diff2.querySelector(".view-line").textContent}`;
+		} else {
+			const [diff1, diff2] = document.querySelectorAll(".view-lines");
+			presenceData.state = `${
+				diff1.querySelector(".view-line").textContent
+			} vs ${diff2.querySelector(".view-line").textContent}`;
+		}
+	} else if (document.querySelector("#notebook-info")) {
+		presenceData.details = "Viewing notebook info";
+		presenceData.state = notebookTitle;
+	} else if (document.querySelector(".notebook-settings"))
+		presenceData.details = "Editing Notebook Settings";
+	else if (document.querySelector(".colab-open-dialog")) {
+		presenceData.details = "Opening Notebook";
+		presenceData.state = `From ${
+			document.querySelector(".colab-open-dialog .iron-selected").textContent
+		}`;
+	} else if (document.querySelector("#preferences-dialog"))
+		presenceData.details = "Editing Settings";
+	else {
+		// Editing or viewing a file
+		// Checking if the user has edit permissions
+		if (
+			document
+				.querySelector("colab-last-saved-indicator")
+				.getAttribute("command") === "save"
+		)
+			presenceData.details = `Viewing ${notebookTitle}`;
+		else presenceData.details = `Editing ${notebookTitle}`;
 
-	if (selected?.classList.contains("code"))
-		presenceData.state = "Editing code block";
-	else if (selected?.classList.contains("text")) {
-		if (selected.classList.contains("edit"))
-			presenceData.state = "Editing text block";
-		else presenceData.state = "Viewing text block";
+		// Getting the type of the selected cell
+		if (selected?.classList.contains("code"))
+			presenceData.state = "Editing code block";
+		else if (selected?.classList.contains("text")) {
+			if (selected.classList.contains("edit"))
+				presenceData.state = "Editing text block";
+			else presenceData.state = "Viewing text block";
+		}
+
+		// Checking if the user is commenting
+		if (document.querySelector(".comment-fragment.editing.focused")) {
+			presenceData.smallImageKey = "comment";
+			presenceData.smallImageText = "Commenting";
+		} else {
+			// Checking runtime resources
+			const connectShadowRoot = document.querySelector(
+				"colab-connect-button"
+			).shadowRoot;
+			if (connectShadowRoot.querySelector("#connect-button-resource-display")) {
+				presenceData.smallImageKey = "information";
+				presenceData.smallImageText = `Ram: ${
+					connectShadowRoot
+						.querySelector(".ram")
+						.shadowRoot.querySelector<HTMLElement>(".total > div").style.width
+				} Disk: ${
+					connectShadowRoot
+						.querySelector(".disk")
+						.shadowRoot.querySelector<HTMLElement>(".total > div").style.width
+				}`;
+			}
+		}
 	}
 
 	presence.setActivity(presenceData);

--- a/websites/G/Google Colab/presence.ts
+++ b/websites/G/Google Colab/presence.ts
@@ -1,0 +1,31 @@
+const presence = new Presence({
+		clientId: "959487033963843594"
+	}),
+	browsingTimestamp = Math.floor(Date.now() / 1000);
+
+presence.on("UpdateData", () => {
+	const presenceData: PresenceData = {
+			largeImageKey: "logo",
+			startTimestamp: browsingTimestamp
+		},
+		notebookTitle = document.querySelector("#doc-name").textContent,
+		selected = document.querySelector(".cell.focused");
+
+	if (
+		document
+			.querySelector("colab-last-saved-indicator")
+			.getAttribute("command") === "save"
+	)
+		presenceData.details = `Viewing ${notebookTitle}`;
+	else presenceData.details = `Editing ${notebookTitle}`;
+
+	if (selected.classList.contains("code"))
+		presenceData.state = "Editing code block";
+	else if (selected.classList.contains("text")) {
+		if (selected.classList.contains("edit"))
+			presenceData.state = "Editing text block";
+		else presenceData.state = "Viewing text block";
+	}
+
+	presence.setActivity(presenceData);
+});

--- a/websites/G/Google Colab/presence.ts
+++ b/websites/G/Google Colab/presence.ts
@@ -8,7 +8,7 @@ presence.on("UpdateData", () => {
 			largeImageKey: "logo",
 			startTimestamp: browsingTimestamp
 		},
-		notebookTitle = document.querySelector("#doc-name").textContent,
+		notebookTitle = document.querySelector<HTMLInputElement>("#doc-name").value,
 		selected = document.querySelector(".cell.focused");
 
 	if (
@@ -19,9 +19,9 @@ presence.on("UpdateData", () => {
 		presenceData.details = `Viewing ${notebookTitle}`;
 	else presenceData.details = `Editing ${notebookTitle}`;
 
-	if (selected.classList.contains("code"))
+	if (selected?.classList.contains("code"))
 		presenceData.state = "Editing code block";
-	else if (selected.classList.contains("text")) {
+	else if (selected?.classList.contains("text")) {
 		if (selected.classList.contains("edit"))
 			presenceData.state = "Editing text block";
 		else presenceData.state = "Viewing text block";

--- a/websites/G/Google Colab/tsconfig.json
+++ b/websites/G/Google Colab/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"extends": "../../../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist/"
+	}
+}


### PR DESCRIPTION
**Describe the changes in this pull request:**
Adds a presence for Google Colab/Google Colaboratory.
Displays details about: 
- the name of the current file being edited
- details about what the user is doing (commenting, looking at settings, etc)
- details when the user is differentiating two projects
- details about the runtime (ram and disk usage)

Resolves #5346 

<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<br>
<!-- Required when a presence has been added or modified --->
<!-- Attach screenshot(s) here --->
<img width="223" alt="2022-04-02 16_23_01" src="https://user-images.githubusercontent.com/32113157/161404924-f2e029ee-badc-4ff6-9105-b726a5d5f02d.png">
<img width="219" alt="2022-04-02 16_25_56" src="https://user-images.githubusercontent.com/32113157/161404925-c59ef368-f0ad-476d-a1c6-ba438acb5816.png">
<img width="223" alt="2022-04-02 16_26_23" src="https://user-images.githubusercontent.com/32113157/161404926-72ac5c1f-000c-499f-881c-c1785df7e12e.png">
<img width="222" alt="2022-04-02 16_26_31" src="https://user-images.githubusercontent.com/32113157/161404927-47554f7c-91ed-442f-8376-d975b4624ec6.png">
<img width="227" alt="2022-04-02 16_26_43" src="https://user-images.githubusercontent.com/32113157/161404928-b5e5a1fa-1cbd-463a-8628-685dfd3a9d12.png">
<img width="219" alt="2022-04-02 16_27_27" src="https://user-images.githubusercontent.com/32113157/161404929-d5f74813-3cc7-4b63-8299-de99644ffae4.png">
<img width="223" alt="2022-04-02 16_28_07" src="https://user-images.githubusercontent.com/32113157/161404930-5652c642-ecf8-41ea-aa59-f41ee63fdc0f.png">
<img width="219" alt="2022-04-02 16_28_23" src="https://user-images.githubusercontent.com/32113157/161404931-32036b1b-aeed-49c0-98cc-cc91ff73a803.png">
<img width="224" alt="2022-04-02 16_29_11" src="https://user-images.githubusercontent.com/32113157/161404932-32e9f680-71cc-4dd5-9cce-680de76529a0.png">
</details>
