### PR TITLE
ci: only run on pushes to main and prs

### DIFF
--- a/.github/workflows/compileLint.yml
+++ b/.github/workflows/compileLint.yml
@@ -1,5 +1,9 @@
 name: Compile and Lint
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
 jobs:
   compileLint:
     name: Compile and Lint


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

No reason to have the same CI run twice on PRs made through internal branches

## Acknowledgements
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)
