### PR TITLE
feat(Coub): buttons, regex, external largeImageKey, elapsed timestamp

### DIFF
--- a/websites/C/Coub/dist/metadata.json
+++ b/websites/C/Coub/dist/metadata.json
@@ -43,13 +43,13 @@
 		},
 		{
 			"id": "show_externalLargeImage",
-			"title": "Show community/channel images",
+			"title": "Show Thumbnails (community/channel images)",
 			"icon": "fas fa-image",
 			"value": true
 		},
 		{
 			"id": "show_startedBrowsing",
-			"title": "Show elapsed time",
+			"title": "Show Elapsed Time",
 			"icon": "fas fa-stopwatch",
 			"value": true
 		}

--- a/websites/C/Coub/dist/metadata.json
+++ b/websites/C/Coub/dist/metadata.json
@@ -19,7 +19,7 @@
 		"vi_VN": "Coub là trang web chia sẻ video trực tuyến. Nó cho phép người dùng tạo và chia sẻ video lặp lại lên tới mười giây, sử dụng các video có sẵn tại YouTube, Vimeo, hoặc tệp riêng của họ"
 	},
 	"url": "coub.com",
-	"version": "2.0.16",
+	"version": "2.1.0",
 	"logo": "https://i.imgur.com/HRAGMzw.png",
 	"thumbnail": "https://i.imgur.com/8P8RhcZ.png",
 	"color": "#0084FF",

--- a/websites/C/Coub/dist/metadata.json
+++ b/websites/C/Coub/dist/metadata.json
@@ -40,6 +40,18 @@
 			"title": "Show current playing button",
 			"icon": "fas fa-external-link-alt",
 			"value": true
+		},
+		{
+			"id": "show_externalLargeImage",
+			"title": "Show community/channel images",
+			"icon": "fas fa-image",
+			"value": true
+		},
+		{
+			"id": "show_startedBrowsing",
+			"title": "Show elapsed time",
+			"icon": "fas fa-stopwatch",
+			"value": true
 		}
 	]
 }

--- a/websites/C/Coub/dist/metadata.json
+++ b/websites/C/Coub/dist/metadata.json
@@ -19,7 +19,7 @@
 		"vi_VN": "Coub là trang web chia sẻ video trực tuyến. Nó cho phép người dùng tạo và chia sẻ video lặp lại lên tới mười giây, sử dụng các video có sẵn tại YouTube, Vimeo, hoặc tệp riêng của họ"
 	},
 	"url": "coub.com",
-	"version": "2.0.15",
+	"version": "2.0.16",
 	"logo": "https://i.imgur.com/HRAGMzw.png",
 	"thumbnail": "https://i.imgur.com/8P8RhcZ.png",
 	"color": "#0084FF",

