### PR TITLE
feat(Geotastic): add presence

### DIFF
--- a/websites/G/Geotastic/dist/metadata.json
+++ b/websites/G/Geotastic/dist/metadata.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.7",
+	"author": {
+		"name": "Nate",
+		"id": "196817730257551360"
+	},
+	"service": "Geotastic",
+	"description": {
+		"en": "Geotastic is a geographical location guessing game created by Eduard But from Edutastic Games.",
+		"fr": "Geotastic est un jeu de devinette de emplacement géographique créé par Eduard But de Edutastic Games."
+	},
+	"url": "geotastic.net",
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/2gjiXL9.png",
+	"thumbnail": "https://i.imgur.com/6G7phcF.png",
+	"color": "#39bf7a",
+	"category": "games",
+	"tags": [
+		"geography",
+		"maps",
+		"guessing"
+	]
+}

--- a/websites/G/Geotastic/dist/metadata.json
+++ b/websites/G/Geotastic/dist/metadata.json
@@ -7,7 +7,7 @@
 	"service": "Geotastic",
 	"description": {
 		"en": "Geotastic is a geographical location guessing game created by Eduard But from Edutastic Games.",
-		"fr": "Geotastic est un jeu de devinette de emplacement géographique créé par Eduard But de Edutastic Games."
+		"fr": "Geotastic est un jeu de devinette de localisation géographique créé par Eduard But de Edutastic Games."
 	},
 	"url": "geotastic.net",
 	"version": "1.0.0",

--- a/websites/G/Geotastic/presence.ts
+++ b/websites/G/Geotastic/presence.ts
@@ -1,0 +1,96 @@
+const presence = new Presence({
+		clientId: "978557181911773214"
+	}),
+	browsingTimestamp = Math.floor(Date.now() / 1000);
+
+presence.on("UpdateData", async () => {
+	const presenceData: PresenceData = {
+		largeImageKey: "logo",
+		details: "Viewing an unsupported page",
+		startTimestamp: browsingTimestamp
+	};
+
+	if (document.location.pathname === "/home")
+		presenceData.details = "Viewing the home page";
+	else if (document.location.pathname === "/local-lobby")
+		presenceData.details = "Creating a local lobby";
+	else if (
+		document.location.pathname === "/play" ||
+		document.location.pathname.includes("/play-online/")
+	) {
+		if (document.querySelector(".active-component-prepare"))
+			presenceData.details = "Preparing for a round";
+		else if (document.querySelector(".active-component-play")) {
+			if (document.querySelector(".side-bar")) {
+				var info = document
+					.querySelector(".meta-infos")
+					.querySelectorAll("span");
+				presenceData.details = "In an online battle";
+				presenceData.state = "Playing map " + info[1].textContent;
+			} else {
+				var info = document
+					.querySelector(".meta-infos")
+					.querySelectorAll("span");
+				presenceData.details = "Playing map " + info[1].textContent;
+				presenceData.state = info[2].textContent + " " + info[3].textContent;
+			}
+		} else if (document.querySelector(".active-component-result")) {
+			presenceData.details = document
+				.querySelector(".round-info")
+				.querySelector("span").textContent;
+			presenceData.state =
+				"Score " + document.querySelector(".own-score").textContent;
+		} else if (document.querySelector(".active-component-finished")) {
+			presenceData.details = "Round finished";
+			presenceData.state =
+				"Final score " + document.querySelector(".score").textContent;
+		} else presenceData.details = "Playing a game";
+	} else if (document.location.pathname === "/user-challenges/find")
+		presenceData.details = "Browsing unplayed user challenges";
+	else if (document.location.pathname === "/user-challenges/played")
+		presenceData.details = "Browsing played user challenges";
+	else if (document.location.pathname === "/user-challenges/own")
+		presenceData.details = "Browing created user challenges";
+	else if (document.location.pathname === "/user-challenges/create")
+		presenceData.details = "Creating a challenge";
+	else if (document.location.pathname.includes("/challenge-details/"))
+		presenceData.details = "Viewing a challenge";
+	else if (document.location.pathname.includes("/online-lobby/"))
+		presenceData.details = "In an online lobby";
+	else if (document.location.pathname === "/matchmaking-lobby")
+		presenceData.details = "In a matchmaking lobby";
+	else if (document.location.pathname === "/community-map")
+		presenceData.details = "Viewing the community map";
+	else if (document.location.pathname === "/squad/list")
+		presenceData.details = "Browsing the list of squads";
+	else if (document.location.pathname === "/squad/management")
+		presenceData.details = "Viewing the squad management page";
+	else if (document.location.pathname === "/map-editor/maps")
+		presenceData.details = "Creating a map";
+	else if (document.location.pathname === "/map-editor/drop-groups")
+		presenceData.details = "Viewing their drop groups";
+	else if (document.location.pathname === "/events")
+		presenceData.details = "Browsing past and future events";
+	else if (document.location.pathname.includes("/events/")) {
+		presenceData.details = "Viewing an event";
+		presenceData.state = document.querySelector("h1").textContent;
+	} else if (document.location.pathname.includes("/help-out/"))
+		presenceData.details = "Viewing ways to support Geotastic";
+	else if (document.location.pathname === "/account/profile")
+		presenceData.details = "Viewing their profile settings";
+	else if (document.location.pathname === "/account/statistics")
+		presenceData.details = "Viewing their statistics";
+	else if (document.location.pathname === "/account/trophies")
+		presenceData.details = "Viewing their trophies";
+	else if (document.location.pathname === "/account/friends")
+		presenceData.details = "Viewing their friends";
+	else if (document.location.pathname === "/account/supporter-status")
+		presenceData.details = "Viewing their supporter status";
+	else if (document.location.pathname === "/account/quota-consumption")
+		presenceData.details = "Viewing their quota consumption";
+	else if (document.location.pathname === "/account/account-settings")
+		presenceData.details = "Viewing their account settings";
+
+	if (presenceData.details) presence.setActivity(presenceData);
+	else presence.setActivity();
+});

