### PR TITLE
fix(dod Games): add alternative fallback game detection

### DIFF
--- a/websites/D/dod Games/dist/metadata.json
+++ b/websites/D/dod Games/dist/metadata.json
@@ -10,7 +10,7 @@
 		"el_GR": "Το dod Games είναι ένα από τα πιο γνωστά site online παιχνιδιών και chatting στην Ελλάδα"
 	},
 	"url": "www.dod.gr",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"logo": "https://i.imgur.com/8on5V0y.png",
 	"thumbnail": "https://i.imgur.com/MqAAZAH.png",
 	"color": "#008fec",

--- a/websites/D/dod Games/dist/metadata.json
+++ b/websites/D/dod Games/dist/metadata.json
@@ -10,7 +10,7 @@
 		"el_GR": "Το dod Games είναι ένα από τα πιο γνωστά site online παιχνιδιών και chatting στην Ελλάδα"
 	},
 	"url": "www.dod.gr",
-	"version": "1.0.3",
+	"version": "1.1.0",
 	"logo": "https://i.imgur.com/8on5V0y.png",
 	"thumbnail": "https://i.imgur.com/MqAAZAH.png",
 	"color": "#008fec",

--- a/websites/D/dod Games/presence.ts
+++ b/websites/D/dod Games/presence.ts
@@ -53,9 +53,8 @@ presence.on("UpdateData", async () => {
 						}/${scores.length}`;
 					}
 				}
-				if (scores.length < 10 && roomURL) 
-					addJoinRoomButton(roomURL);
-				
+				if (scores.length < 10 && roomURL) addJoinRoomButton(roomURL);
+
 				presenceData.details = "Παίζει Ζωγράφισέ Το";
 				presenceData.startTimestamp = timeStarted;
 				break;
@@ -79,9 +78,8 @@ presence.on("UpdateData", async () => {
 						)}/${scores.length}`;
 					}
 				}
-				if (roomURL) 
-					addJoinRoomButton(roomURL);
-				
+				if (roomURL) addJoinRoomButton(roomURL);
+
 				presenceData.details = "Παίζει Κουίζ";
 				presenceData.startTimestamp = timeStarted;
 				break;
