### PR TITLE
feat(Crunchyroll): add showCover setting

### DIFF
--- a/websites/C/Crunchyroll/dist/metadata.json
+++ b/websites/C/Crunchyroll/dist/metadata.json
@@ -42,6 +42,12 @@
 		{
 			"id": "lang",
 			"multiLanguage": true
+		},
+		{
+			"id": "cover",
+			"title": "Show Cover",
+			"icon": "fad fa-images",
+			"value": true
 		}
 	]
 }

--- a/websites/C/Crunchyroll/dist/metadata.json
+++ b/websites/C/Crunchyroll/dist/metadata.json
@@ -27,7 +27,7 @@
 		"www.crunchyroll.com",
 		"beta.crunchyroll.com"
 	],
-	"version": "2.8.0",
+	"version": "2.9.0",
 	"logo": "https://i.imgur.com/LpTKP8c.png",
 	"thumbnail": "https://i.imgur.com/hzM7YCb.png",
 	"color": "#f47521",

--- a/websites/C/Crunchyroll/presence.ts
+++ b/websites/C/Crunchyroll/presence.ts
@@ -59,7 +59,10 @@ presence.on("iFrameData", (data: iFrameData) => {
 });
 
 presence.on("UpdateData", async () => {
-	const newLang = await presence.getSetting<string>("lang").catch(() => "en");
+	const [newLang, showCover] = await Promise.all([
+		presence.getSetting<string>("lang").catch(() => "en"),
+		presence.getSetting<boolean>("cover"),
+	]);
 	if (oldLang !== newLang || !strings) {
 		oldLang = newLang;
 		strings = await getStrings();
@@ -164,9 +167,11 @@ presence.on("UpdateData", async () => {
 		presenceData.details = videoTitle ?? "Title not found...";
 		presenceData.state = episode;
 
-		presenceData.largeImageKey =
-			document.querySelector<HTMLMetaElement>("[property='og:image']")
-				?.content ?? "lg";
+		if (showCover) {
+			presenceData.largeImageKey =
+				document.querySelector<HTMLMetaElement>("[property='og:image']")
+					?.content ?? "lg";
+		}
 		if (paused) {
 			delete presenceData.startTimestamp;
 			delete presenceData.endTimestamp;


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Due to the fresh new addition done in the PR #6504, some users were complaining on the Premid's DIscord about the missing of a setting to deactivate or not the showing of the anime cover.
So I've added it.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![crunchyroll_proof_1](https://user-images.githubusercontent.com/85577959/181353082-8fcdb821-a32b-4eef-8b71-43ad4b5cb31e.PNG)

![crunchyroll_proof_2](https://user-images.githubusercontent.com/85577959/181353099-b8d7fbac-085e-492d-bd57-2ef2e9daec3c.PNG)


</details>