--- a/websites/C/Coub/presence.ts
+++ b/websites/C/Coub/presence.ts
@@ -9,6 +9,7 @@ interface PageContext {
 }
 interface ExecutionArguments {
 	showWatch?: boolean;
+	showExternalImages?: boolean;
 	strings: LocalizedStrings;
 	images: { [key: string]: string };
 	[key: string]: unknown;
@@ -28,24 +29,12 @@ function getQuery() {
 function capitalizeFirstLetter(string: string) {
 	return string.charAt(0).toUpperCase() + string.slice(1);
 }
-const youtubeUrlRegex =
-	/^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(\/(?:[\w-]+\?v=|embed\/|v\/)?)([\w-]+)(\S+)?$/gm;
-function getSourceLink(url: string): ButtonData | null {
-	if (!url) return null;
-	if (youtubeUrlRegex.test(url)) {
-		return {
-			label: "Watch Youtube Source",
-			url,
-		};
-	}
-	return null;
-}
 const pages: PageContext[] = [
 		{
 			middleware: ref =>
-				/^\/?(hot|tags|rising|fresh|feed|rising|stories|random|bookmarks|likes|weekly|best|stories|royal\.coubs|\/)/gi.test(
+				/^\/(hot|tags|rising|fresh|feed|rising|stories|random|bookmarks|likes|weekly|best|stories|royal\.coubs|\/)/gi.test(
 					ref.location.pathname
-				),
+				) || location.pathname === "/",
 			exec: (
 				context,
 				data,
@@ -114,11 +103,6 @@ const pages: PageContext[] = [
 							label: strings.watchVideo,
 							url: `${document.location.origin}/view/${activeMedia.dataset.permalink}`,
 						},
-						getSourceLink(
-							activeMedia.querySelector<HTMLAnchorElement>(
-								".description__stamp a.description__stamp__source"
-							)?.href
-						),
 					];
 				}
 				return data;
@@ -130,7 +114,7 @@ const pages: PageContext[] = [
 			exec: (
 				context,
 				data,
-				{ showWatch, strings, images }: ExecutionArguments
+				{ showWatch, showExternalImages, strings, images }: ExecutionArguments
 			) => {
 				if (!context) return null;
 				const activeMedia = document.querySelector<HTMLElement>(
@@ -140,9 +124,13 @@ const pages: PageContext[] = [
 				const title = activeMedia
 						.querySelector(".description__title")
 						.textContent?.trim(),
-					userName = document.querySelector<HTMLHeadingElement>(
+					channelParent = document.querySelector<HTMLDivElement>(".channel"),
+					userName = channelParent.querySelector<HTMLHeadingElement>(
 						".channel__description > h1[title]"
 					).title,
+					userImage = channelParent.querySelector<HTMLImageElement>(
+						'.avatar-upload img[src*="coub_storage/channel"]'
+					)?.src,
 					activeTab =
 						document.querySelector<HTMLElement>(
 							".page__content .page-menu > .page-menu__inner > .page-menu__item.-active"
@@ -167,6 +155,8 @@ const pages: PageContext[] = [
 						? " (❤)"
 						: ""
 				}`;
+				if (showExternalImages && userImage?.startsWith("https://"))
+					data.largeImageKey = userImage;
 				data.smallImageKey =
 					activeMedia.querySelector("video")?.paused === false
 						? images.PLAY
@@ -223,11 +213,6 @@ const pages: PageContext[] = [
 							label: strings.watchVideo,
 							url: document.location.href,
 						},
-						getSourceLink(
-							activeMedia.parentElement.querySelector<HTMLAnchorElement>(
-								'.coub__info .media-block__item > a[type="embedPopup"]'
-							)?.href
-						),
 					];
 				}
 				return data;
@@ -238,7 +223,7 @@ const pages: PageContext[] = [
 			exec: (
 				context,
 				data,
-				{ showWatch, strings, images }: ExecutionArguments
+				{ showWatch, showExternalImages, strings, images }: ExecutionArguments
 			) => {
 				if (!context) return null;
 				const communityParent = document.querySelector(
@@ -250,6 +235,9 @@ const pages: PageContext[] = [
 				const communityTitle = communityParent
 						.querySelector(".description > .title > h2")
 						?.textContent?.trim(),
+					communityImage = communityParent.querySelector<HTMLImageElement>(
+						'img[src*="coub_storage/category"]'
+					)?.src,
 					title = activeMedia
 						.querySelector(".description__title")
 						?.textContent?.trim();
@@ -260,6 +248,8 @@ const pages: PageContext[] = [
 						".page-menu.hot__menu > .page-menu__inner > .page-menu__item.-active"
 					)?.dataset?.title || "Hot"
 				}`;
+				if (showExternalImages && communityImage?.startsWith("https://"))
+					data.largeImageKey = communityImage;
 				data.smallImageKey =
 					activeMedia.querySelector("video")?.paused === false
 						? images.PLAY
@@ -271,11 +261,6 @@ const pages: PageContext[] = [
 							label: strings.watchVideo,
 							url: `${document.location.origin}/view/${activeMedia.dataset.permalink}`,
 						},
-						getSourceLink(
-							activeMedia.querySelector<HTMLAnchorElement>(
-								".description__stamp a.description__stamp__source"
-							)?.href
-						),
 					];
 				}
 
@@ -313,6 +298,7 @@ function getStrings(newLang?: string) {
 }
 let currentLang: string,
 	localizedStrings: Awaited<ReturnType<typeof getStrings>>;
+const startedBrowsingAt = new Date();
 presence.on("UpdateData", async () => {
 	const newLang = await presence.getSetting<string>("lang").catch(() => "en");
 	if (!localizedStrings || newLang !== currentLang) {
@@ -322,26 +308,33 @@ presence.on("UpdateData", async () => {
 	const query: { [key: string]: unknown } = getQuery(),
 		context = pages.find(x => x.middleware(window, [query]));
 	if (!context) return;
+	const data: PresenceData = {
+			largeImageKey: "logo",
+		},
+		showStartedBrowsing = await presence
+			.getSetting<boolean>("show_startedBrowsing")
+			.catch(() => true);
+
+	if (showStartedBrowsing && !data.startTimestamp)
+		data.startTimestamp = startedBrowsingAt.getTime();
 
 	const result = await Promise.resolve(
-		context.exec(
-			presence,
-			{
-				largeImageKey: "logo",
-			},
-			{
-				strings: localizedStrings,
-				query,
-				images: presenceImageKeys,
-				showWatch: await presence
-					.getSetting<boolean>("show_button_watching")
-					.catch(() => true),
-			}
-		)
+		context.exec(presence, data, {
+			strings: localizedStrings,
+			query,
+			images: presenceImageKeys,
+			showWatch: await presence
+				.getSetting<boolean>("show_button_watching")
+				.catch(() => true),
+			showExternalImages: await presence
+				.getSetting<boolean>("show_externalLargeImage")
+				.catch(() => true),
+			showStartedBrowsing,
+		})
 	);
 	if (!result) {
 		presence.setActivity({
-			largeImageKey: "logo",
+			...data,
 			state: localizedStrings.browsing,
 		});
 	} else if (result.details) presence.setActivity(result);


### PR DESCRIPTION
## Description 
- Fixed top page regex + presence data (null in buttons array wont display presence).
- Added largeImageKeys images (toggleable in settings) for coub channels & communities
- Added Elapsed timestamp (toggleable in settings)
- Removed youtube source buttons

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

New Settings (Show community/channel images & Show elapsed time):
![image](https://user-images.githubusercontent.com/17952364/182041338-a871ff76-17c5-4a18-be5c-9beee3ac4a97.png)

Community Images:
![image](https://user-images.githubusercontent.com/17952364/182041311-ff0dd010-fe26-4a60-bd90-098d8a0ed379.png)

Channel Images:
![image](https://user-images.githubusercontent.com/17952364/182041329-f6f36f19-3d79-4022-ad7d-a9a314bf25ab.png)

Playing Media:
![image](https://user-images.githubusercontent.com/17952364/182041471-2ff6dc99-153b-49e0-b9f2-8b30e6925e49.png)


</details>
