### PR TITLE
fix(Apple TV+): wrong show/movie name, not detecting playback

### DIFF
--- a/websites/A/Apple TV+/dist/metadata.json
+++ b/websites/A/Apple TV+/dist/metadata.json
@@ -44,6 +44,12 @@
 			"title": "Show Buttons",
 			"icon": "fas fa-compress-arrows-alt",
 			"value": true
+		},
+		{
+			"id": "smallImage",
+			"title": "Show Small Image",
+			"icon": "fas fa-image",
+			"value": true
 		}
 	]
 }

--- a/websites/A/Apple TV+/dist/metadata.json
+++ b/websites/A/Apple TV+/dist/metadata.json
@@ -4,6 +4,12 @@
 		"name": "SlowLife",
 		"id": "374905512661221377"
 	},
+	"contributors": [
+		{
+			"name": "N0chteil ^^",
+			"id": "495901098926669825"
+		}
+	],
 	"service": "Apple TV+",
 	"altnames": [
 		"애플 TV"
@@ -15,7 +21,7 @@
 		"vi_VN": "Apple TV+ là dịch vụ phát trực tuyến những chương trình Apple Originals — các sê-ri đoạt giải, các bộ drama cuốn hút, những tư liệu đột phá, chương trình giải trí cho thiếu nhi và hơn nữa — với các chương trình Apple Originals được thêm mỗi tháng."
 	},
 	"url": "tv.apple.com",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"logo": "https://i.imgur.com/9yI21cv.png",
 	"thumbnail": "https://i.imgur.com/i7Vt4uR.png",
 	"color": "#2e2e2e",

--- a/websites/A/Apple TV+/dist/metadata.json
+++ b/websites/A/Apple TV+/dist/metadata.json
@@ -21,7 +21,7 @@
 		"vi_VN": "Apple TV+ là dịch vụ phát trực tuyến những chương trình Apple Originals — các sê-ri đoạt giải, các bộ drama cuốn hút, những tư liệu đột phá, chương trình giải trí cho thiếu nhi và hơn nữa — với các chương trình Apple Originals được thêm mỗi tháng."
 	},
 	"url": "tv.apple.com",
-	"version": "1.0.7",
+	"version": "1.1.0",
 	"logo": "https://i.imgur.com/9yI21cv.png",
 	"thumbnail": "https://i.imgur.com/i7Vt4uR.png",
 	"color": "#2e2e2e",

