### PR TITLE
feat(Facebook): add facebook watch logo

### DIFF
--- a/websites/F/Facebook/dist/metadata.json
+++ b/websites/F/Facebook/dist/metadata.json
@@ -22,7 +22,7 @@
 		"vi_VN": "Kết nối với bạn bè, người thân và những người khác bạn biết. Chia sẻ hình ảnh và video, gửi tin nhắn và nhận các thông báo."
 	},
 	"url": "www.facebook.com",
-	"version": "3.3.1",
+	"version": "3.4.0",
 	"logo": "https://i.imgur.com/nS9sZn6.png",
 	"thumbnail": "https://i.imgur.com/iftQq6r.jpg",
 	"color": "#4267B2",

--- a/websites/F/Facebook/dist/metadata.json
+++ b/websites/F/Facebook/dist/metadata.json
@@ -22,7 +22,7 @@
 		"vi_VN": "Kết nối với bạn bè, người thân và những người khác bạn biết. Chia sẻ hình ảnh và video, gửi tin nhắn và nhận các thông báo."
 	},
 	"url": "www.facebook.com",
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"logo": "https://i.imgur.com/nS9sZn6.png",
 	"thumbnail": "https://i.imgur.com/iftQq6r.jpg",
 	"color": "#4267B2",

--- a/websites/F/Facebook/presence.ts
+++ b/websites/F/Facebook/presence.ts
@@ -108,7 +108,7 @@ presence.on("UpdateData", async () => {
 	} else if (document.location.pathname.includes("/watch")) {
 		const search = new URLSearchParams(location.search).get("q"),
 			videoId = new URLSearchParams(location.search).get("v");
-
+		presenceData.largeImageKey = "https://i.imgur.com/FMIfiPA.png";
 		if (!videoId && !search) {
 			const videoFrame = Array.from(
 				document.querySelectorAll('div[class="l9j0dhe7"]')


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Resolves #6511 by adding an imgur url to the facebook watch logo to the `presenceData.largeImageKey` at the top of the part handling the Facebook watch part of the website.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![fb_proof_4](https://user-images.githubusercontent.com/85577959/181914611-20dfb6bc-7c7f-43a2-9a57-597e081e3c04.PNG)

![fb_proof_3](https://user-images.githubusercontent.com/85577959/181914618-d63de7b7-bde0-469d-93cf-6575deee7e67.PNG)

![fb_proof_2](https://user-images.githubusercontent.com/85577959/181914626-ed1cd276-3c37-4ba1-a803-6e2c4c723b34.PNG)

![fb_proof_1](https://user-images.githubusercontent.com/85577959/181914607-8f81acdf-172b-4e5b-90d1-5ea33016e6c4.PNG)



</details>
