### PR TITLE
chore: increase PR limit on dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
       include: scope
     labels:
       - "dependencies"
+    open-pull-requests-limit: 20
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

Having to merge PRs then wait for others is boring, we can just let it open all PRs at once. FYI there's no good way to disable the limit, so I set it to an amount it should never really reach

## Acknowledgements
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)
