### PR TITLE
feat(GameBanana): support game manager pages and other changes

### DIFF
--- a/websites/G/GameBanana/dist/metadata.json
+++ b/websites/G/GameBanana/dist/metadata.json
@@ -9,7 +9,7 @@
 		"en": "GameBanana is a community of PC and console gamers who love to discuss, download, and share user-created game content."
 	},
 	"url": "gamebanana.com",
-	"version": "1.0.2",
+	"version": "1.1.0",
 	"logo": "https://i.imgur.com/sIjHqBm.png",
 	"thumbnail": "https://i.imgur.com/RDlk1vD.png",
 	"color": "#1c272e",

--- a/websites/G/GameBanana/presence.ts
+++ b/websites/G/GameBanana/presence.ts
@@ -59,7 +59,7 @@ presence.on("UpdateData", async () => {
 			"StatusUpdate",
 			"Support",
 			"Studio",
-			"Wiki"
+			"Wiki",
 		],
 		gamesettingspages = [
 			"welcomemessage",
@@ -67,7 +67,7 @@ presence.on("UpdateData", async () => {
 			"rules",
 			"attribs",
 			"details",
-			"uberstyle"
+			"uberstyle",
 		];
 
 	if (document.location.hostname === "gamebanana.com") {

--- a/websites/G/GameBanana/presence.ts
+++ b/websites/G/GameBanana/presence.ts
@@ -59,7 +59,15 @@ presence.on("UpdateData", async () => {
 			"StatusUpdate",
 			"Support",
 			"Studio",
-			"Wiki",
+			"Wiki"
+		],
+		gamesettingspages = [
+			"welcomemessage",
+			"subcontrols",
+			"rules",
+			"attribs",
+			"details",
+			"uberstyle"
 		];
 
 	if (document.location.hostname === "gamebanana.com") {
@@ -84,12 +92,48 @@ presence.on("UpdateData", async () => {
 				presenceData.details = "Browsing games";
 			else if (document.location.pathname === "/games/add")
 				presenceData.details = "Adding a game";
-			else if (header.textContent.includes(" : ")) {
-				presenceData.details = `Viewing 
+			else if (document.location.pathname.includes("/admin/withhold")) {
+				presenceData.details = "Viewing the withhold page for:";
+				presenceData.state = document.querySelector<HTMLMetaElement>(
+					'meta[property="gb:game_name"]'
+				).content;
+			} else if (document.location.pathname.includes("/edit")) {
+				presenceData.details = "Editing a game:";
+				presenceData.state = document.querySelector<HTMLMetaElement>(
+					'meta[property="gb:game_name"]'
+				).content;
+			} else if (document.location.pathname.includes("/settings")) {
+				if (
+					gamesettingspages.includes(
+						document.location.pathname.split("settings/")[1].split("/")[0]
+					)
+				) {
+					presenceData.details = `Editing
+								${
+									header.textContent
+										.toLowerCase()
+										.replace("welcome area", "the welcome area")
+										.replace("rules", "the rules")
+										.split(" : ")[0]
+								} for:`;
+					presenceData.state = document.querySelector<HTMLMetaElement>(
+						'meta[property="gb:game_name"]'
+					).content;
+				} else {
+					presenceData.details = "Viewing settings for:";
+					presenceData.state = document.querySelector<HTMLMetaElement>(
+						'meta[property="gb:game_name"]'
+					).content;
+				}
+			} else if (header.textContent.includes(" : ")) {
+				presenceData.details = `Viewing
 							${
 								header.textContent
 									.toLowerCase()
+									.replace("featured", "featured submissions")
 									.replace("about", "the about page")
+									.replace("rules", "the rules")
+									.replace("modlog", "the modlog")
 									.split(" : ")[0]
 							} for:`;
 				presenceData.state = document.querySelector<HTMLMetaElement>(
@@ -108,13 +152,14 @@ presence.on("UpdateData", async () => {
 			)
 				presenceData.details = "Adding a submission";
 			else {
-				presenceData.details = `Adding a 
+				presenceData.details = `Adding a
 							${document
 								.querySelector<HTMLMetaElement>(
 									'meta[property="gb:model_name"]'
 								)
 								.content.toLowerCase()
 								.replace("statusupdate", "status update")
+								.replace("news", "news article")
 								.replace("wip", "WiP")} for:`;
 				if (
 					document.querySelector<HTMLMetaElement>(
@@ -170,13 +215,14 @@ presence.on("UpdateData", async () => {
 						.split("- A")[0]
 						.split(" : ")[1];
 					if (document.location.pathname.includes("/edit")) {
-						presenceData.details = `Editing a 
+						presenceData.details = `Editing a
 							${document
 								.querySelector<HTMLMetaElement>(
 									'meta[property="gb:model_name"]'
 								)
 								.content.toLowerCase()
 								.replace("statusupdate", "status update")
+								.replace("news", "news article")
 								.replace("wip", "WiP")}:`;
 						if (
 							document
@@ -187,13 +233,14 @@ presence.on("UpdateData", async () => {
 						)
 							presenceData.state = "(Private)";
 					} else if (document.location.pathname.includes("/trash")) {
-						presenceData.details = `Trashing a 
+						presenceData.details = `Trashing a
 							${document
 								.querySelector<HTMLMetaElement>(
 									'meta[property="gb:model_name"]'
 								)
 								.content.toLowerCase()
 								.replace("statusupdate", "status update")
+								.replace("news", "news article")
 								.replace("wip", "WiP")}:`;
 					} else {
 						presenceData.details = `Viewing ${header.textContent
@@ -201,13 +248,14 @@ presence.on("UpdateData", async () => {
 							.toLowerCase()
 							.replace("license", "the license")
 							.replace("withhold", "the withhold page")
-							.replace("team", "the team")} for a 
+							.replace("team", "the team")} for a
 							${document
 								.querySelector<HTMLMetaElement>(
 									'meta[property="gb:model_name"]'
 								)
 								.content.toLowerCase()
 								.replace("statusupdate", "status update")
+								.replace("news", "news article")
 								.replace("wip", "WiP")}:`;
 					}
 				} else {
@@ -218,7 +266,7 @@ presence.on("UpdateData", async () => {
 							).content
 						)
 					) {
-						presenceData.details = `Viewing a 
+						presenceData.details = `Viewing a
 							${document
 								.querySelector<HTMLMetaElement>(
 									'meta[property="gb:model_name"]'
@@ -226,13 +274,14 @@ presence.on("UpdateData", async () => {
 								.content.toLowerCase()
 								.replace("statusupdate", "status update")}:`;
 					} else {
-						presenceData.details = `Viewing a 
+						presenceData.details = `Viewing a
 								${document
 									.querySelector<HTMLMetaElement>(
 										'meta[property="gb:model_name"]'
 									)
 									.content.toLowerCase()
-									.replace("wip", "WiP")} for 
+									.replace("news", "news article")
+									.replace("wip", "WiP")} for
 								${
 									document.querySelector<HTMLMetaElement>(
 										'meta[property="gb:game_abbreviation"]'
@@ -243,12 +292,17 @@ presence.on("UpdateData", async () => {
 				}
 				if (document.querySelector("#PrivateAccessNoticeModule"))
 					presenceData.state = "(Private)";
+				else if (document.querySelector("#WithholdNoticeModule"))
+					presenceData.state = "(Withheld)";
+				else if (document.querySelector("#TrashNoticeModule"))
+					presenceData.state = "(Trashed)";
 			} else {
-				presenceData.details = `Browsing 
+				presenceData.details = `Browsing
 					${document
 						.querySelector<HTMLMetaElement>('meta[property="gb:plural_title"]')
 						.content.toLowerCase()
 						.replace("statusupdate", "status update")
+						.replace("news", "news article")
 						.replace("wip", "WiP")}`;
 			}
 		} else if (document.location.pathname.includes("/search"))
@@ -296,7 +350,7 @@ presence.on("UpdateData", async () => {
 				)
 					presenceData.details = "Viewing the submitters leaderboard";
 			} else if (document.location.pathname.includes("/settings")) {
-				presenceData.details = `Changing 
+				presenceData.details = `Changing
 							${
 								header.textContent
 									.toLowerCase()


### PR DESCRIPTION
## Description 
This update to the GameBanana presence adds support to game manager related pages, including game settings pages and the modlog. The names for withheld and trashed submissions are now hidden, similarly to private submissions. Instances of "a news" have been changed to "a news article", and the strings "Viewing featured for:" and "Viewing rules for:" have been changed to "Viewing featured submissions for:" and "Viewing the rules for:" respectively.

## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://user-images.githubusercontent.com/7158344/173210063-dc7c187a-1dc6-4778-9c91-7e86b40c8256.png)
![image](https://user-images.githubusercontent.com/7158344/173210139-5b20f2e3-1f1c-4c77-8cf0-2d2476d7f36a.png)
![image](https://user-images.githubusercontent.com/7158344/173210251-eff31fca-9738-4abe-bc98-b63f00006b68.png)
![image](https://user-images.githubusercontent.com/7158344/173210260-7d172ca6-9bb3-436d-ba21-9d03694c823f.png)
![image](https://user-images.githubusercontent.com/7158344/173210270-a7e3b064-d9c6-4d92-9f16-f69be426dd96.png)

</details>
