### PR TITLE
Correct a spacing mistake in the Cookie Clicker / DashNet presence.

### DIFF
--- a/websites/D/DashNet/dist/metadata.json
+++ b/websites/D/DashNet/dist/metadata.json
@@ -14,7 +14,7 @@
 	},
 	"url": "dashnet.org",
 	"regExp": "([a-z0-9-]+[.])*dashnet[.]org[/]",
-	"version": "1.3.5",
+	"version": "1.3.6",
 	"logo": "https://i.imgur.com/xcK0UqX.png",
 	"thumbnail": "https://i.imgur.com/PnsZ4Nv.png",
 	"color": "#042B48",
@@ -22,5 +22,11 @@
 	"tags": [
 		"cookie",
 		"clicker"
+	],
+	"contributors": [
+		{
+			"name": "DananaBanana",
+			"id": "423478609529929728"
+		}
 	]
 }

--- a/websites/D/DashNet/presence.ts
+++ b/websites/D/DashNet/presence.ts
@@ -14,12 +14,12 @@ function presenceSet(): void {
 	}
 }
 
-function spaceAfterNumbers(str) {
+function spaceAfterNumbers(str: string) {
 	let arr = str.split('')
     let newStr = String()
     let found = false;
 	arr.forEach(c => {
-        newStr += (isNaN(c) && found == false) ? " " + c : c
+        newStr += (isNaN(Number(c)) && found == false && c !== ".") ? " " + c : c
         if (newStr.includes(" ")) found = true;
     })
 
@@ -40,12 +40,12 @@ presence.on("UpdateData", () => {
 
 	if (document.location.pathname.includes("/cookieclicker/")) {
 		const cookies = document
-			.querySelector("#cookies")
+			.querySelector("#cookies") 
 			.textContent.replace(
 				document.querySelector("#cookies div").textContent,
 				""
 			);
-		if (cookies.includes(" cookies")) presenceData.details = cookies;
+		if (cookies.includes(" cookies")) presenceData.details = spaceAfterNumbers(cookies);
 		else presenceData.details = spaceAfterNumbers(cookies).replace("cookies", " cookies");
 
 		presenceData.state = document

--- a/websites/D/DashNet/presence.ts
+++ b/websites/D/DashNet/presence.ts
@@ -14,6 +14,18 @@ function presenceSet(): void {
 	}
 }
 
+function spaceAfterNumbers(str) {
+	let arr = str.split('')
+    let newStr = String()
+    let found = false;
+	arr.forEach(c => {
+        newStr += (isNaN(c) && found == false) ? " " + c : c
+        if (newStr.includes(" ")) found = true;
+    })
+
+    return newStr
+}
+
 const browsingTimestamp = Math.floor(Date.now() / 1000);
 
 presenceSet();
@@ -34,7 +46,7 @@ presence.on("UpdateData", () => {
 				""
 			);
 		if (cookies.includes(" cookies")) presenceData.details = cookies;
-		else presenceData.details = cookies.replace("cookies", " cookies");
+		else presenceData.details = spaceAfterNumbers(cookies).replace("cookies", " cookies");
 
 		presenceData.state = document
 			.querySelector("#cookies div")

--- a/websites/D/DashNet/presence.ts
+++ b/websites/D/DashNet/presence.ts
@@ -19,7 +19,7 @@ function spaceAfterNumbers(str: string) {
     let newStr = String()
     let found = false;
 	arr.forEach(c => {
-        newStr += (isNaN(Number(c)) && found == false && c !== ".") ? " " + c : c
+        newStr += (isNaN(Number(c)) && found == false && c !== "." && c !== ",") ? " " + c : c
         if (newStr.includes(" ")) found = true;
     })
 
@@ -40,7 +40,7 @@ presence.on("UpdateData", () => {
 
 	if (document.location.pathname.includes("/cookieclicker/")) {
 		const cookies = document
-			.querySelector("#cookies") 
+			.querySelector("#cookies")
 			.textContent.replace(
 				document.querySelector("#cookies div").textContent,
 				""


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
There is no space between the integer and the shortened number. (e.g.: million, billion, trillion)
I have added a function that adds a space in between these values, as well as keeping all the working rules in place.

## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

Here is a screenshot showing it works when [Shortened Numbers](https://i.imgur.com/V6U90Ee.png) are enabled as well as when [they aren't.](https://i.imgur.com/nJNpjM5.png)

</details>