### PR TITLE
fix(Mycanal): rectify the title when a movie is played

### DIFF
--- a/websites/M/myCANAL/dist/metadata.json
+++ b/websites/M/myCANAL/dist/metadata.json
@@ -20,7 +20,7 @@
 		"nl": "Canal + is een Franse abonnementsaanbieder die is gekoppeld aan het kanaal met dezelfde naam. Het is eigendom van Vivendi met een aandeel van honderd procent."
 	},
 	"url": "www.canalplus.com",
-	"version": "1.1.16",
+	"version": "1.1.17",
 	"logo": "https://i.imgur.com/H3IXznl.png",
 	"thumbnail": "https://i.imgur.com/xRKwqvI.png",
 	"color": "#000",

--- a/websites/M/myCANAL/presence.ts
+++ b/websites/M/myCANAL/presence.ts
@@ -22,7 +22,9 @@ presence.on("UpdateData", async () => {
 				presenceData.smallImageText = (await strings).live;
 				presenceData.startTimestamp = browsingTimestamp;
 			} else {
-				title = document.querySelector(".bodyTitle___DZEtt").textContent;
+				title = `${
+					document.querySelector("._3tdt8zwgvMCJ6v_sElXneQ").textContent
+				} ${document.querySelector("._3pyJlyeeH9KBKeFd4nFAmt").textContent}`;
 
 				presenceData.smallImageKey = video.paused ? "pause" : "play";
 				presenceData.smallImageText = video.paused


### PR DESCRIPTION
## Description 
Fixes #6290 issue when playing a show or a movie

## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>


![Discord_3CIjMeuto7](https://user-images.githubusercontent.com/72155852/173191797-f6b372eb-adda-4fd8-b316-57a97695dad9.png)
![Discord_5E9zOpFUDC](https://user-images.githubusercontent.com/72155852/173191802-1e39c471-7bc5-46ba-a7e3-c8d9972da991.png)


</details>
