### PR TITLE
fix(AniCloud): add new domain

### DIFF
--- a/websites/A/AniCloud/dist/metadata.json
+++ b/websites/A/AniCloud/dist/metadata.json
@@ -4,6 +4,10 @@
 		"name": "Emijor",
 		"id": "466885774621540372"
 	},
+	"contributors": [{
+		"id": "909084461197578260",
+		"name": "blueyukira"
+	}],
 	"service": "AniCloud",
 	"description": {
 		"en": "Watch now over 1,000+ animes for free on AniCloud. Anime Video-On Demand: ✓ 100% Free ✓ Instantly Online ✓ Exclusive Animes",
@@ -11,8 +15,8 @@
 		"nl": "Bekijk nu meer dan 1.000+ animes gratis op AniCloud. Anime Video-On Demand: 100% Gratis ✓ Direct Online ✓ Exclusieve Animes",
 		"vi_VN": "Xem ngay hơn 1,000+ bộ anime tại AniCloud hoàn toàn miễn phí. Anime theo nhu cầu: ✓ 100% miễn phí ✓ Trực tuyến ✓ Những bộ anime độc quyền"
 	},
-	"url": "anicloud.io",
-	"version": "1.0.13",
+	"url": ["anicloud.io", "aniworld.to"],
+	"version": "1.0.14",
 	"logo": "https://i.imgur.com/eCZpN6e.png",
 	"thumbnail": "https://i.imgur.com/fKBCijM.png",
 	"color": "#637cf9",


### PR DESCRIPTION
close #6089

**Describe the changes in this pull request:**

<details>
<summary> Added new domain for the extension</summary>

<br>
Modified due to a new domain change in the Anicloud. website when entering the <code>anicloud.to</code> domain.
</br>

 &nbsp; 

Resolved back:
<img src="https://user-images.githubusercontent.com/96798571/164723271-f0d5a281-1272-4061-9ba9-d8c0a083d2a4.PNG">

</details>

This pull request is to resolve issue #6089, maintainers should close the issue after merge.
