### PR TITLE
fix(DashNet): cookie clicker spacing issue

### DIFF
--- a/websites/D/DashNet/dist/metadata.json
+++ b/websites/D/DashNet/dist/metadata.json
@@ -4,6 +4,12 @@
 		"name": "Bas950",
 		"id": "241278257335500811"
 	},
+	"contributors": [
+		{
+			"name": "DananaBanana",
+			"id": "423478609529929728"
+		}
+	],
 	"service": "DashNet",
 	"altnames": [
 		"Cookie Clicker"
@@ -14,7 +20,7 @@
 	},
 	"url": "dashnet.org",
 	"regExp": "([a-z0-9-]+[.])*dashnet[.]org[/]",
-	"version": "1.3.5",
+	"version": "1.3.6",
 	"logo": "https://i.imgur.com/xcK0UqX.png",
 	"thumbnail": "https://i.imgur.com/PnsZ4Nv.png",
 	"color": "#042B48",

--- a/websites/D/DashNet/dist/metadata.json
+++ b/websites/D/DashNet/dist/metadata.json
@@ -14,7 +14,7 @@
 	},
 	"url": "dashnet.org",
 	"regExp": "([a-z0-9-]+[.])*dashnet[.]org[/]",
-	"version": "1.3.5",
+	"version": "1.3.6",
 	"logo": "https://i.imgur.com/xcK0UqX.png",
 	"thumbnail": "https://i.imgur.com/PnsZ4Nv.png",
 	"color": "#042B48",
@@ -22,5 +22,11 @@
 	"tags": [
 		"cookie",
 		"clicker"
+	],
+	"contributors": [
+		{
+			"name": "DananaBanana",
+			"id": "423478609529929728"
+		}
 	]
 }

--- a/websites/D/DashNet/presence.ts
+++ b/websites/D/DashNet/presence.ts
@@ -14,6 +14,21 @@ function presenceSet(): void {
 	}
 }
 
+function spaceAfterNumbers(str: string) {
+	const arr = str.split("");
+	let newStr = String(),
+		found = false;
+	for (const c of arr) {
+		newStr +=
+			isNaN(Number(c)) && found == false && c !== "." && c !== ","
+				? ` ${c}`
+				: c;
+		if (newStr.includes(" ")) found = true;
+	}
+
+	return newStr;
+}
+
 const browsingTimestamp = Math.floor(Date.now() / 1000);
 
 presenceSet();
@@ -33,8 +48,14 @@ presence.on("UpdateData", () => {
 				document.querySelector("#cookies div").textContent,
 				""
 			);
-		if (cookies.includes(" cookies")) presenceData.details = cookies;
-		else presenceData.details = cookies.replace("cookies", " cookies");
+		if (cookies.includes(" cookies"))
+			presenceData.details = spaceAfterNumbers(cookies);
+		else {
+			presenceData.details = spaceAfterNumbers(cookies).replace(
+				"cookies",
+				" cookies"
+			);
+		}
 
 		presenceData.state = document
 			.querySelector("#cookies div")

--- a/websites/D/DashNet/presence.ts
+++ b/websites/D/DashNet/presence.ts
@@ -14,6 +14,18 @@ function presenceSet(): void {
 	}
 }
 
+function spaceAfterNumbers(str: string) {
+	let arr = str.split('')
+    let newStr = String()
+    let found = false;
+	arr.forEach(c => {
+        newStr += (isNaN(Number(c)) && found == false && c !== "." && c !== ",") ? " " + c : c
+        if (newStr.includes(" ")) found = true;
+    })
+
+    return newStr
+}
+
 const browsingTimestamp = Math.floor(Date.now() / 1000);
 
 presenceSet();