@@ -146,9 +144,7 @@ presence.on("UpdateData", async () => {
 					presenceData.state = `${
 						Object.keys(state).length
 					}/${nPlayers} παίκτες...`;
-					if (roomURL) 
-						addJoinRoomButton(roomURL);
-					
+					if (roomURL) addJoinRoomButton(roomURL);
 				}
 				presenceData.details = `Παίζει Αγωνία | 💪🏻 ${document
 					.querySelector(".mytr")
@@ -205,9 +201,7 @@ presence.on("UpdateData", async () => {
 					presenceData.state = `${
 						teamPlayers.length + opPlayers.length
 					}/4 παίκτες...`;
-					if (roomURL) 
-						addJoinRoomButton(roomURL);
-					
+					if (roomURL) addJoinRoomButton(roomURL);
 				}
 				presenceData.details = `Παίζει Tichu | 💪🏻 ${document
 					.querySelector(".mytr")

--- a/websites/D/dod Games/presence.ts
+++ b/websites/D/dod Games/presence.ts
@@ -12,225 +12,243 @@ presence.on("UpdateData", async () => {
 		playerName = document.querySelector(
 			"#component_top_right_loginasname_text"
 		).textContent,
-		urls = document.querySelectorAll("#topBarDownLink");
+		urls = document.querySelectorAll("#topBarDownLink"),
+		supportedGames: string[] = ["drawit", "quiz", "agonia", "tichu"];
 	let openRooms = 0;
+
+	function addJoinRoomButton(roomURL: string) {
+		presenceData.buttons = [
+			{
+				label: "Είσοδος",
+				url: roomURL,
+			},
+		];
+	}
+
+	function parseGameData(game: string, roomURL?: string) {
+		if (!isInGame) {
+			timeStarted = Date.now();
+			isInGame = true;
+		}
+
+		switch (game) {
+			case "drawit": {
+				const scores = document.querySelectorAll("#playersContainer .player");
+				for (let i = 0; i < scores.length; i++) {
+					if (scores[i].querySelector(".name").textContent === playerName) {
+						if (
+							document.querySelector<HTMLDivElement>("#drawtools").style
+								.display !== "none"
+						) {
+							presenceData.smallImageKey = "molivaki";
+							presenceData.smallImageText = "Ζωγραφίζει";
+						}
+
+						presenceData.state = `Σκορ: ${
+							scores[i].querySelector(".score").textContent
+						} | Γύρος: ${document
+							.querySelector("#round b")
+							.textContent.replaceAll(" ", "")} | Θέση #${
+							parseInt(scores[i].getAttribute("index")) + 1
+						}/${scores.length}`;
+					}
+				}
+				if (scores.length < 10 && roomURL) 
+					addJoinRoomButton(roomURL);
+				
+				presenceData.details = "Παίζει Ζωγράφισέ Το";
+				presenceData.startTimestamp = timeStarted;
+				break;
+			}
+
+			case "quiz": {
+				const scores = document.querySelectorAll(
+					"#playersContainer .numberAndPlayerContainer"
+				);
+				for (let i = 0; i < scores.length; i++) {
+					if (
+						scores[i].querySelector(".quiz_playerName").textContent ===
+						playerName
+					) {
+						presenceData.state = `Σκορ: ${
+							scores[i].querySelector(".quiz_playerPoints").textContent
+						} | Γύρος: ${
+							parseInt(document.querySelector("#countRound").textContent) || "–"
+						} | Θέση #${parseInt(
+							scores[i].querySelector(".quiz_playerNumber").textContent
+						)}/${scores.length}`;
+					}
+				}
+				if (roomURL) 
+					addJoinRoomButton(roomURL);
+				
+				presenceData.details = "Παίζει Κουίζ";
+				presenceData.startTimestamp = timeStarted;
+				break;
+			}
+
+			case "agonia": {
+				const nPlayers = parseInt(
+						document.querySelector("#agonia_content").className.match(/\d+/g)[0]
+					),
+					playerClassNames = [
+						"agonia_player1",
+						"agonia_player2",
+						"agonia_player3",
+						"agonia_player4",
+					],
+					state: { [key: string]: AgoniaPlayerState } = {};
+				for (const playerClassName of playerClassNames) {
+					const player = document.querySelector(`#${playerClassName}`);
+					if (player) {
+						const playerName = player.querySelector(".gnh_name").textContent;
+						if (playerName) {
+							state[playerName] = {
+								score: player.querySelector(".gnh_score_text").textContent,
+								winner: false,
+							};
+						}
+					}
+				}
+
+				const gameOverVisible =
+					document.querySelector("#gameover_content").parentElement.style
+						.display !== "none";
+				if (gameOverVisible) {
+					const gameOverClassNames = [
+						"gameover_user1",
+						"gameover_user2",
+						"gameover_user3",
+						"gameover_user4",
+					];
+					for (const gameOverClassName of gameOverClassNames) {
+						const player = document.querySelector(`#${gameOverClassName}`);
+						if (
+							player &&
+							player.querySelector<HTMLDivElement>(".gameover_userphotowin")
+								.style.display !== "none"
+						) {
+							const winnerName = player.getAttribute("shownname");
+							if (winnerName in state) state[winnerName].winner = true;
+						}
+					}
+				}
+				let stateString = "";
+				for (const key in state) {
+					const value = state[key];
+					stateString += `${value.winner ? " 🏆 " : ""}${key}: ${
+						value.score
+					} – `;
+				}
+				if (Object.keys(state).length === nPlayers || gameOverVisible)
+					presenceData.state = stateString.substring(0, stateString.length - 3);
+				else {
+					presenceData.state = `${
+						Object.keys(state).length
+					}/${nPlayers} παίκτες...`;
+					if (roomURL) 
+						addJoinRoomButton(roomURL);
+					
+				}
+				presenceData.details = `Παίζει Αγωνία | 💪🏻 ${document
+					.querySelector(".mytr")
+					.getAttribute("elo")}`;
+				presenceData.startTimestamp = timeStarted;
+				break;
+			}
+
+			case "tichu": {
+				const playerPositions = ["bottom", "up", "right", "left"],
+					teamPlayers: string[] = [],
+					opPlayers: string[] = [],
+					playerState: { [key: string]: TichuPlayerState } = {};
+				for (const playerPos of playerPositions) {
+					const playerName = document.querySelector(
+						`#nickholder_${playerPos} .playerName`
+					).textContent;
+					if (playerName)
+						playerState[playerPos] = { name: playerName, bet: null };
+				}
+
+				for (const pos of ["up", "left", "right"]) {
+					if (!(pos in playerState)) continue;
+					const betElement = document.querySelector<HTMLDivElement>(
+						`#nickholder_${pos} #tichugrand`
+					);
+					if (betElement.style.display !== "none")
+						playerState[pos].bet = betElement.className;
+				}
+
+				let betElement =
+					document.querySelector<HTMLDivElement>("#btnTichuToggle");
+				if (betElement.style.display !== "none") playerState.bot.bet = "tichu";
+
+				betElement = document.querySelector<HTMLDivElement>("#btnGrandToggle");
+				if (betElement.style.display !== "none") playerState.bot.bet = "grand";
+
+				for (const pos in playerState) {
+					const player = playerState[pos];
+					(["bottom", "up"].includes(pos) ? teamPlayers : opPlayers).push(
+						`${
+							player.bet === "tichu" ? "🟠" : player.bet === "grand" ? "🔴" : ""
+						}${player.name}`
+					);
+				}
+
+				if (teamPlayers.length === 2 && opPlayers.length === 2) {
+					presenceData.state = `(${teamPlayers[0]}, ${teamPlayers[1]}) ${
+						document.querySelector("#txtMyTeamScore").textContent
+					} – ${document.querySelector("#txtOpTeamScore").textContent} (${
+						opPlayers[0]
+					}, ${opPlayers[1]})`;
+				} else {
+					presenceData.state = `${
+						teamPlayers.length + opPlayers.length
+					}/4 παίκτες...`;
+					if (roomURL) 
+						addJoinRoomButton(roomURL);
+					
+				}
+				presenceData.details = `Παίζει Tichu | 💪🏻 ${document
+					.querySelector(".mytr")
+					.getAttribute("elo")}`;
+				presenceData.startTimestamp = timeStarted;
+				break;
+			}
+		}
+	}
 
 	for (const url of urls) {
 		if (url.textContent.includes("&room=")) openRooms++;
 
-		// Draw It
-		if (url.textContent.includes("game=drawit&room=")) {
-			if (!isInGame) {
-				timeStarted = Date.now();
-				isInGame = true;
-			}
-
-			const scores = document.querySelectorAll("#playersContainer .player");
-			for (let i = 0; i < scores.length; i++) {
-				if (scores[i].querySelector(".name").textContent === playerName) {
-					if (
-						document.querySelector<HTMLDivElement>("#drawtools").style
-							.display !== "none"
-					) {
-						presenceData.smallImageKey = "molivaki";
-						presenceData.smallImageText = "Ζωγραφίζει";
-					}
-
-					presenceData.state = `Σκορ: ${
-						scores[i].querySelector(".score").textContent
-					} | Γύρος: ${document
-						.querySelector("#round b")
-						.textContent.replaceAll(" ", "")} | Θέση #${
-						parseInt(scores[i].getAttribute("index")) + 1
-					}/${scores.length}`;
-				}
-			}
-			if (scores.length < 10) {
-				presenceData.buttons = [
-					{
-						label: "Είσοδος",
-						url: url.textContent,
-					},
-				];
-			}
-			presenceData.details = "Παίζει Ζωγράφισέ Το";
-			presenceData.startTimestamp = timeStarted;
-			break;
-		} else if (url.textContent.includes("game=quiz&room=")) {
-			// Quiz
-			if (!isInGame) {
-				timeStarted = Date.now();
-				isInGame = true;
-			}
-			presenceData.buttons = [
-				{
-					label: "Είσοδος",
-					url: url.textContent,
-				},
-			];
-
-			const scores = document.querySelectorAll(
-				"#playersContainer .numberAndPlayerContainer"
-			);
-			for (let i = 0; i < scores.length; i++) {
-				if (
-					scores[i].querySelector(".quiz_playerName").textContent === playerName
-				) {
-					presenceData.state = `Σκορ: ${
-						scores[i].querySelector(".quiz_playerPoints").textContent
-					} | Γύρος: ${
-						parseInt(document.querySelector("#countRound").textContent) || "–"
-					} | Θέση #${parseInt(
-						scores[i].querySelector(".quiz_playerNumber").textContent
-					)}/${scores.length}`;
-				}
-			}
-			presenceData.details = "Παίζει Κουίζ";
-			presenceData.startTimestamp = timeStarted;
-			break;
-		} else if (url.textContent.includes("game=agonia&room=")) {
-			// Αγωνία
-			const nPlayers = parseInt(
-				document.querySelector("#agonia_content").className.match(/\d+/g)[0]
-			);
-			if (!isInGame) {
-				timeStarted = Date.now();
-				isInGame = true;
-			}
-
-			const playerClassNames = [
-					"agonia_player1",
-					"agonia_player2",
-					"agonia_player3",
-					"agonia_player4",
-				],
-				state: { [key: string]: AgoniaPlayerState } = {};
-			for (const playerClassName of playerClassNames) {
-				const player = document.querySelector(`#${playerClassName}`);
-				if (player) {
-					const playerName = player.querySelector(".gnh_name").textContent;
-					if (playerName) {
-						state[playerName] = {
-							score: player.querySelector(".gnh_score_text").textContent,
-							winner: false,
-						};
-					}
-				}
-			}
-
-			const gameOverVisible =
-				document.querySelector("#gameover_content").parentElement.style
-					.display !== "none";
-			if (gameOverVisible) {
-				const gameOverClassNames = [
-					"gameover_user1",
-					"gameover_user2",
-					"gameover_user3",
-					"gameover_user4",
-				];
-				for (const gameOverClassName of gameOverClassNames) {
-					const player = document.querySelector(`#${gameOverClassName}`);
-					if (
-						player &&
-						player.querySelector<HTMLDivElement>(".gameover_userphotowin").style
-							.display !== "none"
-					) {
-						const winnerName = player.getAttribute("shownname");
-						if (winnerName in state) state[winnerName].winner = true;
-					}
-				}
-			}
-			let stateString = "";
-			for (const key in state) {
-				const value = state[key];
-				stateString += `${value.winner ? " 🏆 " : ""}${key}: ${value.score} – `;
-			}
-			if (Object.keys(state).length === nPlayers || gameOverVisible)
-				presenceData.state = stateString.substring(0, stateString.length - 3);
-			else {
-				presenceData.state = `${
-					Object.keys(state).length
-				}/${nPlayers} παίκτες...`;
-				presenceData.buttons = [
-					{
-						label: "Είσοδος",
-						url: url.textContent,
-					},
-				];
-			}
-			presenceData.details = `Παίζει Αγωνία | 💪🏻 ${document
-				.querySelector(".mytr")
-				.getAttribute("elo")}`;
-			presenceData.startTimestamp = timeStarted;
-			break;
-		} else if (url.textContent.includes("game=tichu&room=")) {
-			// Tichu
-			if (!isInGame) {
-				timeStarted = Date.now();
-				isInGame = true;
-			}
-
-			const playerPositions = ["bottom", "up", "right", "left"],
-				teamPlayers: string[] = [],
-				opPlayers: string[] = [],
-				playerState: { [key: string]: TichuPlayerState } = {};
-			for (const playerPos of playerPositions) {
-				const playerName = document.querySelector(
-					`#nickholder_${playerPos} .playerName`
-				).textContent;
-				if (playerName)
-					playerState[playerPos] = { name: playerName, bet: null };
-			}
-
-			for (const pos of ["up", "left", "right"]) {
-				if (!(pos in playerState)) continue;
-				const betElement = document.querySelector<HTMLDivElement>(
-					`#nickholder_${pos} #tichugrand`
-				);
-				if (betElement.style.display !== "none")
-					playerState[pos].bet = betElement.className;
-			}
-
-			let betElement =
-				document.querySelector<HTMLDivElement>("#btnTichuToggle");
-			if (betElement.style.display !== "none") playerState.bot.bet = "tichu";
-
-			betElement = document.querySelector<HTMLDivElement>("#btnGrandToggle");
-			if (betElement.style.display !== "none") playerState.bot.bet = "grand";
-
-			for (const pos in playerState) {
-				const player = playerState[pos];
-				(["bottom", "up"].includes(pos) ? teamPlayers : opPlayers).push(
-					`${
-						player.bet === "tichu" ? "🟠" : player.bet === "grand" ? "🔴" : ""
-					}${player.name}`
-				);
-			}
-
-			if (teamPlayers.length === 2 && opPlayers.length === 2) {
-				presenceData.state = `(${teamPlayers[0]}, ${teamPlayers[1]}) ${
-					document.querySelector("#txtMyTeamScore").textContent
-				} – ${document.querySelector("#txtOpTeamScore").textContent} (${
-					opPlayers[0]
-				}, ${opPlayers[1]})`;
-			} else {
-				presenceData.state = `${
-					teamPlayers.length + opPlayers.length
-				}/4 παίκτες...`;
-				presenceData.buttons = [
-					{
-						label: "Είσοδος",
-						url: url.textContent,
-					},
-				];
-			}
-			presenceData.details = `Παίζει Tichu | 💪🏻 ${document
-				.querySelector(".mytr")
-				.getAttribute("elo")}`;
-			presenceData.startTimestamp = timeStarted;
-			break;
+		for (const game of supportedGames) {
+			if (url.textContent.includes(`game=${game}&room=`))
+				parseGameData(game, url.textContent);
 		}
 	}
+
+	if (!openRooms) {
+		const lobbyTabs = document.querySelectorAll(
+			"#windowLobbyTab2.windowLobbyTabSelected > .windowTabText > .dodlangspan"
+		);
+
+		for (const tab of lobbyTabs) {
+			if (tab.textContent.includes("Ζωγράφισε")) {
+				openRooms++;
+				parseGameData("drawit");
+			} else if (tab.textContent.includes("Κουίζ")) {
+				openRooms++;
+				parseGameData("quiz");
+			} else if (tab.textContent.includes("Αγωνία")) {
+				openRooms++;
+				parseGameData("agonia");
+			} else if (tab.textContent.includes("Tichu")) {
+				openRooms++;
+				parseGameData("tichu");
+			}
+		}
+	}
+
 	if (!openRooms) isInGame = false;
 	if (isInGame) presence.setActivity(presenceData);
 	else presence.setActivity();


### PR DESCRIPTION
## Description
In some cases (when browser window height is low and another case I could not reproduce) the site's "pseudo-URLs" are not showing, so the presence fails to detect open game rooms. I added a fallback game detection method that doesn't rely on URLs to catch those cases.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://user-images.githubusercontent.com/16375254/182023131-91cdc841-6953-4d75-9326-53bc63e46d8c.png)

</details>
