### PR TITLE
fix(Homestuck^2): corrected domain support

### DIFF
--- a/websites/H/Homestuck^2/dist/metadata.json
+++ b/websites/H/Homestuck^2/dist/metadata.json
@@ -8,8 +8,11 @@
 	"description": {
 		"en": "The Homestuck^2 website hosts the official continuation of the popular MSPaintAdventure Homestuck and all Patreon-driven bonus content."
 	},
-	"url": "homestuck2.com",
-	"version": "1.0.0",
+	"url": [
+		"www.homestuck2.com", 
+		"homestuck2.com"
+	],
+	"version": "1.0.1",
 	"logo": "https://i.imgur.com/wYCAFtE.png",
 	"thumbnail": "https://i.imgur.com/bnnYvGO.png",
 	"color": "#f2a400",


### PR DESCRIPTION
## Description 
url metadata without `www.` fails to actually support `www.`, this change adds support for both.

## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
(Screenshot taken with `www.`)

![image](https://user-images.githubusercontent.com/38714062/181371332-6d3ff3c8-b81d-4f7e-9b74-1ce1067b1711.png)


</details>