@@ -33,8 +45,8 @@ presence.on("UpdateData", () => {
 				document.querySelector("#cookies div").textContent,
 				""
 			);
-		if (cookies.includes(" cookies")) presenceData.details = cookies;
-		else presenceData.details = cookies.replace("cookies", " cookies");
+		if (cookies.includes(" cookies")) presenceData.details = spaceAfterNumbers(cookies);
+		else presenceData.details = spaceAfterNumbers(cookies).replace("cookies", " cookies");
 
 		presenceData.state = document
 			.querySelector("#cookies div")

--- a/websites/D/DashNet/presence.ts
+++ b/websites/D/DashNet/presence.ts
@@ -1,29 +1,32 @@
 let presence: Presence, newID: string, latestID: string;
 function presenceSet(): void {
-	if (document.location.pathname.includes("/cookieclicker/")) {
-		presence = new Presence({ clientId: "676126246928777250" });
-		newID = "676126246928777250";
-	} else {
-		presence = new Presence({ clientId: "676120967159742465" });
-		newID = "676120967159742465";
-	}
+  if (document.location.pathname.includes("/cookieclicker/")) {
+    presence = new Presence({ clientId: "676126246928777250" });
+    newID = "676126246928777250";
+  } else {
+    presence = new Presence({ clientId: "676120967159742465" });
+    newID = "676120967159742465";
+  }
 
-	if (newID !== latestID && latestID) {
-		presence.clearActivity();
-		latestID = newID;
-	}
+  if (newID !== latestID && latestID) {
+    presence.clearActivity();
+    latestID = newID;
+  }
 }
 
 function spaceAfterNumbers(str: string) {
-	let arr = str.split('')
-    let newStr = String()
-    let found = false;
-	arr.forEach(c => {
-        newStr += (isNaN(Number(c)) && found == false && c !== "." && c !== ",") ? " " + c : c
-        if (newStr.includes(" ")) found = true;
-    })
+  let arr = str.split("");
+  let newStr = String();
+  let found = false;
+  arr.forEach((c) => {
+    newStr +=
+      isNaN(Number(c)) && found == false && c !== "." && c !== ","
+        ? " " + c
+        : c;
+    if (newStr.includes(" ")) found = true;
+  });
 
-    return newStr
+  return newStr;
 }
 
 const browsingTimestamp = Math.floor(Date.now() / 1000);
@@ -31,67 +34,72 @@ const browsingTimestamp = Math.floor(Date.now() / 1000);
 presenceSet();
 
 presence.on("UpdateData", () => {
-	const presenceData: PresenceData = {
-		largeImageKey: "dashnet",
-		startTimestamp: browsingTimestamp,
-	};
+  const presenceData: PresenceData = {
+    largeImageKey: "dashnet",
+    startTimestamp: browsingTimestamp,
+  };
 
-	presenceSet();
+  presenceSet();
 
-	if (document.location.pathname.includes("/cookieclicker/")) {
-		const cookies = document
-			.querySelector("#cookies")
-			.textContent.replace(
-				document.querySelector("#cookies div").textContent,
-				""
-			);
-		if (cookies.includes(" cookies")) presenceData.details = spaceAfterNumbers(cookies);
-		else presenceData.details = spaceAfterNumbers(cookies).replace("cookies", " cookies");
+  if (document.location.pathname.includes("/cookieclicker/")) {
+    const cookies = document
+      .querySelector("#cookies")
+      .textContent.replace(
+        document.querySelector("#cookies div").textContent,
+        ""
+      );
+    if (cookies.includes(" cookies"))
+      presenceData.details = spaceAfterNumbers(cookies);
+    else
+      presenceData.details = spaceAfterNumbers(cookies).replace(
+        "cookies",
+        " cookies"
+      );
 
-		presenceData.state = document
-			.querySelector("#cookies div")
-			.textContent.replace("per second :", "Per second:");
-		presenceData.smallImageKey = "legacyy";
-		presenceData.smallImageText = `Legacy level: ${
-			document.querySelector("#ascendNumber").textContent
-		}`;
-	} else if (document.location.pathname === "/") {
-		presenceData.details = "Browsing DashNet's";
-		presenceData.state = "video games and other fun things";
-		presenceData.smallImageKey = "reading";
-	} else if (document.location.pathname.includes("/legacy/"))
-		presenceData.details = "Playing Legacy";
-	else if (document.location.pathname.includes("/igm/"))
-		presenceData.details = "Making an idle game";
-	else if (document.location.pathname.includes("/randomgen/"))
-		presenceData.details = "Using RandomGen";
-	else if (document.location.pathname.includes("/nested/"))
-		presenceData.details = "Playing Nested";
-	else if (document.location.pathname.includes("/murdergames/"))
-		presenceData.details = "Playing Murder Games";
-	else if (document.location.pathname.includes("/lsystem/"))
-		presenceData.details = "Playing Tutrle Toy";
-	else if (document.location.pathname.includes("/taskmaster/"))
-		presenceData.details = "Using TaskMaster";
-	else if (document.location.pathname.includes("/cookies2cash/"))
-		presenceData.details = "Using Cookies2Cash";
-	else if (document.location.pathname.includes("/musicgen/"))
-		presenceData.details = "Using MusicGen";
-	else if (document.location.pathname.includes("/dungeongenerator/"))
-		presenceData.details = "Using Dungeon Generator";
-	else if (document.location.pathname.includes("/dreamlog/"))
-		presenceData.details = "Playing Dreamlog";
-	else if (document.location.pathname.includes("/PretendEverything/"))
-		presenceData.details = "Playing PretendEverything";
-	else if (document.location.pathname.includes("/teaparty/"))
-		presenceData.details = "Having a tea party";
-	else if (document.location.pathname.includes("/mailtopia/"))
-		presenceData.details = "Playing mailtopia";
-	else if (document.location.pathname.includes("/life"))
-		presenceData.details = "Playing Life";
-	else if (document.location.pathname.includes("/3dtest/2"))
-		presenceData.details = "Using WebGL test";
+    presenceData.state = document
+      .querySelector("#cookies div")
+      .textContent.replace("per second :", "Per second:");
+    presenceData.smallImageKey = "legacyy";
+    presenceData.smallImageText = `Legacy level: ${
+      document.querySelector("#ascendNumber").textContent
+    }`;
+  } else if (document.location.pathname === "/") {
+    presenceData.details = "Browsing DashNet's";
+    presenceData.state = "video games and other fun things";
+    presenceData.smallImageKey = "reading";
+  } else if (document.location.pathname.includes("/legacy/"))
+    presenceData.details = "Playing Legacy";
+  else if (document.location.pathname.includes("/igm/"))
+    presenceData.details = "Making an idle game";
+  else if (document.location.pathname.includes("/randomgen/"))
+    presenceData.details = "Using RandomGen";
+  else if (document.location.pathname.includes("/nested/"))
+    presenceData.details = "Playing Nested";
+  else if (document.location.pathname.includes("/murdergames/"))
+    presenceData.details = "Playing Murder Games";
+  else if (document.location.pathname.includes("/lsystem/"))
+    presenceData.details = "Playing Tutrle Toy";
+  else if (document.location.pathname.includes("/taskmaster/"))
+    presenceData.details = "Using TaskMaster";
+  else if (document.location.pathname.includes("/cookies2cash/"))
+    presenceData.details = "Using Cookies2Cash";
+  else if (document.location.pathname.includes("/musicgen/"))
+    presenceData.details = "Using MusicGen";
+  else if (document.location.pathname.includes("/dungeongenerator/"))
+    presenceData.details = "Using Dungeon Generator";
+  else if (document.location.pathname.includes("/dreamlog/"))
+    presenceData.details = "Playing Dreamlog";
+  else if (document.location.pathname.includes("/PretendEverything/"))
+    presenceData.details = "Playing PretendEverything";
+  else if (document.location.pathname.includes("/teaparty/"))
+    presenceData.details = "Having a tea party";
+  else if (document.location.pathname.includes("/mailtopia/"))
+    presenceData.details = "Playing mailtopia";
+  else if (document.location.pathname.includes("/life"))
+    presenceData.details = "Playing Life";
+  else if (document.location.pathname.includes("/3dtest/2"))
+    presenceData.details = "Using WebGL test";
 
-	if (presenceData.details) presence.setActivity(presenceData);
-	else presence.setActivity();
+  if (presenceData.details) presence.setActivity(presenceData);
+  else presence.setActivity();
 });


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
There is no space between the integer and the shortened number. (e.g.: million, billion, trillion)
I have added a function that adds a space in between these values, as well as keeping all the working rules in place.
This works with both the shortened and long number format.

## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

It works with shortened numbers:
![image](https://user-images.githubusercontent.com/37070388/174394414-7dc42bd0-52ee-4784-a71a-573a9ef7df6b.png)

As well as long numbers: 
![image](https://user-images.githubusercontent.com/37070388/174394498-d998b00b-ea6c-462c-a5d2-80811e4eea90.png)

</details>