### PR TITLE
chore: disable scope case rule

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,7 +1,7 @@
 {
 	"extends": ["@commitlint/config-angular"],
 	"rules": {
-		"scope-case": [2, "always", "sentence-case"],
+		"scope-case": [0],
 		"type-enum": [
 			2,
 			"always",


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

Disables the scope-case rule in commitlint since presences can have many different casing styles

## Acknowledgements
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

