### PR TITLE
feat(Facebook): add reels support and fix bad display

### DIFF
--- a/websites/F/Facebook/dist/metadata.json
+++ b/websites/F/Facebook/dist/metadata.json
@@ -22,7 +22,7 @@
 		"vi_VN": "Kết nối với bạn bè, người thân và những người khác bạn biết. Chia sẻ hình ảnh và video, gửi tin nhắn và nhận các thông báo."
 	},
 	"url": "www.facebook.com",
-	"version": "3.5.0",
+	"version": "3.6.0",
 	"logo": "https://i.imgur.com/nS9sZn6.png",
 	"thumbnail": "https://i.imgur.com/iftQq6r.jpg",
 	"color": "#4267B2",

--- a/websites/F/Facebook/presence.ts
+++ b/websites/F/Facebook/presence.ts
@@ -177,12 +177,21 @@ presence.on("UpdateData", async () => {
 			presenceData.details = "Watch - Viewing a user's page";
 		else {
 			presenceData.details = "Watch";
-			presenceData.state = `Viewing ${
-				document.querySelector('span > a[role="link"] > span').textContent
-			}'s page`;
+			const queryUserName =
+				document.querySelector("h2 > span.d2edcug0.hzawbc8m > span") ??
+				document.querySelector('span > a[role="link"] > span');
+			presenceData.state = `Viewing ${queryUserName.textContent.trim()}'s page`;
 			presenceData.buttons = [
 				{ label: "View User", url: document.location.href },
 			];
+		}
+	} else if (document.location.pathname.includes("/reel")) {
+		presenceData.details = "Watching a reel";
+		presenceData.largeImageKey = "https://i.imgur.com/x2Mx3si.png";
+		if (!privacyMode) {
+			presenceData.state = `From ${document
+				.querySelector<HTMLLinkElement>("h2 > span > span > a.oajrlxb2")
+				.textContent.trim()}`;
 		}
 	} else if (document.location.pathname.includes("/marketplace/")) {
 		presenceData.startTimestamp = browsingTimestamp;


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Resolves #6218 and Resolves #6602 by adding the support for Facebook's reels.
Also Resolves #6606 by adding a work around for the query of the user's page name depending of the UI.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![fb_proof_1](https://user-images.githubusercontent.com/85577959/183242252-cef01e39-48e0-441e-b35d-65de030f4c09.PNG)

![fb_proof_3](https://user-images.githubusercontent.com/85577959/183242255-1cdbbc04-94f3-4fdc-81de-4b28999b6784.PNG)

![fb_proof_2](https://user-images.githubusercontent.com/85577959/183242261-c3f78c98-6d7c-4502-aa38-4265c7c04303.PNG)



</details>
