### PR TITLE
feat(Formula 1 TV): add extra details to presence

### DIFF
--- a/websites/F/FormulaOneTv/dist/metadata.json
+++ b/websites/F/FormulaOneTv/dist/metadata.json
@@ -27,7 +27,7 @@
 		}
 	],
 	"url": "f1tv.formula1.com",
-	"version": "1.0.5",
+	"version": "1.1.0",
 	"logo": "https://i.imgur.com/opuHbca.png",
 	"thumbnail": "https://i.imgur.com/uDxWlhL.jpg",
 	"color": "#e10600",

--- a/websites/F/FormulaOneTv/dist/metadata.json
+++ b/websites/F/FormulaOneTv/dist/metadata.json
@@ -4,6 +4,12 @@
 		"name": "AnOmniMoose",
 		"id": "180867904135233536"
 	},
+	"contributors": [
+		{
+			"name": "dAn",
+			"id": "169516316124905473"
+		}
+	],
 	"service": "FormulaOneTv",
 	"altnames": [
 		"Formula 1 TV",
@@ -12,6 +18,14 @@
 	"description": {
 		"en": "Watch F1 live & on demand. Every F1 race live and on demand. With exclusive access to on-board cameras, team radio and live timing."
 	},
+	"settings": [
+		{
+			"id": "privacy",
+			"title": "Privacy Mode",
+			"icon": "fad fa-user-secret",
+			"value": false
+		}
+	],
 	"url": "f1tv.formula1.com",
 	"version": "1.0.5",
 	"logo": "https://i.imgur.com/opuHbca.png",
@@ -21,6 +35,10 @@
 	"tags": [
 		"formula1",
 		"racing",
-		"driving"
+		"driving",
+		"f1tv",
+		"f1",
+		"f2",
+		"f3"
 	]
 }

--- a/websites/F/FormulaOneTv/presence.ts
+++ b/websites/F/FormulaOneTv/presence.ts
@@ -1,15 +1,54 @@
+interface VideoDetails {
+	[contentId: string]: {
+		metadata?: {
+			shortDescription: string;
+			title: string;
+			contentSubtype:
+				| "LIVE"
+				| "REPLAY"
+				| "SHOW"
+				| "DOCUMENTARY"
+				| "FEATURE"
+				| "HIGHLIGHTS"
+				| "EXTENDED HIGHLIGHTS"
+				| "PRESS CONFERENCE";
+			duration: number;
+			emfAttributes: {
+				Global_Meeting_Name: string;
+				Series: "FORMULA 1" | "FORMULA 2" | "FORMULA 3";
+			};
+		};
+	};
+}
+
 const presence = new Presence({ clientId: "916438450952097834" }),
 	strings = presence.getStrings({
 		play: "presence.playback.playing",
 		pause: "presence.playback.paused",
 		browsing: "general.browsing"
-	});
+	}),
+	videoDetails: VideoDetails = {};
 
