### PR TITLE
ci(SV): don't run on push

### DIFF
--- a/.github/workflows/SV.yml
+++ b/.github/workflows/SV.yml
@@ -1,5 +1,5 @@
 name: Schema Validation Check
-on: [push, pull_request]
+on: pull_request
 jobs:
   validate:
     name: Schema Validation Check


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
It seems like before #6339 SV was being run on push but it wasn't doing anything since the files changed wouldn't get written so it would always validate 0 presences. This PR makes it so the CI just doesn't run at all on push, avoiding unnecessary fails

## Acknowledgements
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

