### PR TITLE
chore: remove title templates from issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: Create a report to help us improve the PreMiD Store
-title: Service Name | Service URL
 labels: [bug, needs repro]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/service_request.yml
+++ b/.github/ISSUE_TEMPLATE/service_request.yml
@@ -1,6 +1,5 @@
 name: Service Request
 description: Request a new presence to be added to the store
-title: Service Name | Service URL
 labels: [service request]
 body:
   - type: markdown


### PR DESCRIPTION
## Description 
Templates for issues titles are just absurd, there should be some freedom so title's can be descriptive without having to click on them to understand them