### PR TITLE
feat(Facebook): add user's page displaying

### DIFF
--- a/websites/F/Facebook/dist/metadata.json
+++ b/websites/F/Facebook/dist/metadata.json
@@ -22,7 +22,7 @@
 		"vi_VN": "Kết nối với bạn bè, người thân và những người khác bạn biết. Chia sẻ hình ảnh và video, gửi tin nhắn và nhận các thông báo."
 	},
 	"url": "www.facebook.com",
-	"version": "3.4.1",
+	"version": "3.5.0",
 	"logo": "https://i.imgur.com/nS9sZn6.png",
 	"thumbnail": "https://i.imgur.com/iftQq6r.jpg",
 	"color": "#4267B2",

--- a/websites/F/Facebook/presence.ts
+++ b/websites/F/Facebook/presence.ts
@@ -109,7 +109,7 @@ presence.on("UpdateData", async () => {
 		const search = new URLSearchParams(location.search).get("q"),
 			videoId = new URLSearchParams(location.search).get("v");
 		presenceData.largeImageKey = "https://i.imgur.com/FMIfiPA.png";
-		if (!videoId && !search) {
+		if (!videoId && !search && document.location.href.includes("?v=")) {
 			const videoFrame = Array.from(
 				document.querySelectorAll('div[class="l9j0dhe7"]')
 			).find(
@@ -130,7 +130,7 @@ presence.on("UpdateData", async () => {
 						isLive ? "live" : "video"
 					}`;
 				} else if (isLive) {
-					presenceData.details = "Wattch - Watching a live:";
+					presenceData.details = "Watch - Watching a live:";
 					presenceData.state = description || user;
 
 					presenceData.smallImageKey = "live";
@@ -173,6 +173,15 @@ presence.on("UpdateData", async () => {
 		} else if (search && !privacyMode) {
 			presenceData.details = "Watch - Searching for:";
 			presenceData.state = showSeachQuery ? decodeURI(search) : "(Hidden)";
+		} else if (privacyMode)
+			presenceData.details = "Watch - Viewing an user's page";
+		else {
+			presenceData.details = `Watch - Viewing ${
+				document.querySelector('span > a[role="link"] > span').textContent
+			}'s page`;
+			presenceData.buttons = [
+				{ label: "View User", url: document.location.href },
+			];
 		}
 	} else if (document.location.pathname.includes("/marketplace/")) {
 		presenceData.startTimestamp = browsingTimestamp;

--- a/websites/F/Facebook/presence.ts
+++ b/websites/F/Facebook/presence.ts
@@ -174,7 +174,7 @@ presence.on("UpdateData", async () => {
 			presenceData.details = "Watch - Searching for:";
 			presenceData.state = showSeachQuery ? decodeURI(search) : "(Hidden)";
 		} else if (privacyMode)
-			presenceData.details = "Watch - Viewing an user's page";
+			presenceData.details = "Watch - Viewing a user's page";
 		else {
 			presenceData.details = "Watch";
 			presenceData.state = `Viewing ${

--- a/websites/F/Facebook/presence.ts
+++ b/websites/F/Facebook/presence.ts
@@ -179,7 +179,7 @@ presence.on("UpdateData", async () => {
 			presenceData.details = "Watch";
 			presenceData.state = `Viewing ${
 				document.querySelector('span > a[role="link"] > span').textContent
-			}'s page`
+			}'s page`;
 			presenceData.buttons = [
 				{ label: "View User", url: document.location.href },
 			];

--- a/websites/F/Facebook/presence.ts
+++ b/websites/F/Facebook/presence.ts
@@ -176,9 +176,10 @@ presence.on("UpdateData", async () => {
 		} else if (privacyMode)
 			presenceData.details = "Watch - Viewing an user's page";
 		else {
-			presenceData.details = `Watch - Viewing ${
+			presenceData.details = "Watch";
+			presenceData.state = `Viewing ${
 				document.querySelector('span > a[role="link"] > span').textContent
-			}'s page`;
+			}'s page`
 			presenceData.buttons = [
 				{ label: "View User", url: document.location.href },
 			];


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Resolves #6588 by adding the case of when the user is on an FB watch user's page.
Also, a little grammatical correction, a "Watch" was written "Wattch" lol.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![fb_proof_1](https://user-images.githubusercontent.com/85577959/182590543-e89f877e-ba8f-4ee2-9d25-d941418dbfd3.PNG)

![fb_proof_2](https://user-images.githubusercontent.com/85577959/182590610-db3eee49-b40a-499c-8496-55e2581ba58f.PNG)

![fb_proof_3](https://user-images.githubusercontent.com/85577959/182590583-54f454b3-00ea-4618-96e8-86fbf7db20ae.PNG)


</details>