--- a/websites/A/Apple TV+/presence.ts
+++ b/websites/A/Apple TV+/presence.ts
@@ -208,7 +208,7 @@ presence.on("UpdateData", async () => {
 	let presenceSelect;
 
 	for (const [pathname, PData] of Object.entries(data.presence)) {
-		if (document.location.pathname.match(pathname)) {
+		if (new RegExp(pathname).test(document.location.pathname)) {
 			presenceSelect = pathname;
 			PData.setPresenceData();
 		}

--- a/websites/A/Apple TV+/presence.ts
+++ b/websites/A/Apple TV+/presence.ts
@@ -40,6 +40,9 @@ class AppleTV extends Presence {
 			title ??
 			document.querySelector(".review-card__title.typ-headline-emph > span")
 				?.textContent ??
+			document.querySelector(
+				"div.product-header__image-logo__show-title.typ-headline"
+			)?.textContent ??
 			"Unknown"
 		);
 	}

--- a/websites/A/Apple TV+/presence.ts
+++ b/websites/A/Apple TV+/presence.ts
@@ -30,8 +30,7 @@ class AppleTV extends Presence {
 			"div.product-header__image-logo.clr-primary-text-on-dark > a > h2"
 		)?.textContent;
 
-		if (title) return title;
-		else return document.querySelector<HTMLImageElement>("img").alt;
+		return title ?? document.querySelector(".review-card__title.typ-headline-emph > span")?.textContent ?? "Unknown";
 	}
 
 	getEpisodeTitle() {
@@ -110,7 +109,7 @@ presence.on("UpdateData", async () => {
 						delete presenceData.endTimestamp;
 					}
 				} else {
-					presenceData.details = "Viewing show:";
+					presenceData.details = "Viewing Show:";
 					presenceData.state = presence.getTitle();
 
 					presenceData.buttons = [
@@ -147,7 +146,7 @@ presence.on("UpdateData", async () => {
 						delete presenceData.endTimestamp;
 					}
 				} else {
-					presenceData.details = "Viewing movie:";
+					presenceData.details = "Viewing Movie:";
 					presenceData.state = presence.getTitle();
 
 					presenceData.buttons = [
@@ -161,7 +160,7 @@ presence.on("UpdateData", async () => {
 		},
 		"/person/([a-zA-Z0-9-]+)": {
 			setPresenceData() {
-				presenceData.details = "Viewing person:";
+				presenceData.details = "Viewing Person:";
 				presenceData.state = document.querySelector(
 					"div.person-header__bio > h1"
 				)?.textContent;
@@ -169,7 +168,7 @@ presence.on("UpdateData", async () => {
 		},
 		"/settings": {
 			setPresenceData() {
-				presenceData.details = "Viewing their settings";
+				presenceData.details = "Viewing their Settings";
 			}
 		}
 	};

--- a/websites/A/Apple TV+/presence.ts
+++ b/websites/A/Apple TV+/presence.ts
@@ -194,6 +194,11 @@ presence.on("UpdateData", async () => {
 			id: "buttons",
 			delete: true,
 			data: ["buttons"]
+		},
+		{
+			id: "smallImage",
+			delete: true,
+			data: ["smallImageKey"]
 		}
 	];
 

--- a/websites/A/Apple TV+/presence.ts
+++ b/websites/A/Apple TV+/presence.ts
@@ -7,8 +7,14 @@ class AppleTV extends Presence {
 		return document
 			.querySelector("apple-tv-plus-player")
 			.shadowRoot.querySelector("amp-video-player-internal")
-			.shadowRoot.querySelector("amp-video-player")
-			.shadowRoot.querySelector<HTMLVideoElement>("#apple-music-video-player");
+			?.shadowRoot.querySelector("amp-video-player")
+			?.shadowRoot.querySelector<HTMLVideoElement>("#apple-music-video-player");
+	}
+
+	getVideoType() {
+		return document
+			.querySelector("apple-tv-plus-player")
+			.shadowRoot.querySelector(".container.takeover")?.classList[2];
 	}
 
 	getTitle(eyebrow = false) {
@@ -16,35 +22,40 @@ class AppleTV extends Presence {
 			const title = document
 				.querySelector("apple-tv-plus-player")
 				.shadowRoot.querySelector("amp-video-player-internal")
-				.shadowRoot.querySelector("div.info__eyebrow")?.textContent;
+				?.shadowRoot.querySelector("div.info__eyebrow")?.textContent;
 
 			if (title || eyebrow) return title;
 			else {
 				return document
 					.querySelector("apple-tv-plus-player")
 					.shadowRoot.querySelector("amp-video-player-internal")
-					.shadowRoot.querySelector("div.info__title")?.textContent;
+					?.shadowRoot.querySelector("div.info__title")?.textContent;
 			}
 		}
 		const title = document.querySelector(
 			"div.product-header__image-logo.clr-primary-text-on-dark > a > h2"
 		)?.textContent;
 
-		return title ?? document.querySelector(".review-card__title.typ-headline-emph > span")?.textContent ?? "Unknown";
+		return (
+			title ??
+			document.querySelector(".review-card__title.typ-headline-emph > span")
+				?.textContent ??
+			"Unknown"
+		);
 	}
 
 	getEpisodeTitle() {
 		return document
 			.querySelector("apple-tv-plus-player")
 			.shadowRoot.querySelector("amp-video-player-internal")
-			.shadowRoot.querySelector("div.info__title")?.textContent;
+			?.shadowRoot.querySelector("div.info__title")?.textContent;
 	}
 
 	isWatching() {
 		return !!document
 			.querySelector("apple-tv-plus-player")
 			.shadowRoot.querySelector("amp-video-player-internal")
-			.shadowRoot.querySelector("div.info__title")?.textContent;
+			?.shadowRoot.querySelector("div.info__title")?.textContent;
 	}
 }
 
@@ -186,8 +197,22 @@ presence.on("UpdateData", async () => {
 		}
 	];
 
-	for (const [pathname, PData] of Object.entries(data.presence))
-		if (document.location.pathname.match(pathname)) PData.setPresenceData();
+	let presenceSelect;
+
+	for (const [pathname, PData] of Object.entries(data.presence)) {
+		if (document.location.pathname.match(pathname)) {
+			presenceSelect = pathname;
+			PData.setPresenceData();
+		}
+	}
+
+	if (!presenceSelect && presence.isWatching()) {
+		data.presence[
+			presence.getVideoType() === "movie"
+				? "/movie/([a-zA-Z0-9-]+)"
+				: "/(show|episode)/([a-zA-Z0-9-]+)"
+		].setPresenceData();
+	}
 
 	for (const setting of data.settings) {
 		const settingValue = await presence.getSetting<boolean>(setting.id);

--- a/websites/A/Apple TV+/presence.ts
+++ b/websites/A/Apple TV+/presence.ts
@@ -123,7 +123,7 @@ presence.on("UpdateData", async () => {
 						delete presenceData.endTimestamp;
 					}
 				} else {
-					presenceData.details = "Viewing Show:";
+					presenceData.details = "Viewing show:";
 					presenceData.state = presence.getTitle();
 
 					presenceData.buttons = [
@@ -160,7 +160,7 @@ presence.on("UpdateData", async () => {
 						delete presenceData.endTimestamp;
 					}
 				} else {
-					presenceData.details = "Viewing Movie:";
+					presenceData.details = "Viewing movie:";
 					presenceData.state = presence.getTitle();
 
 					presenceData.buttons = [
@@ -174,7 +174,7 @@ presence.on("UpdateData", async () => {
 		},
 		"/person/([a-zA-Z0-9-]+)": {
 			setPresenceData() {
-				presenceData.details = "Viewing Person:";
+				presenceData.details = "Viewing person:";
 				presenceData.state = document.querySelector(
 					"div.person-header__bio > h1"
 				)?.textContent;
@@ -182,7 +182,7 @@ presence.on("UpdateData", async () => {
 		},
 		"/settings": {
 			setPresenceData() {
-				presenceData.details = "Viewing their Settings";
+				presenceData.details = "Viewing their settings";
 			}
 		}
 	};


### PR DESCRIPTION
## Description 
* _Screenshot titles_
* Added setting to disable `smallImageKey`

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] I bumped the version of the presence in accordance with [Semver](https://devhints.io/semver)

## Screenshots
<details>
<summary>Wrong show/movie name</summary>

![Screenshot_144](https://user-images.githubusercontent.com/53608074/169706938-0069d470-3b66-481e-95ce-e7aa9f75c82a.png)
![Screenshot_145](https://user-images.githubusercontent.com/53608074/169706940-9e310d01-80dd-4d84-87b9-64f86390a3bf.png)
</details>

<details>
<summary>Not detecting playback</summary>

Before:
![image](https://user-images.githubusercontent.com/53608074/169707871-1e6bf26b-743d-479b-b6b7-0bbf5bb19782.png)

After:
![Screenshot_146](https://user-images.githubusercontent.com/53608074/169707840-f1bd1abd-396d-4ba0-ab92-6f434c09aba3.png)
</details>