--- a/websites/G/Geotastic/presence.ts
+++ b/websites/G/Geotastic/presence.ts
@@ -10,8 +10,7 @@ presence.on("UpdateData", async () => {
 		startTimestamp: browsingTimestamp
 	};
 
-	const [] = await Promise.all([]),
-		pages: Record<string, PresenceData> = {
+	let pages: Record<string, PresenceData> = {
 			"/home": { details: "Viewing the home page" },
 			"/local-lobby": { details: "Creating a local lobby" },
 			"/user-challenges/find": { details: "Browsing unplayed user challenges" },

--- a/websites/G/Geotastic/presence.ts
+++ b/websites/G/Geotastic/presence.ts
@@ -22,13 +22,13 @@ presence.on("UpdateData", async () => {
 			presenceData.details = "Preparing for a round";
 		else if (document.querySelector(".active-component-play")) {
 			if (document.querySelector(".side-bar")) {
-				var info = document
+				let info = document
 					.querySelector(".meta-infos")
 					.querySelectorAll("span");
 				presenceData.details = "In an online battle";
 				presenceData.state = "Playing map " + info[1].textContent;
 			} else {
-				var info = document
+				let info = document
 					.querySelector(".meta-infos")
 					.querySelectorAll("span");
 				presenceData.details = "Playing map " + info[1].textContent;

--- a/websites/G/Geotastic/presence.ts
+++ b/websites/G/Geotastic/presence.ts
@@ -22,74 +22,128 @@ presence.on("UpdateData", async () => {
 			presenceData.details = "Preparing for a round";
 		else if (document.querySelector(".active-component-play")) {
 			if (document.querySelector(".side-bar")) {
-				let info = document
-					.querySelector(".meta-infos")
-					.querySelectorAll("span");
 				presenceData.details = "In an online battle";
-				presenceData.state = "Playing map " + info[1].textContent;
+				presenceData.state = `Playing map ${
+					document.querySelector(".meta-infos").querySelectorAll("span")[1]
+						.textContent
+				}`;
 			} else {
-				let info = document
+				const info = document
 					.querySelector(".meta-infos")
 					.querySelectorAll("span");
-				presenceData.details = "Playing map " + info[1].textContent;
-				presenceData.state = info[2].textContent + " " + info[3].textContent;
+				presenceData.details = `Playing map ${info[1].textContent}`;
+				presenceData.state = `${info[2].textContent} ${info[3].textContent}`;
 			}
 		} else if (document.querySelector(".active-component-result")) {
 			presenceData.details = document
 				.querySelector(".round-info")
 				.querySelector("span").textContent;
-			presenceData.state =
-				"Score " + document.querySelector(".own-score").textContent;
+			presenceData.state = `Score ${
+				document.querySelector(".own-score").textContent
+			}`;
 		} else if (document.querySelector(".active-component-finished")) {
 			presenceData.details = "Round finished";
-			presenceData.state =
-				"Final score " + document.querySelector(".score").textContent;
+			presenceData.state = `Final score ${
+				document.querySelector(".score").textContent
+			}`;
 		} else presenceData.details = "Playing a game";
-	} else if (document.location.pathname === "/user-challenges/find")
-		presenceData.details = "Browsing unplayed user challenges";
-	else if (document.location.pathname === "/user-challenges/played")
-		presenceData.details = "Browsing played user challenges";
-	else if (document.location.pathname === "/user-challenges/own")
-		presenceData.details = "Browing created user challenges";
-	else if (document.location.pathname === "/user-challenges/create")
-		presenceData.details = "Creating a challenge";
-	else if (document.location.pathname.includes("/challenge-details/"))
-		presenceData.details = "Viewing a challenge";
-	else if (document.location.pathname.includes("/online-lobby/"))
-		presenceData.details = "In an online lobby";
-	else if (document.location.pathname === "/matchmaking-lobby")
-		presenceData.details = "In a matchmaking lobby";
-	else if (document.location.pathname === "/community-map")
-		presenceData.details = "Viewing the community map";
-	else if (document.location.pathname === "/squad/list")
-		presenceData.details = "Browsing the list of squads";
-	else if (document.location.pathname === "/squad/management")
-		presenceData.details = "Viewing the squad management page";
-	else if (document.location.pathname === "/map-editor/maps")
-		presenceData.details = "Creating a map";
-	else if (document.location.pathname === "/map-editor/drop-groups")
-		presenceData.details = "Viewing their drop groups";
-	else if (document.location.pathname === "/events")
-		presenceData.details = "Browsing past and future events";
-	else if (document.location.pathname.includes("/events/")) {
-		presenceData.details = "Viewing an event";
-		presenceData.state = document.querySelector("h1").textContent;
-	} else if (document.location.pathname.includes("/help-out/"))
-		presenceData.details = "Viewing ways to support Geotastic";
-	else if (document.location.pathname === "/account/profile")
-		presenceData.details = "Viewing their profile settings";
-	else if (document.location.pathname === "/account/statistics")
-		presenceData.details = "Viewing their statistics";
-	else if (document.location.pathname === "/account/trophies")
-		presenceData.details = "Viewing their trophies";
-	else if (document.location.pathname === "/account/friends")
-		presenceData.details = "Viewing their friends";
-	else if (document.location.pathname === "/account/supporter-status")
-		presenceData.details = "Viewing their supporter status";
-	else if (document.location.pathname === "/account/quota-consumption")
-		presenceData.details = "Viewing their quota consumption";
-	else if (document.location.pathname === "/account/account-settings")
-		presenceData.details = "Viewing their account settings";
+	} else {
+		switch (document.location.pathname) {
+			case "/user-challenges/find": {
+				presenceData.details = "Browsing unplayed user challenges";
+				break;
+			}
+			case "/user-challenges/played": {
+				presenceData.details = "Browsing played user challenges";
+				break;
+			}
+			case "/user-challenges/own": {
+				presenceData.details = "Browing created user challenges";
+				break;
+			}
+			case "/user-challenges/create": {
+				presenceData.details = "Creating a challenge";
+				break;
+			}
+			default:
+				if (document.location.pathname.includes("/challenge-details/"))
+					presenceData.details = "Viewing a challenge";
+				else if (document.location.pathname.includes("/online-lobby/"))
+					presenceData.details = "In an online lobby";
+				else {
+					switch (document.location.pathname) {
+						case "/matchmaking-lobby": {
+							presenceData.details = "In a matchmaking lobby";
+							break;
+						}
+						case "/community-map": {
+							presenceData.details = "Viewing the community map";
+							break;
+						}
+						case "/squad/list": {
+							presenceData.details = "Browsing the list of squads";
+							break;
+						}
+						case "/squad/management": {
+							presenceData.details = "Viewing the squad management page";
+							break;
+						}
+						case "/map-editor/maps": {
+							presenceData.details = "Creating a map";
+							break;
+						}
+						case "/map-editor/drop-groups": {
+							presenceData.details = "Viewing their drop groups";
+							break;
+						}
+						case "/events": {
+							presenceData.details = "Browsing past and future events";
+							break;
+						}
+						default:
+							if (document.location.pathname.includes("/events/")) {
+								presenceData.details = "Viewing an event";
+								presenceData.state = document.querySelector("h1").textContent;
+							} else if (document.location.pathname.includes("/help-out/"))
+								presenceData.details = "Viewing ways to support Geotastic";
+							else {
+								switch (document.location.pathname) {
+									case "/account/profile": {
+										presenceData.details = "Viewing their profile settings";
+										break;
+									}
+									case "/account/statistics": {
+										presenceData.details = "Viewing their statistics";
+										break;
+									}
+									case "/account/trophies": {
+										presenceData.details = "Viewing their trophies";
+										break;
+									}
+									case "/account/friends": {
+										presenceData.details = "Viewing their friends";
+										break;
+									}
+									case "/account/supporter-status": {
+										presenceData.details = "Viewing their supporter status";
+										break;
+									}
+									case "/account/quota-consumption": {
+										presenceData.details = "Viewing their quota consumption";
+										break;
+									}
+									case "/account/account-settings":
+										{
+											presenceData.details = "Viewing their account settings";
+											// No default
+										}
+										break;
+								}
+							}
+					}
+				}
+		}
+	}
 
 	if (presenceData.details) presence.setActivity(presenceData);
 	else presence.setActivity();

--- a/websites/G/Geotastic/presence.ts
+++ b/websites/G/Geotastic/presence.ts
@@ -9,8 +9,7 @@ presence.on("UpdateData", async () => {
 		details: "Viewing an unsupported page",
 		startTimestamp: browsingTimestamp
 	};
-
-	let pages: Record<string, PresenceData> = {
+	const pages: Record<string, PresenceData> = {
 		"/home": { details: "Viewing the home page" },
 		"/local-lobby": { details: "Creating a local lobby" },
 		"/user-challenges/find": { details: "Browsing unplayed user challenges" },

--- a/websites/G/Geotastic/presence.ts
+++ b/websites/G/Geotastic/presence.ts
@@ -101,7 +101,8 @@ presence.on("UpdateData", async () => {
 				presenceData.state = document.querySelector("h1").textContent;
 			} else if (document.location.pathname.includes("/help-out/"))
 				presenceData.details = "Viewing ways to support Geotastic";
-	} if (
+	}
+	if (
 		document.location.pathname === "/play" ||
 		document.location.pathname.includes("/play-online/")
 	) {

--- a/websites/G/Geotastic/presence.ts
+++ b/websites/G/Geotastic/presence.ts
@@ -29,8 +29,12 @@ presence.on("UpdateData", async () => {
 			"/account/statistics": { details: "Viewing their statistics" },
 			"/account/trophies": { details: "Viewing their trophies" },
 			"/account/friends": { details: "Viewing their friends" },
-			"/account/supporter-status": { details: "Viewing their supporter status" },
-			"/account/quota-consumption": { details: "Viewing their quota consumption" },
+			"/account/supporter-status": {
+				details: "Viewing their supporter status"
+			},
+			"/account/quota-consumption": {
+				details: "Viewing their quota consumption"
+			},
 			"/account/account-settings": { details: "Viewing their account settings" }
 		};
 

--- a/websites/G/Geotastic/presence.ts
+++ b/websites/G/Geotastic/presence.ts
@@ -1,5 +1,5 @@
 const presence = new Presence({
-		clientId: "978557181911773214"
+		clientId: "978557181911773214",
 	}),
 	browsingTimestamp = Math.floor(Date.now() / 1000);
 
@@ -7,7 +7,7 @@ presence.on("UpdateData", async () => {
 	let presenceData: PresenceData = {
 		largeImageKey: "logo",
 		details: "Viewing an unsupported page",
-		startTimestamp: browsingTimestamp
+		startTimestamp: browsingTimestamp,
 	};
 	const pages: Record<string, PresenceData> = {
 		"/home": { details: "Viewing the home page" },
@@ -28,12 +28,12 @@ presence.on("UpdateData", async () => {
 		"/account/trophies": { details: "Viewing their trophies" },
 		"/account/friends": { details: "Viewing their friends" },
 		"/account/supporter-status": {
-			details: "Viewing their supporter status"
+			details: "Viewing their supporter status",
 		},
 		"/account/quota-consumption": {
-			details: "Viewing their quota consumption"
+			details: "Viewing their quota consumption",
 		},
-		"/account/account-settings": { details: "Viewing their account settings" }
+		"/account/account-settings": { details: "Viewing their account settings" },
 	};
 
 	for (const [path, data] of Object.entries(pages)) {

--- a/websites/G/Geotastic/presence.ts
+++ b/websites/G/Geotastic/presence.ts
@@ -11,31 +11,31 @@ presence.on("UpdateData", async () => {
 	};
 
 	let pages: Record<string, PresenceData> = {
-			"/home": { details: "Viewing the home page" },
-			"/local-lobby": { details: "Creating a local lobby" },
-			"/user-challenges/find": { details: "Browsing unplayed user challenges" },
-			"/user-challenges/played": { details: "Browsing played user challenges" },
-			"/user-challenges/own": { details: "Browsing created user challenges" },
-			"/user-challenges/create": { details: "Creating a challenge" },
-			"/matchmaking-lobby": { details: "In a matchmaking lobby" },
-			"/community-map": { details: "Viewing the community map" },
-			"/squad/list": { details: "Browsing the list of squads" },
-			"/squad/management": { details: "Viewing the squad management page" },
-			"/map-editor/maps": { details: "Creating a map" },
-			"/map-editor/drop-groups": { details: "Viewing their drop groups" },
-			"/events": { details: "Browsing past and future events" },
-			"/account/profile": { details: "Viewing their profile settings" },
-			"/account/statistics": { details: "Viewing their statistics" },
-			"/account/trophies": { details: "Viewing their trophies" },
-			"/account/friends": { details: "Viewing their friends" },
-			"/account/supporter-status": {
-				details: "Viewing their supporter status"
-			},
-			"/account/quota-consumption": {
-				details: "Viewing their quota consumption"
-			},
-			"/account/account-settings": { details: "Viewing their account settings" }
-		};
+		"/home": { details: "Viewing the home page" },
+		"/local-lobby": { details: "Creating a local lobby" },
+		"/user-challenges/find": { details: "Browsing unplayed user challenges" },
+		"/user-challenges/played": { details: "Browsing played user challenges" },
+		"/user-challenges/own": { details: "Browsing created user challenges" },
+		"/user-challenges/create": { details: "Creating a challenge" },
+		"/matchmaking-lobby": { details: "In a matchmaking lobby" },
+		"/community-map": { details: "Viewing the community map" },
+		"/squad/list": { details: "Browsing the list of squads" },
+		"/squad/management": { details: "Viewing the squad management page" },
+		"/map-editor/maps": { details: "Creating a map" },
+		"/map-editor/drop-groups": { details: "Viewing their drop groups" },
+		"/events": { details: "Browsing past and future events" },
+		"/account/profile": { details: "Viewing their profile settings" },
+		"/account/statistics": { details: "Viewing their statistics" },
+		"/account/trophies": { details: "Viewing their trophies" },
+		"/account/friends": { details: "Viewing their friends" },
+		"/account/supporter-status": {
+			details: "Viewing their supporter status"
+		},
+		"/account/quota-consumption": {
+			details: "Viewing their quota consumption"
+		},
+		"/account/account-settings": { details: "Viewing their account settings" }
+	};
 
 	for (const [path, data] of Object.entries(pages)) {
 		if (document.location.pathname.includes(path))

--- a/websites/G/Geotastic/presence.ts
+++ b/websites/G/Geotastic/presence.ts
@@ -10,11 +10,98 @@ presence.on("UpdateData", async () => {
 		startTimestamp: browsingTimestamp
 	};
 
-	if (document.location.pathname === "/home")
-		presenceData.details = "Viewing the home page";
-	else if (document.location.pathname === "/local-lobby")
-		presenceData.details = "Creating a local lobby";
-	else if (
+	switch (document.location.pathname) {
+		case "/home": {
+			presenceData.details = "Viewing the home page";
+			break;
+		}
+		case "/local-lobby": {
+			presenceData.details = "Creating a local lobby";
+			break;
+		}
+		case "/user-challenges/find": {
+			presenceData.details = "Browsing unplayed user challenges";
+			break;
+		}
+		case "/user-challenges/played": {
+			presenceData.details = "Browsing played user challenges";
+			break;
+		}
+		case "/user-challenges/own": {
+			presenceData.details = "Browing created user challenges";
+			break;
+		}
+		case "/user-challenges/create": {
+			presenceData.details = "Creating a challenge";
+			break;
+		}
+		case "/matchmaking-lobby": {
+			presenceData.details = "In a matchmaking lobby";
+			break;
+		}
+		case "/community-map": {
+			presenceData.details = "Viewing the community map";
+			break;
+		}
+		case "/squad/list": {
+			presenceData.details = "Browsing the list of squads";
+			break;
+		}
+		case "/squad/management": {
+			presenceData.details = "Viewing the squad management page";
+			break;
+		}
+		case "/map-editor/maps": {
+			presenceData.details = "Creating a map";
+			break;
+		}
+		case "/map-editor/drop-groups": {
+			presenceData.details = "Viewing their drop groups";
+			break;
+		}
+		case "/events": {
+			presenceData.details = "Browsing past and future events";
+			break;
+		}
+		case "/account/profile": {
+			presenceData.details = "Viewing their profile settings";
+			break;
+		}
+		case "/account/statistics": {
+			presenceData.details = "Viewing their statistics";
+			break;
+		}
+		case "/account/trophies": {
+			presenceData.details = "Viewing their trophies";
+			break;
+		}
+		case "/account/friends": {
+			presenceData.details = "Viewing their friends";
+			break;
+		}
+		case "/account/supporter-status": {
+			presenceData.details = "Viewing their supporter status";
+			break;
+		}
+		case "/account/quota-consumption": {
+			presenceData.details = "Viewing their quota consumption";
+			break;
+		}
+		case "/account/account-settings": {
+			presenceData.details = "Viewing their account settings";
+			break;
+		}
+		default:
+			if (document.location.pathname.includes("/challenge-details/"))
+				presenceData.details = "Viewing a challenge";
+			else if (document.location.pathname.includes("/online-lobby/"))
+				presenceData.details = "In an online lobby";
+			else if (document.location.pathname.includes("/events/")) {
+				presenceData.details = "Viewing an event";
+				presenceData.state = document.querySelector("h1").textContent;
+			} else if (document.location.pathname.includes("/help-out/"))
+				presenceData.details = "Viewing ways to support Geotastic";
+	} if (
 		document.location.pathname === "/play" ||
 		document.location.pathname.includes("/play-online/")
 	) {
@@ -47,102 +134,6 @@ presence.on("UpdateData", async () => {
 				document.querySelector(".score").textContent
 			}`;
 		} else presenceData.details = "Playing a game";
-	} else {
-		switch (document.location.pathname) {
-			case "/user-challenges/find": {
-				presenceData.details = "Browsing unplayed user challenges";
-				break;
-			}
-			case "/user-challenges/played": {
-				presenceData.details = "Browsing played user challenges";
-				break;
-			}
-			case "/user-challenges/own": {
-				presenceData.details = "Browing created user challenges";
-				break;
-			}
-			case "/user-challenges/create": {
-				presenceData.details = "Creating a challenge";
-				break;
-			}
-			default:
-				if (document.location.pathname.includes("/challenge-details/"))
-					presenceData.details = "Viewing a challenge";
-				else if (document.location.pathname.includes("/online-lobby/"))
-					presenceData.details = "In an online lobby";
-				else {
-					switch (document.location.pathname) {
-						case "/matchmaking-lobby": {
-							presenceData.details = "In a matchmaking lobby";
-							break;
-						}
-						case "/community-map": {
-							presenceData.details = "Viewing the community map";
-							break;
-						}
-						case "/squad/list": {
-							presenceData.details = "Browsing the list of squads";
-							break;
-						}
-						case "/squad/management": {
-							presenceData.details = "Viewing the squad management page";
-							break;
-						}
-						case "/map-editor/maps": {
-							presenceData.details = "Creating a map";
-							break;
-						}
-						case "/map-editor/drop-groups": {
-							presenceData.details = "Viewing their drop groups";
-							break;
-						}
-						case "/events": {
-							presenceData.details = "Browsing past and future events";
-							break;
-						}
-						default:
-							if (document.location.pathname.includes("/events/")) {
-								presenceData.details = "Viewing an event";
-								presenceData.state = document.querySelector("h1").textContent;
-							} else if (document.location.pathname.includes("/help-out/"))
-								presenceData.details = "Viewing ways to support Geotastic";
-							else {
-								switch (document.location.pathname) {
-									case "/account/profile": {
-										presenceData.details = "Viewing their profile settings";
-										break;
-									}
-									case "/account/statistics": {
-										presenceData.details = "Viewing their statistics";
-										break;
-									}
-									case "/account/trophies": {
-										presenceData.details = "Viewing their trophies";
-										break;
-									}
-									case "/account/friends": {
-										presenceData.details = "Viewing their friends";
-										break;
-									}
-									case "/account/supporter-status": {
-										presenceData.details = "Viewing their supporter status";
-										break;
-									}
-									case "/account/quota-consumption": {
-										presenceData.details = "Viewing their quota consumption";
-										break;
-									}
-									case "/account/account-settings":
-										{
-											presenceData.details = "Viewing their account settings";
-											// No default
-										}
-										break;
-								}
-							}
-					}
-				}
-		}
 	}
 
 	if (presenceData.details) presence.setActivity(presenceData);

--- a/websites/G/Geotastic/presence.ts
+++ b/websites/G/Geotastic/presence.ts
@@ -4,104 +4,57 @@ const presence = new Presence({
 	browsingTimestamp = Math.floor(Date.now() / 1000);
 
 presence.on("UpdateData", async () => {
-	const presenceData: PresenceData = {
+	let presenceData: PresenceData = {
 		largeImageKey: "logo",
 		details: "Viewing an unsupported page",
 		startTimestamp: browsingTimestamp
 	};
 
-	switch (document.location.pathname) {
-		case "/home": {
-			presenceData.details = "Viewing the home page";
-			break;
-		}
-		case "/local-lobby": {
-			presenceData.details = "Creating a local lobby";
-			break;
-		}
-		case "/user-challenges/find": {
-			presenceData.details = "Browsing unplayed user challenges";
-			break;
-		}
-		case "/user-challenges/played": {
-			presenceData.details = "Browsing played user challenges";
-			break;
-		}
-		case "/user-challenges/own": {
-			presenceData.details = "Browing created user challenges";
-			break;
-		}
-		case "/user-challenges/create": {
-			presenceData.details = "Creating a challenge";
-			break;
-		}
-		case "/matchmaking-lobby": {
-			presenceData.details = "In a matchmaking lobby";
-			break;
-		}
-		case "/community-map": {
-			presenceData.details = "Viewing the community map";
-			break;
-		}
-		case "/squad/list": {
-			presenceData.details = "Browsing the list of squads";
-			break;
-		}
-		case "/squad/management": {
-			presenceData.details = "Viewing the squad management page";
-			break;
-		}
-		case "/map-editor/maps": {
-			presenceData.details = "Creating a map";
-			break;
-		}
-		case "/map-editor/drop-groups": {
-			presenceData.details = "Viewing their drop groups";
-			break;
-		}
-		case "/events": {
-			presenceData.details = "Browsing past and future events";
-			break;
-		}
-		case "/account/profile": {
-			presenceData.details = "Viewing their profile settings";
-			break;
-		}
-		case "/account/statistics": {
-			presenceData.details = "Viewing their statistics";
-			break;
-		}
-		case "/account/trophies": {
-			presenceData.details = "Viewing their trophies";
-			break;
-		}
-		case "/account/friends": {
-			presenceData.details = "Viewing their friends";
-			break;
-		}
-		case "/account/supporter-status": {
-			presenceData.details = "Viewing their supporter status";
-			break;
-		}
-		case "/account/quota-consumption": {
-			presenceData.details = "Viewing their quota consumption";
-			break;
-		}
-		case "/account/account-settings": {
-			presenceData.details = "Viewing their account settings";
-			break;
-		}
-		default:
-			if (document.location.pathname.includes("/challenge-details/"))
-				presenceData.details = "Viewing a challenge";
-			else if (document.location.pathname.includes("/online-lobby/"))
-				presenceData.details = "In an online lobby";
-			else if (document.location.pathname.includes("/events/")) {
-				presenceData.details = "Viewing an event";
-				presenceData.state = document.querySelector("h1").textContent;
-			} else if (document.location.pathname.includes("/help-out/"))
-				presenceData.details = "Viewing ways to support Geotastic";
+	const [] = await Promise.all([]),
+		pages: Record<string, PresenceData> = {
+			"/home": { details: "Viewing the home page" },
+			"/local-lobby": { details: "Creating a local lobby" },
+			"/user-challenges/find": { details: "Browsing unplayed user challenges" },
+			"/user-challenges/played": { details: "Browsing played user challenges" },
+			"/user-challenges/own": { details: "Browsing created user challenges" },
+			"/user-challenges/create": { details: "Creating a challenge" },
+			"/matchmaking-lobby": { details: "In a matchmaking lobby" },
+			"/community-map": { details: "Viewing the community map" },
+			"/squad/list": { details: "Browsing the list of squads" },
+			"/squad/management": { details: "Viewing the squad management page" },
+			"/map-editor/maps": { details: "Creating a map" },
+			"/map-editor/drop-groups": { details: "Viewing their drop groups" },
+			"/events": { details: "Browsing past and future events" },
+			"/account/profile": { details: "Viewing their profile settings" },
+			"/account/statistics": { details: "Viewing their statistics" },
+			"/account/trophies": { details: "Viewing their trophies" },
+			"/account/friends": { details: "Viewing their friends" },
+			"/account/supporter-status": { details: "Viewing their supporter status" },
+			"/account/quota-consumption": { details: "Viewing their quota consumption" },
+			"/account/account-settings": { details: "Viewing their account settings" }
+		};
+
+	for (const [path, data] of Object.entries(pages)) {
+		if (document.location.pathname.includes(path))
+			presenceData = { ...presenceData, ...data };
 	}
+
+	switch (true) {
+		case document.location.pathname.includes("/challenge-details/"):
+			presenceData.details = "Viewing a challenge";
+			break;
+		case document.location.pathname.includes("/online-lobby/"):
+			presenceData.details = "In an online lobby";
+			break;
+		case document.location.pathname.includes("/events/"):
+			presenceData.details = "Viewing an event";
+			presenceData.state = document.querySelector("h1").textContent;
+			break;
+		case document.location.pathname.includes("/help-out/"):
+			presenceData.details = "Viewing ways to support Geotastic";
+			break;
+	}
+
 	if (
 		document.location.pathname === "/play" ||
 		document.location.pathname.includes("/play-online/")

--- a/websites/G/Geotastic/tsconfig.json
+++ b/websites/G/Geotastic/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"extends": "../../../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist/"
+	}
+}


### PR DESCRIPTION
## Description 
A new presence for the geography location guessing game, Geotastic. Detects all pages and displays info for all game modes.

## Acknowledgements
✓ I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
✓ I linted the code by running `yarn format`

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://user-images.githubusercontent.com/47200527/170112606-aad1b45a-c115-4c08-80e2-71e8a5786101.png)

![image](https://user-images.githubusercontent.com/47200527/170112718-91eba2cf-20c1-4d21-9cdf-d9860fe76293.png)
</details>