### PR TITLE
 fix(Tidal): update element selectors

### DIFF
--- a/websites/T/Tidal/dist/metadata.json
+++ b/websites/T/Tidal/dist/metadata.json
@@ -8,6 +8,10 @@
 		{
 			"name": "Kyrie",
 			"id": "368399721494216706"
+		},
+		{
+			"name": "VirusBLITZ",
+			"id": "280746709590474753"
 		}
 	],
 	"service": "Tidal",
@@ -22,7 +26,7 @@
 		"listen.tidal.com",
 		"tidal.com"
 	],
-	"version": "3.1.5",
+	"version": "3.1.6",
 	"logo": "https://i.imgur.com/i9pIvqR.png",
 	"thumbnail": "https://i.imgur.com/xNeJ8oq.png",
 	"color": "#000000",

--- a/websites/T/Tidal/dist/metadata.json
+++ b/websites/T/Tidal/dist/metadata.json
@@ -8,10 +8,6 @@
 		{
 			"name": "Kyrie",
 			"id": "368399721494216706"
-		},
-		{
-			"name": "VirusBLITZ",
-			"id": "280746709590474753"
 		}
 	],
 	"service": "Tidal",

--- a/websites/T/Tidal/presence.ts
+++ b/websites/T/Tidal/presence.ts
@@ -33,16 +33,16 @@ presence.on("UpdateData", async () => {
 	}
 
 	const presenceData: PresenceData = {
-			largeImageKey: "logo",
-		},
+		largeImageKey: "logo",
+	},
 		songTitle = document.querySelector<HTMLAnchorElement>(
 			'div[data-test="footer-track-title"] > a'
 		),
 		currentTime = document
-			.querySelector<HTMLElement>("time.current-time")
+			.querySelector<HTMLElement>('time[data-test="current-time"]')
 			.textContent.split(":"),
 		endTime = document
-			.querySelector<HTMLElement>("time.duration-time")
+			.querySelector<HTMLElement>('time[data-test="duration"]')
 			.textContent.split(":"),
 		currentTimeSec =
 			(parseFloat(currentTime[0]) * 60 + parseFloat(currentTime[1])) * 1000,

--- a/websites/T/Tidal/presence.ts
+++ b/websites/T/Tidal/presence.ts
@@ -31,10 +31,9 @@ presence.on("UpdateData", async () => {
 		oldLang = newLang;
 		strings = await getStrings();
 	}
-
 	const presenceData: PresenceData = {
-		largeImageKey: "logo",
-	},
+			largeImageKey: "logo",
+		},
 		songTitle = document.querySelector<HTMLAnchorElement>(
 			'div[data-test="footer-track-title"] > a'
 		),


### PR DESCRIPTION
## Description 
With Tidal's update on June 13th the presence stopped working, 
This was fixed by changing some element selectors.

## Acknowledgements
- [x]  I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

## Before

![grafik](https://user-images.githubusercontent.com/58221423/174487666-804571c3-ebc2-45b5-8045-755e4ec31694.png)

## After

![After](https://user-images.githubusercontent.com/58221423/174487548-e1ab937e-7579-4999-a673-e1ac28241395.png)



</details>
