### PR TITLE
Fix(flixTor): fix presence not showing

### DIFF
--- a/websites/F/FlixTor/dist/metadata.json
+++ b/websites/F/FlixTor/dist/metadata.json
@@ -27,7 +27,7 @@
 		"flixtor.cz"
 	],
 	"regExp": "flixtor[.](to|ch|se|vc|nu|sx|tk|cz)",
-	"version": "2.3.2",
+	"version": "2.3.3",
 	"logo": "https://i.imgur.com/FIXyNZo.png",
 	"thumbnail": "https://i.imgur.com/iaHbvZ7.png",
 	"color": "#1d3343",

--- a/websites/F/FlixTor/presence.ts
+++ b/websites/F/FlixTor/presence.ts
@@ -1,5 +1,5 @@
 const presence = new Presence({
-		clientId: "616754182858342426",
+		clientId: "1001112348192423946",
 	}),
 	strings = presence.getStrings({
 		play: "presence.playback.playing",
@@ -45,7 +45,8 @@ presence.on("UpdateData", async () => {
 			);
 		presenceData.largeImageKey = document
 			.querySelector<HTMLMetaElement>('meta[property="og:image"]')
-			.getAttribute("content");
+			.getAttribute("content")
+			.replace("https:https:", "https:");
 
 		presenceData.smallImageKey = video.paused ? "pause" : "play";
 		presenceData.smallImageText = video.paused
@@ -111,7 +112,6 @@ presence.on("UpdateData", async () => {
 			delete presenceData.startTimestamp;
 			delete presenceData.endTimestamp;
 		}
-
 		if (videoTitle) presence.setActivity(presenceData, !video.paused);
 	}
 });


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Presence were not showing because of the invalid clientId for the presence object. I've replaced it and corrected a bug for the displaying of movies' cover.

close #6485 

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![flixtor_proof_1](https://user-images.githubusercontent.com/85577959/180792564-a93ad416-bbf4-464e-aaec-4416673cc946.PNG)

![flixtor_proof_2](https://user-images.githubusercontent.com/85577959/180792578-af4bf8be-d8a8-45d5-bc2f-886599a86cec.PNG)

![flixtor_proof_3](https://user-images.githubusercontent.com/85577959/180792589-7b6dd11c-2efb-4b57-8db3-af7b0e3acf10.PNG)

![flixtor_proof_4](https://user-images.githubusercontent.com/85577959/180792607-bbea3815-4b0a-437f-b95b-251091ad638c.PNG)



</details>
