### PR TITLE
feat(Sonic Retro): add presence

### DIFF
--- a/websites/S/Sonic Retro/dist/metadata.json
+++ b/websites/S/Sonic Retro/dist/metadata.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.7",
+	"author": {
+		"name": "BigBoi",
+		"id": "853932304257908746"
+	},
+	"service": "Sonic Retro",
+	"description": {
+		"en": "Second only to Sega - Sonic Retro is the Sonic scene's GFDL input and output wiki resource for collecting data about Sonic the Hedgehog that is open to the entire community."
+	},
+	"url": "sonicretro.org",
+	"regExp": "((info|forums)+[.])*(sonicretro[.]org)[/]",
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/m2ByWe1.png",
+	"thumbnail": "https://i.imgur.com/XSQE7IW.png",
+	"color": "#84846a",
+	"category": "other",
+	"tags": [
+		"wiki",
+		"sonic",
+		"retro",
+		"sega"
+	]
+}

--- a/websites/S/Sonic Retro/presence.ts
+++ b/websites/S/Sonic Retro/presence.ts
@@ -1,0 +1,275 @@
+const presence = new Presence({
+		clientId: "970743721404530798",
+	}),
+	browsingTimestamp = Math.floor(Date.now() / 1000);
+presence.on("UpdateData", async () => {
+	const presenceData: PresenceData = {
+			startTimestamp: browsingTimestamp,
+		},
+		{ pathname, search, hostname, href } = window.location;
+	switch (hostname) {
+		case "sonicretro.org": {
+			presenceData.smallImageKey = "home_512";
+			if (search) {
+				presenceData.largeImageKey = "search";
+				if (!new URLSearchParams(search).get("s"))
+					presenceData.details = "Searching for something...";
+				else {
+					presenceData.details = `Searching for "${
+						document.querySelector("#main > div.archive-box > h1").textContent
+					}"`;
+				}
+			} else if (
+				!search &&
+				(pathname === "/" || pathname === "/#" || pathname.includes("/page/"))
+			) {
+				presenceData.largeImageKey = "home";
+				presenceData.details = "Zooming through the main page";
+			} else if (pathname.includes("/category/")) {
+				presenceData.largeImageKey = "search";
+				presenceData.details = `Looking through ${
+					document.querySelector("#main > div.archive-box > h1").textContent
+				}`;
+			} else if (
+				/https:\/\/sonicretro.org\/\d{4}\/\d{2}\/(\d{2})*\//.test(pathname)
+			) {
+				presenceData.largeImageKey = "search";
+				presenceData.details = `Looking for posts from ${
+					document.title.split("-")[0]
+				}`;
+			} else if (
+				/https:\/\/sonicretro.org\/([0-9]+(\/[0-9]+)+)\/+((\w|-|\d)*)\//g.test(
+					href
+				)
+			) {
+				presenceData.largeImageKey = "reading";
+				presenceData.details = "Reading an article";
+				presenceData.state = document.title.split(" - Sonic Retro")[0];
+				presenceData.buttons = [
+					{
+						label: "Read Article",
+						url: href,
+					},
+				];
+			} else {
+				presenceData.largeImageKey = "logo_1024";
+				presenceData.details = "Viewing an unsupported page";
+			}
+			break;
+		}
+		case "info.sonicretro.org": {
+			// a full on wiki or index for the site
+			const unsupported = [
+				"Cite This Page - Sonic Retro",
+				"Compare pages - Sonic Retro",
+				"Export pages - Sonic Retro",
+				"What links here - Sonic Retro",
+				"Create account - Sonic Retro",
+				"Log in - Sonic Retro",
+				"Reset password - Sonic Retro",
+				"Login required - Sonic Retro",
+				"Preferences - Sonic Retro",
+				"Watchlist - Sonic Retro",
+				"Reset tokens - Sonic Retro",
+				"Blocked users - Sonic Retro",
+				"File list - Sonic Retro",
+			];
+			presenceData.smallImageKey = "info_512";
+			if (
+				pathname === "/" ||
+				pathname.includes("/Main_Page") ||
+				(pathname.includes("/index.php") && !search)
+			) {
+				presenceData.largeImageKey = "info";
+				presenceData.details = "Zooming through the main page";
+			} else if (pathname.includes("Special:")) {
+				if (unsupported.includes(document.title)) {
+					presenceData.largeImageKey = "logo_1024";
+					presenceData.details = "Viewing an unsupported page";
+				} else if (pathname.includes("/Special:SpecialPages")) {
+					presenceData.largeImageKey = "search";
+					presenceData.details = "Browsing special pages";
+				} else if (pathname.includes("/Special:Search")) {
+					presenceData.largeImageKey = "search";
+					presenceData.details = "Searching for something...";
+				} else {
+					presenceData.largeImageKey = "category";
+					presenceData.details = "Browsing a special page:";
+					presenceData.state = document.title.split(" - Sonic Retro")[0];
+					presenceData.buttons = [
+						{
+							label: "View Special Page",
+							url: href,
+						},
+					];
+				}
+			} else if (document.title.startsWith("Category:")) {
+				presenceData.largeImageKey = "reading";
+				presenceData.details = "Reading an article:";
+				presenceData.state = document.title
+					.split("Category:")[1]
+					.split(" - Sonic Retro")[0];
+				presenceData.buttons = [
+					{
+						label: "View Article",
+						url: href,
+					},
+				];
+			} else if (document.title.startsWith("Talk:")) {
+				presenceData.largeImageKey = "reading";
+				presenceData.details = "Browsing a talk page:";
+				presenceData.state = document.title
+					.split("Talk:")[1]
+					.split(" - Sonic Retro")[0];
+			} else if (document.title.startsWith("Sonic Retro:")) {
+				presenceData.largeImageKey = "reading";
+				presenceData.details = "Reading an article:";
+				presenceData.state = document.title
+					.split("Sonic Retro:")[1]
+					.split(" - Sonic Retro")[0];
+				presenceData.buttons = [
+					{
+						label: "View Article",
+						url: href,
+					},
+				];
+			} else if (document.title.startsWith("User:")) {
+				presenceData.largeImageKey = "reading";
+				presenceData.details = "Viewing a user's page:";
+				presenceData.state = `@${
+					document.title.split("User:")[1].split(" - Sonic Retro")[0]
+				}`;
+				presenceData.buttons = [
+					{
+						label: "View User",
+						url: href,
+					},
+				];
+			} else if (
+				pathname.includes("/File:") ||
+				pathname.includes("/Sonic_Retro:General_disclaimer")
+			) {
+				presenceData.largeImageKey = "logo_1024";
+				presenceData.details = "Viewing an unsupported page";
+			} else if (pathname === "/index.php" && search.includes("search=")) {
+				presenceData.largeImageKey = "search";
+				if (document.title.startsWith("Search -"))
+					presenceData.details = "Searching for something...";
+				else {
+					presenceData.details = `Searching for ${
+						document.title
+							.split("Search results for ")[1]
+							.split(" - Sonic Retro")[0]
+					}`;
+				}
+			} else if (
+				pathname === "/index.php" ||
+				pathname.startsWith("User_talk:")
+			) {
+				presenceData.largeImageKey = "logo_1024";
+				presenceData.details = "Viewing an unsupported page";
+			} else {
+				presenceData.largeImageKey = "reading";
+				presenceData.details = "Reading an article:";
+				presenceData.state = document.title.split(" - Sonic Retro")[0];
+				presenceData.buttons = [
+					{
+						label: "Read Article",
+						url: href,
+					},
+				];
+			}
+			break;
+		}
+		case "forums.sonicretro.org": {
+			presenceData.smallImageKey = "forums_512";
+			if (search) {
+				const forumTitle = document.title.split(
+					" | Sonic and Sega Retro Forums"
+				)[0];
+				presenceData.largeImageKey = "search";
+				if (search.includes("?watched/forums"))
+					presenceData.details = "Browsing watched forums";
+				else if (search.startsWith("?watched/threads"))
+					presenceData.details = "Browsing watched threads";
+				else if (search.startsWith("?find-new/") && search.includes("/posts"))
+					presenceData.details = "Browsing new posts";
+				else if (
+					search.startsWith("?find-new/") &&
+					search.includes("/profile-posts")
+				)
+					presenceData.details = "Browsing new profile posts";
+				else if (search.startsWith("?forums/")) {
+					presenceData.details = "Browsing a forum:";
+					presenceData.state = forumTitle;
+					presenceData.buttons = [
+						{
+							label: "View Forum",
+							url: href,
+						},
+					];
+				} else if (search.startsWith("?threads/")) {
+					presenceData.largeImageKey = "reading";
+					presenceData.details = "Reading a thread:";
+					presenceData.state = forumTitle;
+					presenceData.buttons = [
+						{
+							label: "Read Thread",
+							url: href,
+						},
+					];
+				} else if (search.startsWith("?members/")) {
+					if (document.title.startsWith("Notable Members")) {
+						presenceData.largeImageKey = "search";
+						presenceData.details = "Browsing notable members";
+					} else {
+						presenceData.largeImageKey = "reading";
+						presenceData.details = "Viewing a member's page";
+						presenceData.state = `@${forumTitle}`;
+						presenceData.buttons = [
+							{
+								label: "View Member",
+								url: href,
+							},
+						];
+					}
+				} else if (search.startsWith("?search/")) {
+					presenceData.largeImageKey = "search";
+					if (
+						document.title.startsWith("Error") ||
+						document.title.startsWith("Search")
+					)
+						presenceData.details = "Searching for something...";
+					else {
+						presenceData.details = `Searching for ${
+							document.title
+								.split("Search Results for Query: ")[1]
+								.split(" | Sonic and Sega Retro Forums")[0]
+						}`;
+					}
+				} else if (
+					/(\?conversations\/|\?account\/|\?help\/|\?forums\/-\/index.rss)/.test(
+						search
+					)
+				) {
+					presenceData.largeImageKey = "logo_1024";
+					presenceData.details = "Viewing an unsupported page";
+				}
+			} else if (pathname === "/index.php" && !search) {
+				presenceData.largeImageKey = "forums";
+				presenceData.details = "Zooming through the main page";
+			} else {
+				presenceData.largeImageKey = "logo_1024";
+				presenceData.details = "Viewing an unsupported page";
+			}
+			break;
+		}
+		default: {
+			presenceData.smallImageKey = "unsupported_512";
+			presenceData.smallImageText = "Unknown Page";
+			presenceData.largeImageKey = "logo_1024";
+			presenceData.details = "Viewing an unsupported page";
+		}
+	}
+	presence.setActivity(presenceData);
+});

