### PR TITLE
feat(AniMixPlay): add cover when viewing episode and anime info

### DIFF
--- a/websites/A/AniMixPlay/dist/metadata.json
+++ b/websites/A/AniMixPlay/dist/metadata.json
@@ -12,7 +12,7 @@
 		"vi_VN": "AniMixPlay là trang web giúp bạn xem Anime khắp thể giới, hoàn toàn miễn phí."
 	},
 	"url": "animixplay.to",
-	"version": "1.0.18",
+	"version": "1.1.0",
 	"logo": "https://i.imgur.com/eMXyO0Y.png",
 	"thumbnail": "https://i.imgur.com/XcEtF5e.png",
 	"color": "#3AACE7",
@@ -22,5 +22,13 @@
 		"animixplay",
 		"videos"
 	],
-	"iframe": true
+	"iframe": true,
+	"settings": [
+		{
+		"id": "cover",
+		"title": "Show Cover",
+		"icon": "fad fa-images",
+		"value": true
+	}
+]
 }

--- a/websites/A/AniMixPlay/dist/metadata.json
+++ b/websites/A/AniMixPlay/dist/metadata.json
@@ -25,10 +25,10 @@
 	"iframe": true,
 	"settings": [
 		{
-		"id": "cover",
-		"title": "Show Cover",
-		"icon": "fad fa-images",
-		"value": true
-	}
-]
+			"id": "cover",
+			"title": "Show Cover",
+			"icon": "fad fa-images",
+			"value": true
+		}
+	]
 }

--- a/websites/A/AniMixPlay/presence.ts
+++ b/websites/A/AniMixPlay/presence.ts
@@ -83,7 +83,6 @@ presence.on("UpdateData", async () => {
 				Math.floor(duration)
 			);
 		}
-
 		if (!isNaN(duration)) {
 			presenceData.smallImageKey = paused ? "pause-v1" : "play-v1";
 			presenceData.smallImageText = paused
@@ -93,6 +92,11 @@ presence.on("UpdateData", async () => {
 			presenceData.details = document.querySelector(
 				"#aligncenter > span.animetitle"
 			).textContent;
+			if (showCover) {
+				presenceData.largeImageKey = document
+					.querySelector('meta[property="og:image"]')
+					.getAttribute("content");
+			}
 			presenceData.state = `Episode ${document
 				.querySelector("#eptitle > span#eptitleplace")
 				.textContent.replace(/\D/g, "")}`;

--- a/websites/A/AniMixPlay/presence.ts
+++ b/websites/A/AniMixPlay/presence.ts
@@ -34,9 +34,10 @@ presence.on(
 
 presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
-		largeImageKey: "logo-v2",
-		startTimestamp: browsingTimestamp,
-	};
+			largeImageKey: "logo-v2",
+			startTimestamp: browsingTimestamp,
+		},
+		showCover = await presence.getSetting<boolean>("cover");
 
 	if (location.pathname === "/") {
 		const urlParams = new URLSearchParams(window.location.search);
@@ -112,6 +113,11 @@ presence.on("UpdateData", async () => {
 		presenceData.state = `${
 			document.querySelector("#animepagetitle").textContent
 		} (${document.querySelector("#addInfo").textContent.split(" ")[5].trim()})`;
+		if (showCover) {
+			presenceData.largeImageKey = document
+				.querySelector("#maincoverimage")
+				.getAttribute("src");
+		}
 		presenceData.smallImageKey = "reading-v1";
 		presenceData.smallImageText = "Reading...";
 	}


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Resolves #6585 by adding the cover of the anime when you're on the anime informations page.
~~Sadly, it can't be done for when you're watching an episode since the cover isn't displayed on the episode page.~~ *Finally done by getting it in the metadata of the page.*
I've also added a setting to let the user choose if he want to show the cover or not.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![animixplay_proof_2](https://user-images.githubusercontent.com/85577959/182495710-2a5268a2-bad7-484a-90f5-d8c71f220be7.PNG)

![animixplay_proof_1](https://user-images.githubusercontent.com/85577959/182495723-88d65475-8b21-439e-8993-c766ed6e11a6.PNG)

![animixplay_proof_3](https://user-images.githubusercontent.com/85577959/182495731-033d803e-a589-43f5-81a8-9ab0b6305c4c.PNG)



</details>
