### PR TITLE
fix(Tellingtone): fix localized string and wrong color metadata

### DIFF
--- a/websites/T/Tellingtone/dist/metadata.json
+++ b/websites/T/Tellingtone/dist/metadata.json
@@ -13,7 +13,7 @@
 	"version": "1.0.0",
 	"logo": "https://i.imgur.com/L4eWRh1.png",
 	"thumbnail": "https://i.imgur.com/6FokOfw.png",
-	"color": "#45A8FC",
+	"color": "#f58800",
 	"category": "other",
 	"tags": [
 		"superflame",

--- a/websites/T/Tellingtone/presence.ts
+++ b/websites/T/Tellingtone/presence.ts
@@ -10,7 +10,7 @@ async function getStrings() {
 			episode: "general.episode",
 			viewPage: "general.viewPage",
 			buttonViewSeries: "general.buttonViewSeries",
-			currentlyListening: "general.currentlyListening",
+			listeningTo: "general.listeningTo",
 		},
 		await presence.getSetting<string>("lang").catch(() => "en")
 	);
@@ -55,7 +55,7 @@ presence.on("UpdateData", async () => {
 			presenceData.buttons = [{ label: strings.buttonViewSeries, url: href }];
 	}
 	if (document.querySelector("div#Player")) {
-		presenceData.details = strings.currentlyListening
+		presenceData.details = strings.listeningTo
 			.replace("{0}", " ")
 			.replace(
 				"{1}",


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

Fix the localized string `general.listeningTo` since its identifier has been change.
Also fix the color in the metadata file, to match the logo's color.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![tellingtone_proof_2](https://user-images.githubusercontent.com/85577959/184937841-ff9407a1-c65f-4752-be30-0f037af1124f.PNG)

![tellingtone_proof_1](https://user-images.githubusercontent.com/85577959/184937848-5b947463-133d-4472-ab17-e2d5b1a50cd2.PNG)


</details>
