### PR TITLE
fix(Nimo): presence not displaying in Theatre mode

### DIFF
--- a/websites/N/Nimo/dist/metadata.json
+++ b/websites/N/Nimo/dist/metadata.json
@@ -16,7 +16,7 @@
 		"www.nimo.tv",
 		"dashboard.nimo.tv"
 	],
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"logo": "https://i.imgur.com/dXRRZoM.png",
 	"thumbnail": "https://i.imgur.com/Sq0hpoF.jpeg",
 	"color": "#622DF7",

--- a/websites/N/Nimo/presence.ts
+++ b/websites/N/Nimo/presence.ts
@@ -74,10 +74,10 @@ presence.on("UpdateData", async () => {
 			presence.getSetting<boolean>("buttons")
 		]),
 		title = getElement(
-			":is(div.nimo-rm_title-text > h3, #meta-info > div.video-info h1)"
+			":is(div.nimo-rm_title-text > h3, #meta-info > div.video-info h1, .nimo-player__room-meta_title-text)"
 		),
 		streamer = getElement(
-			":is(div.nimo-rm_sub-title > h1, #meta-info div.anchor-name.n-as-text-over > a > h2)"
+			":is(div.nimo-rm_sub-title > h1, #meta-info div.anchor-name.n-as-text-over > a > h2, .nimo-player__room-meta__nick)"
 		),
 		game = getElement("div.nimo-anchor-broadcast-game > a > h4");
 


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

Add another element selector rule to include elements in Theatre Mode

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://user-images.githubusercontent.com/77577746/173498880-57c960d7-d42a-4a4c-8679-bf3cd03ad3d2.png)



</details>
