### PR TITLE
fix(DashNet): cookie clicker spacing issue

### DIFF
--- a/websites/D/DashNet/dist/metadata.json
+++ b/websites/D/DashNet/dist/metadata.json
@@ -4,6 +4,12 @@
 		"name": "Bas950",
 		"id": "241278257335500811"
 	},
+	"contributors": [
+		{
+			"name": "DananaBanana",
+			"id": "423478609529929728"
+		}
+	],
 	"service": "DashNet",
 	"altnames": [
 		"Cookie Clicker"
@@ -14,7 +20,7 @@
 	},
 	"url": "dashnet.org",
 	"regExp": "([a-z0-9-]+[.])*dashnet[.]org[/]",
-	"version": "1.3.5",
+	"version": "1.3.6",
 	"logo": "https://i.imgur.com/xcK0UqX.png",
 	"thumbnail": "https://i.imgur.com/PnsZ4Nv.png",
 	"color": "#042B48",
@@ -22,5 +28,11 @@
 	"tags": [
 		"cookie",
 		"clicker"
+	],
+	"contributors": [
+		{
+			"name": "DananaBanana",
+			"id": "423478609529929728"
+		}
 	]
 }

--- a/websites/D/DashNet/presence.ts
+++ b/websites/D/DashNet/presence.ts
@@ -15,25 +15,9 @@ function presenceSet(): void {
 }
 
 function spaceAfterNumbers(str: string) {
-	let arr = str.split("");
-	let newStr = String();
-	let found = false;
-	arr.forEach(c => {
-		newStr +=
-			isNaN(Number(c)) && found == false && c !== "." && c !== ","
-				? " " + c
-				: c;
-		if (newStr.includes(" ")) found = true;
-	});
-
-	return newStr;
-}
-
-function spaceAfterNumbers(str: string) {
-	const arr = str.split("");
 	let newStr = String(),
 		found = false;
-	for (const c of arr) {
+	for (const c of str.split("")) {
 		newStr +=
 			isNaN(Number(c)) && found == false && c !== "." && c !== ","
 				? ` ${c}`

--- a/websites/D/DashNet/presence.ts
+++ b/websites/D/DashNet/presence.ts
@@ -14,20 +14,6 @@ function presenceSet(): void {
 	}
 }
 
-function spaceAfterNumbers(str: string) {
-	let newStr = String(),
-		found = false;
-	for (const c of str.split("")) {
-		newStr +=
-			isNaN(Number(c)) && found == false && c !== "." && c !== ","
-				? ` ${c}`
-				: c;
-		if (newStr.includes(" ")) found = true;
-	}
-
-	return newStr;
-}
-
 const browsingTimestamp = Math.floor(Date.now() / 1000);
 
 presenceSet();
@@ -43,18 +29,11 @@ presence.on("UpdateData", () => {
 	if (document.location.pathname.includes("/cookieclicker/")) {
 		const cookies = document
 			.querySelector("#cookies")
-			.textContent.replace(
-				document.querySelector("#cookies div").textContent,
-				""
-			);
-		if (cookies.includes(" cookies"))
-			presenceData.details = spaceAfterNumbers(cookies);
-		else {
-			presenceData.details = spaceAfterNumbers(cookies).replace(
-				"cookies",
-				" cookies"
-			);
-		}
+			.innerHTML.replace("<br>", " ")
+			.split("<")[0];
+
+		if (cookies.includes(" cookies")) presenceData.details = cookies;
+		else presenceData.details = cookies.replace("cookies", " cookies");
 
 		presenceData.state = document
 			.querySelector("#cookies div")

--- a/websites/D/DashNet/presence.ts
+++ b/websites/D/DashNet/presence.ts
@@ -14,6 +14,36 @@ function presenceSet(): void {
 	}
 }
 
+function spaceAfterNumbers(str: string) {
+	let arr = str.split("");
+	let newStr = String();
+	let found = false;
+	arr.forEach(c => {
+		newStr +=
+			isNaN(Number(c)) && found == false && c !== "." && c !== ","
+				? " " + c
+				: c;
+		if (newStr.includes(" ")) found = true;
+	});
+
+	return newStr;
+}
+
+function spaceAfterNumbers(str: string) {
+	const arr = str.split("");
+	let newStr = String(),
+		found = false;
+	for (const c of arr) {
+		newStr +=
+			isNaN(Number(c)) && found == false && c !== "." && c !== ","
+				? ` ${c}`
+				: c;
+		if (newStr.includes(" ")) found = true;
+	}
+
+	return newStr;
+}
+
 const browsingTimestamp = Math.floor(Date.now() / 1000);
 
 presenceSet();
@@ -33,8 +63,14 @@ presence.on("UpdateData", () => {
 				document.querySelector("#cookies div").textContent,
 				""
 			);
-		if (cookies.includes(" cookies")) presenceData.details = cookies;
-		else presenceData.details = cookies.replace("cookies", " cookies");
+		if (cookies.includes(" cookies"))
+			presenceData.details = spaceAfterNumbers(cookies);
+		else {
+			presenceData.details = spaceAfterNumbers(cookies).replace(
+				"cookies",
+				" cookies"
+			);
+		}
 
 		presenceData.state = document
 			.querySelector("#cookies div")


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
There is no space between the integer and the shortened number. (e.g.: million, billion, trillion)
I have added a function that adds a space in between these values, as well as keeping all the working rules in place.
This works with both the shortened and long number format.

## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

**Before**:
A screenshot of my friend, that is using the version from the store:
![image](https://user-images.githubusercontent.com/37070388/174401501-35d949b4-656c-4834-be53-35d0c48f347d.png)

**After**:
It works with shortened numbers:
![image](https://user-images.githubusercontent.com/37070388/174394414-7dc42bd0-52ee-4784-a71a-573a9ef7df6b.png)

As well as long numbers: 
![image](https://user-images.githubusercontent.com/37070388/174394498-d998b00b-ea6c-462c-a5d2-80811e4eea90.png)

</details>