### PR TITLE
refactor(Youtube Music): remove duplicated code

### DIFF
--- a/websites/Y/YouTube Music/dist/metadata.json
+++ b/websites/Y/YouTube Music/dist/metadata.json
@@ -25,7 +25,7 @@
 		"vi_VN": "Một dịch vụ phát nhạc mới với các album, đĩa đơn, video, bản remix, và các tiết mục trực tiếp chính thức và hơn nữa cho Android, iOS và máy tính. Tất cả đều tại đây."
 	},
 	"url": "music.youtube.com",
-	"version": "2.9.3",
+	"version": "2.9.4",
 	"logo": "https://i.imgur.com/31gvH2b.png",
 	"thumbnail": "https://i.imgur.com/iQ8MA50.png",
 	"color": "#E40813",

--- a/websites/Y/YouTube Music/presence.ts
+++ b/websites/Y/YouTube Music/presence.ts
@@ -65,15 +65,6 @@ presence.on("UpdateData", async () => {
 			];
 		}
 
-		if (buttons) {
-			presenceData.buttons = [
-				{
-					label: "Listen Along",
-					url: `https://music.youtube.com/watch?v=${watchID}`,
-				},
-			];
-		}
-
 		if (video.paused || !timestamps) {
 			delete presenceData.startTimestamp;
 			delete presenceData.endTimestamp;


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
The code to add the "Listen Along" button was duplicated in the presence.ts file, so I've remove the duplicated part


## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![ytb_music_proof_1](https://user-images.githubusercontent.com/85577959/180962820-64dc9667-eaf3-493c-a4c1-cd0d209ce250.PNG)

![ytb_music_proof_2](https://user-images.githubusercontent.com/85577959/180962888-fd00e21a-46eb-4d79-84b7-848c5bdc7fc8.PNG)


</details>
