### PR TITLE
chore: replace last PR ack with commitlint

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -4,7 +4,7 @@
 ## Acknowledgements
 - [ ] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
 - [ ] I linted the code by running `yarn format`
-- [ ] I bumped the version of the presence in accordance with [Semver](https://devhints.io/semver)
+- [ ] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)
 
 ## Screenshots
 <details>


### PR DESCRIPTION
The semver acknowledgment didn't make sense since we already have SV which checks for that, so I added this new one to ensure people read the doc in case they're not familiar with it. I also plan on adding a CI in the future that checks this for us