### PR TITLE
feat(TruckersMP): buttons shouldn't show if privacy mode is enabled

### DIFF
--- a/websites/T/TruckersMP/dist/metadata.json
+++ b/websites/T/TruckersMP/dist/metadata.json
@@ -21,7 +21,7 @@
 		"stats.truckersmp.com",
 		"map.truckersmp.com"
 	],
-	"version": "3.0.6",
+	"version": "3.0.7",
 	"logo": "https://i.imgur.com/ptddTU8.png",
 	"thumbnail": "https://i.imgur.com/Z8CxsNw.png",
 	"color": "#B92025",
@@ -35,22 +35,25 @@
 	],
 	"settings": [
 		{
+			"id": "privacy",
+			"title": "Privacy Mode",
+			"icon": "fad fa-user-secret",
+			"value": false
+		},
+		{
 			"id": "buttons",
+			"if": {
+				"privacy": false
+			},
 			"title": "Show Buttons",
 			"icon": "fas fa-compress-arrows-alt",
 			"value": true
 		},
 		{
 			"id": "timestamp",
-			"title": "Show timestamps",
+			"title": "Show Timestamps",
 			"icon": "fad fa-stopwatch",
 			"value": true
-		},
-		{
-			"id": "privacy",
-			"title": "Privacy Mode",
-			"icon": "fad fa-user-secret",
-			"value": false
 		}
 	]
 }

--- a/websites/T/TruckersMP/presence.ts
+++ b/websites/T/TruckersMP/presence.ts
@@ -103,7 +103,7 @@ presence.on("UpdateData", async () => {
 					presenceData.buttons = [{ label: "View Topic", url: document.URL }];
 					break;
 				case document.location.pathname.includes("/forum"):
-					presenceData.details = "Browing the forum";
+					presenceData.details = "Browsing the forum";
 					presenceData.state =
 						document.querySelector<HTMLHeadingElement>(
 							"header > h1"


### PR DESCRIPTION
## Description 
- Fixed spelling for "Browsing"
- Fixed buttons displaying when privacy mode is enabled

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)