### PR TITLE
fix(Twitch): fix several querySelectors and remove useless code

### DIFF
--- a/websites/T/Twitch/dist/metadata.json
+++ b/websites/T/Twitch/dist/metadata.json
@@ -8,6 +8,10 @@
 		{
 			"name": "Alanexei ✔",
 			"id": "163319338403627008"
+		},
+		{
+			"name": "RisingSunLight",
+			"id": "240521747852558347"
 		}
 	],
 	"service": "Twitch",
@@ -41,7 +45,7 @@
 		"devstatus.twitch.tv",
 		"status.twitch.tv"
 	],
-	"version": "3.1.19",
+	"version": "3.2.0",
 	"logo": "https://i.imgur.com/So7h3G0.png",
 	"thumbnail": "https://i.imgur.com/OAcBmwW.png",
 	"color": "#9146FF",

--- a/websites/T/Twitch/presence.ts
+++ b/websites/T/Twitch/presence.ts
@@ -291,7 +291,7 @@ presence.on("UpdateData", async () => {
 
 				let user = getElement(".home-header-sticky .tw-title");
 				if (user) {
-					const tab = getElement(".tw-c-text-link"),
+					const tab = getElement('a[aria-selected="true"] > div > div > p'),
 						profilePic = document
 							.querySelector<HTMLImageElement>(
 								".tw-halo > .tw-aspect > .tw-avatar > .tw-image-avatar"
@@ -319,12 +319,7 @@ presence.on("UpdateData", async () => {
 
 				if (path.includes("/settings/")) {
 					presenceData.details = strings.viewSettings;
-					presenceData.state = getElement(".tw-tab__link--active");
-				}
-
-				if (path.includes("/friends/")) {
-					presenceData.details = strings.viewFriends;
-					presenceData.state = getElement(".tw-tab__link--active");
+					presenceData.state = getElement('a[aria-selected="true"]');
 				}
 
 				let searching = false;
@@ -332,9 +327,8 @@ presence.on("UpdateData", async () => {
 					searching = true;
 
 					presenceData.details = strings.searchingFor;
-					presenceData.state = getElement(
-						".tw-combo-input__input > div > input"
-					);
+					presenceData.state =
+						document.querySelector<HTMLInputElement>("input").value;
 					presenceData.smallImageKey = "search";
 				}
 
@@ -345,10 +339,11 @@ presence.on("UpdateData", async () => {
 					presenceData.details = strings.viewDropsComp;
 
 					let activeDrop = null;
+
 					for (const drop of document.querySelector(
-						".drops-root__content > div:nth-child(5)"
+						".drops-root__content > div:nth-child(4)"
 					).children) {
-						if (!drop.children[1].className.includes("tw-hide"))
+						if (drop.children[0].children[0].ariaExpanded === "true")
 							activeDrop = `${drop.firstElementChild.firstElementChild.firstElementChild.children[1].firstElementChild.children[0].textContent} (${drop.firstElementChild.firstElementChild.firstElementChild.children[1].firstElementChild.children[1].textContent})`;
 					}
 
@@ -356,44 +351,49 @@ presence.on("UpdateData", async () => {
 				}
 
 				if (path.includes("/subscriptions/")) {
-					const tab = getElement(".tw-tab__link--active");
+					const tab = getElement(
+						'li:not([data-a-target="paid"]) > button[aria-selected="true"]'
+					);
 
 					presenceData.details = strings.subs;
-					if (!tab.includes("Your"))
-						presenceData.state = tab.replace("Subscriptions", "");
+					if (tab)
+						presenceData.state = tab.replace(/(Subscriptions|Abonnements)/, "");
 				}
 
 				if (path.includes("/wallet/")) {
-					const tab = getElement(".tw-c-text-link");
+					const tab = getElement(
+						'li:not([data-index="0"]) > button[aria-selected="true"] > div > div > p'
+					);
 
 					presenceData.details = strings.viewWallet;
-					if (!tab.includes("Wallet")) presenceData.state = tab;
+					if (tab) presenceData.state = tab;
 				}
 
-				if (path.includes("/directory/")) {
-					presenceData.details = strings.browse;
-					presenceData.state = getElement(".tw-c-text-link");
-				}
-
-				if (path.includes("/directory/game/")) {
-					const category = getElement(".directory-header-new__banner-cover h1");
-					presenceData.details = strings.viewCategory;
-					presenceData.state =
-						category && `${category} (${getElement(".tw-c-text-link")})`;
-				}
-
-				if (path.includes("/directory/esports/")) {
-					presenceData.details = strings.viewEsports;
-					presenceData.state = getElement(
-						".esports-directory-single-category-header__info p"
-					);
-				}
-
+				const pathSplit = path.split("/");
 				if (path.includes("/directory/following/")) {
-					const tab = getElement(".tw-c-text-link");
+					const tab = getElement(
+						'li:not([data-index="0"]) > a[aria-selected="true"] > div > div > p'
+					);
 
 					presenceData.details = strings.viewFollow;
-					if (!tab.includes("Overview")) presenceData.state = tab;
+					if (tab) presenceData.state = tab;
+				} else if (path.includes("/directory/esports/")) {
+					presenceData.details = strings.viewEsports;
+					if (pathSplit.length > 4) {
+						presenceData.state = getElement(
+							`label[for="game_selector_${pathSplit[5]}"] > div > div > div.jnFWYC > p`
+						);
+					}
+				} else if (
+					["gaming", "irl", "music", "creative"].includes(pathSplit[2])
+				) {
+					presenceData.details = strings.viewCategory;
+					presenceData.state = getElement("h1.tw-title");
+				} else if (path.includes("/directory/")) {
+					presenceData.details = strings.browse;
+					presenceData.state = getElement(
+						'a[aria-selected="true"] > div > div > p'
+					);
 				}
 
 				if (privacy && searching) {


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Thanks @Bas950 for the help to understand better some case in the code !

### Changelog

- fix user's tab display when viewing an user
- fix tab display in settings
- remove friends part, since this feature has been removed by Twitch
- fix display of the searching keywords when you search something on Twitch
- fix displaying of the currently activeDrop the user is viewing
- fix subscriptions' tab display -> **should be localized to remove the word "Subscriptions" in every language (actually available in English and French)**
- fix wallet's tab display
- fix directory following part's tab display
- fix game name display in esport category
- fix display of the currently viewed category
- fix directory part's tab display


## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![twitch_proof_12](https://user-images.githubusercontent.com/85577959/183300499-1ee999f2-d3fd-473e-a74c-758e2bca15cb.PNG)

![twitch_proof_11](https://user-images.githubusercontent.com/85577959/183300503-5585fec9-a012-4949-8e2f-3343371fd8c3.PNG)

![twitch_proof_10](https://user-images.githubusercontent.com/85577959/183300514-01032bbd-c870-483e-bedd-f4253cc9d126.PNG)

![twitch_proof_9](https://user-images.githubusercontent.com/85577959/183300525-2fc17ceb-d0b2-41d1-8cfa-bda91bd8ab44.PNG)

![twitch_proof_8](https://user-images.githubusercontent.com/85577959/183300529-6dc86ce1-5f01-4b2e-ba81-a3d95d375641.PNG)

![twitch_proof_7](https://user-images.githubusercontent.com/85577959/183300543-e9ecb622-e6d6-4da1-950b-3418ff8a5d7a.PNG)

![twitch_proof_6](https://user-images.githubusercontent.com/85577959/183300556-eb1976e0-eef8-4156-8d4a-2669951fe89c.PNG)

![twitch_proof_5](https://user-images.githubusercontent.com/85577959/183300564-e1478c04-9815-44f1-8cba-f342bb4de89d.PNG)

![twitch_proof_4](https://user-images.githubusercontent.com/85577959/183300578-1e946225-12e3-449a-8a4b-0728cd6a6c56.PNG)

![twitch_proof_3](https://user-images.githubusercontent.com/85577959/183300597-c8c1da42-7fb6-49d5-91a0-3cdd01514041.PNG)

![twitch_proof_2](https://user-images.githubusercontent.com/85577959/183300618-ef1689e0-504c-4acd-990b-f2d3b404c996.PNG)

![twitch_proof_1](https://user-images.githubusercontent.com/85577959/183300472-3656051f-8728-4fa0-9ee6-3c52d2fb6041.PNG)

</details>