--- a/websites/S/Sonic Retro/tsconfig.json
+++ b/websites/S/Sonic Retro/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"extends": "../../../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist/"
+	}
+}


### PR DESCRIPTION
**Describe the changes in this pull request:**
#
# (Feature) New presence for Sonic Retro
Resolves #5889
Features:
- Detects main pages of each subdomain `sonicretro.org`, `info.sonicretro.org`, & `forums.sonicretro.org`
    - `smallImageKey` displays an icon for each subdomain
- `sonicretro.org`:
    -  Detects home pages, search pages (by category, date, or custom keywords), and articles
    - A button appears when user is on an article (links to the article being read)
- `info.sonicretro.org`:
    - Detects home pages, search pages (by custom keywords), and articles
- `forums.sonicretro.org`:
    - Detects home pages, search pages (by custom keywords), and forums, and threads
#
<summary> Proof showing the creation/modification is working as expected </summary>
<br>
<!-- Required when a presence has been added or modified --->
<!-- Attach screenshot(s) here --->
<details>
<summary>Screenshots</summary>

## - Detection of Homepages
<details>
<summary>Pics</summary>

`v sonicretro.org v`
![image](https://user-images.githubusercontent.com/96930330/168490418-fbaee637-7da7-4331-9c87-a69d61062ff1.png)
`v info.sonicretro.org v`
![image](https://user-images.githubusercontent.com/96930330/168490422-130c980a-0450-4660-882a-0a84778b0831.png)
`v forums.sonicretro.org v`
![image](https://user-images.githubusercontent.com/96930330/168490429-208c988b-23d6-46ec-afca-c4d6a080df64.png)
</details>

## - `sonicretro.org`
<details>
<summary>Pics</summary>

#### Homepage
![image](https://user-images.githubusercontent.com/96930330/168490418-fbaee637-7da7-4331-9c87-a69d61062ff1.png)

#### Search By Month
![image](https://user-images.githubusercontent.com/96930330/168511797-8677757c-6b32-42a4-9b48-ef4b6696b339.png)

#### Search By Date
![image](https://user-images.githubusercontent.com/96930330/168511849-fe7c2e6d-23f4-4fc7-bd89-be19abb58ecd.png)

#### Article
![image](https://user-images.githubusercontent.com/96930330/168511180-0804eb50-0020-4b18-ab0f-259103465641.png)

</details>

## - `info.sonicretro.org`
<details>
<summary>Pics</summary>

#### Homepage
![image](https://user-images.githubusercontent.com/96930330/168519461-2367a56e-cf3a-485d-aa68-736d86bddda5.png)

#### Search
![image](https://user-images.githubusercontent.com/96930330/168519642-15667cf5-1ba9-4980-919c-e27887b383e8.png)
![image](https://user-images.githubusercontent.com/96930330/168519676-6b07aadd-1495-4ec0-82ec-b67719dc2c67.png)

#### Special Pages
![image](https://user-images.githubusercontent.com/96930330/168519505-1534cbd6-410d-4748-8e44-391bafafd2e0.png)

#### Article
![image](https://user-images.githubusercontent.com/96930330/168519570-463a6d21-8fa5-4e6a-9017-92eaaddd4381.png)

</details>

## - `forums.sonicretro.org`
<details>
<summary>Pics</summary>

#### Homepage
![image](https://user-images.githubusercontent.com/96930330/168490429-208c988b-23d6-46ec-afca-c4d6a080df64.png)

#### Search
![image](https://user-images.githubusercontent.com/96930330/168520769-d2f05e01-afa4-42e6-8a86-c04d22d7053a.png)
![image](https://user-images.githubusercontent.com/96930330/168520818-3ff2ce09-8ef5-4808-b718-ef5db0ccc9c2.png)

#### Forum
![image](https://user-images.githubusercontent.com/96930330/168520538-38c78b89-3bb8-40b4-ad42-c3add1e76f8b.png)

#### Thread
![image](https://user-images.githubusercontent.com/96930330/168520614-c671ce2e-1006-4b36-abfc-25afeab5bbd7.png)

#### Member Page
![image](https://user-images.githubusercontent.com/96930330/168520676-ad543caa-e3e1-42f4-8ce8-ef39aaab35c9.png)


</details>
</details>