### PR TITLE
fix(Neovel): change presence's color

### DIFF
--- a/websites/N/Neovel/dist/metadata.json
+++ b/websites/N/Neovel/dist/metadata.json
@@ -18,10 +18,10 @@
 		"fr.neopload.neovel.io",
 		"es.neopload.neovel.io"
 	],
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"logo": "https://i.imgur.com/CYk2ZDX.jpg",
 	"thumbnail": "https://i.imgur.com/Ei5H8Zz.jpg",
-	"color": "#f576ab",
+	"color": "#041a26",
 	"category": "other",
 	"tags": [
 		"read",


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
I've forgot to change the color in the metadata file for this presence. So I've patched it.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![neovel_proof_1](https://user-images.githubusercontent.com/85577959/181778279-7e0f6865-ee4a-4c39-b400-4dd003e82021.PNG)

![neovel_proof_2](https://user-images.githubusercontent.com/85577959/181778266-c8e4c203-46f4-456c-a364-e82b04c880ed.PNG)



</details>