-function getEpochInMs(): number {
+let fetchingVideoDetails = false;
+
+function capitaliseFirstLetters(str: string): string {
+	if (!str) return "";
+
+	return str
+		.split(" ")
+		.map(word => {
+			return (
+				word.substring(0, 1).toUpperCase() + word.substring(1).toLowerCase()
+			);
+		})
+		.join(" ");
+}
+
+function getEpochInSeconds(): number {
 	return Math.floor(Date.now() / 1000);
 }
 
-function parseTimeToMilliseconds(length: string): number {
+function parseTimeToSeconds(length: string): number {
 	const [seconds, minutes, hours] = length
 		.split(":")
 		.reverse()
@@ -18,38 +57,65 @@ function parseTimeToMilliseconds(length: string): number {
 	return seconds + (minutes || 0) * 60 + (hours || 0) * 3600;
 }
 
-async function setWatchingVideoActivity(presenceData: PresenceData) {
-	// Get video title
-	presenceData.details = `Watching ${
-		document.querySelector(".media-body h5")?.textContent || "a race"
-	}`;
+async function setWatchingVideoActivity(
+	presenceData: PresenceData,
+	contentId: string
+) {
+	// An UpdateData event was fired before the video metadata has been fetched, ignore and wait for it to be available in another update
+	if (!videoDetails[contentId]) return;
+
+	const privacyMode = await presence.getSetting<boolean>("privacy"),
+		videoMetadata = videoDetails[contentId].metadata;
+
+	if (privacyMode) {
+		presenceData.details = "Watching a video";
+		delete presenceData.state;
+	} else if (["LIVE", "REPLAY"].includes(videoMetadata.contentSubtype)) {
+		// Show which session is being watched; typically Practice 1-3, Qualifying, Sprint or Race
+		presenceData.details = `Watching ${videoMetadata.shortDescription}`;
+		// Show which series and event name is being watched
+		presenceData.state = `${
+			{
+				"FORMULA 1": "F1",
+				"FORMULA 2": "F2",
+				"FORMULA 3": "F3"
+			}[videoMetadata.emfAttributes.Series]
+		} - ${videoMetadata.emfAttributes.Global_Meeting_Name}`;
+	} else {
+		// Show which type of video is being watched; Examples include "Watching Documentary", "Watching Show", "Watching Highlights"
+		presenceData.details = `Watching ${capitaliseFirstLetters(
+			videoMetadata.contentSubtype
+		)}`;
+		// Show the title of the video being watched
+		presenceData.state = videoMetadata.title;
+	}
 
 	// Video is playing / play button is pressed
 	if (
 		document.querySelector(".bmpui-ui-playbacktogglebutton")?.ariaPressed ===
 		"true"
 	) {
-		delete presenceData.state;
-
-		presenceData.startTimestamp = getEpochInMs();
+		presenceData.startTimestamp = getEpochInSeconds();
 		presenceData.smallImageKey = "play";
-		presenceData.smallImageText = (await strings).play;
+		presenceData.smallImageText =
+			videoMetadata.contentSubtype === "LIVE"
+				? "Watching Live"
+				: (await strings).play;
 
-		const [currentTime, videoLength] = document
+		// Find the elapsed time of the current video
+		const [currentTime] = document
 			.querySelector(".bmpui-container-wrapper")
 			.querySelectorAll(".bmpui-ui-playbacktimelabel");
 
-		if (videoLength && currentTime) {
+		if (videoMetadata.duration && currentTime) {
 			presenceData.endTimestamp =
-				getEpochInMs() +
-				parseTimeToMilliseconds(videoLength.textContent) -
-				parseTimeToMilliseconds(currentTime.textContent);
+				getEpochInSeconds() +
+				(videoMetadata.duration - parseTimeToSeconds(currentTime.textContent));
 		}
 	} else {
 		delete presenceData.startTimestamp;
 		delete presenceData.endTimestamp;
 
-		presenceData.state = "Video paused";
 		presenceData.smallImageKey = "pause";
 		presenceData.smallImageText = (await strings).pause;
 	}
@@ -60,7 +126,7 @@ async function setBrowsingActivity(presenceData: PresenceData) {
 	delete presenceData.endTimestamp;
 
 	presenceData.details = "Browsing...";
-	presenceData.startTimestamp = getEpochInMs();
+	presenceData.startTimestamp = getEpochInSeconds();
 	presenceData.smallImageKey = "search";
 	presenceData.smallImageText = (await strings).browsing;
 }
@@ -69,10 +135,27 @@ presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
 		largeImageKey: "logo_512"
 	};
+	let contentId = "";
+
+	if (document.location.href.includes("detail"))
+		contentId = window.location.pathname.split("/")[2];
+
+	// Fetch the metadata for the current video based on the ID of the content found in the URL
+	if (!videoDetails[contentId] && !fetchingVideoDetails && contentId !== "") {
+		fetchingVideoDetails = true;
+
+		const response = await fetch(
+			`https://f1tv.formula1.com/3.0/R/ENG/WEB_DASH/ALL/CONTENT/VIDEO/${contentId}/F1_TV_Pro_Annual/2`
+		);
+
+		videoDetails[contentId] = (await response.json()).resultObj.containers[0];
+
+		fetchingVideoDetails = false;
+	}
 
 	// Watching video
 	if (document.location.href.includes("detail"))
-		await setWatchingVideoActivity(presenceData);
+		await setWatchingVideoActivity(presenceData, contentId);
 	// Browsing
 	else await setBrowsingActivity(presenceData);
 


### PR DESCRIPTION
**Describe the changes in this pull request:**
- Add ability to display what video is being watched, including a privacy mode to keep previous functionality

<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<br>
<!-- Required when a presence has been added or modified --->

![image](https://user-images.githubusercontent.com/37845774/164891980-1b4ea78c-e8a5-47f3-ace7-525aa4c394a1.png)

![image](https://user-images.githubusercontent.com/37845774/164892017-f71af41d-7b4b-4bdf-b83b-2b59ddea6191.png)

![image](https://user-images.githubusercontent.com/37845774/164892066-2b13c924-018d-4b58-89ca-7607421c7caf.png)

</details>
