### PR TITLE
refactor(MangaDex): redo all codebase and add features

### DIFF
--- a/websites/M/MangaDex/dist/metadata.json
+++ b/websites/M/MangaDex/dist/metadata.json
@@ -49,10 +49,10 @@
 			"value": true
 		},
 		{
-		"id": "buttons",
-		"title": "Show Buttons",
-		"icon": "fad fa-compress-arrows-alt",
-		"value": true
-	}
-]
+			"id": "buttons",
+			"title": "Show Buttons",
+			"icon": "fad fa-compress-arrows-alt",
+			"value": true
+		}
+	]
 }

--- a/websites/M/MangaDex/dist/metadata.json
+++ b/websites/M/MangaDex/dist/metadata.json
@@ -6,6 +6,10 @@
 	},
 	"contributors": [
 		{
+			"name": "RisingSunLight",
+			"id": "240521747852558347"
+		},
+		{
 			"name": "Aya",
 			"id": "256422547556401152"
 		},
@@ -28,7 +32,7 @@
 		"www.mangadex.org",
 		"mangadex.cc"
 	],
-	"version": "2.0.8",
+	"version": "3.0.0",
 	"logo": "https://i.imgur.com/zs8myqz.png",
 	"thumbnail": "https://i.imgur.com/xiKNaUJ.png",
 	"color": "#F18F1E",
@@ -36,5 +40,19 @@
 	"tags": [
 		"mangadex",
 		"reading"
-	]
+	],
+	"settings": [
+		{
+			"id": "cover",
+			"title": "Show Manga Cover",
+			"icon": "fas fa-images",
+			"value": true
+		},
+		{
+		"id": "buttons",
+		"title": "Show Buttons",
+		"icon": "fad fa-compress-arrows-alt",
+		"value": true
+	}
+]
 }

--- a/websites/M/MangaDex/presence.ts
+++ b/websites/M/MangaDex/presence.ts
@@ -3,78 +3,120 @@ const presence = new Presence({
 	}),
 	browsingTimestamp = Math.floor(Date.now() / 1000);
 
-let username: string;
+let username: string,
+	mangaId: string = null,
+	coverFileName: string = null;
+
+enum Assets {
+	Logo = "https://i.imgur.com/zs8myqz.png",
+	Reading = "https://i.imgur.com/53N4eY6.png",
+	Searching = "https://i.imgur.com/OIgfjTG.png",
+}
+
+async function getCoverImage(newMangaId: string) {
+	/**
+	 * Use MangaDex API to get the fileName of the cover to obtain the image.
+	 * More here : https://api.mangadex.org/docs/get-covers/
+	 */
+	if (mangaId === newMangaId)
+		return `https://uploads.mangadex.org/covers/${mangaId}/${coverFileName}`;
+	mangaId = newMangaId;
+	const req = await fetch(
+		`https://api.mangadex.org/manga/${mangaId}?includes%5B%5D=cover_art`
+	);
+	if (!req.ok) return Assets.Logo;
+	const { relationships } = (await req.json()).data;
+	coverFileName = relationships.find(
+		(relation: { type: string }) => relation.type === "cover_art"
+	).attributes.fileName;
+	return `https://uploads.mangadex.org/covers/${mangaId}/${coverFileName}`;
+}
 
 presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
-		largeImageKey: "logo",
-		startTimestamp: browsingTimestamp,
-	};
+			largeImageKey: Assets.Logo,
+			startTimestamp: browsingTimestamp,
+		},
+		{ pathname, href } = document.location,
+		pathArr = pathname.split("/"),
+		[showCover, showButtons] = await Promise.all([
+			presence.getSetting<boolean>("cover"),
+			presence.getSetting<boolean>("buttons"),
+		]);
 
-	if (document.location.pathname === "/")
-		presenceData.details = "Viewing the Homepage";
-	else if (document.location.pathname.endsWith("/settings"))
-		presenceData.details = "Viewing the Settings Page";
-	else if (document.location.pathname.endsWith("/about"))
-		presenceData.details = "Viewing About Page";
-	else if (document.location.pathname.endsWith("/rules"))
-		presenceData.details = "Viewing Rules";
-	else if (document.location.pathname.startsWith("/title")) {
-		if (document.location.pathname.startsWith("/titles")) {
-			if (document.location.pathname.endsWith("/latest"))
-				presenceData.details = "Browsing Latest Manga";
-			else if (document.location.pathname.endsWith("/feed"))
-				presenceData.details = "Viewing Feed";
-			else if (document.location.pathname.endsWith("/follows"))
-				presenceData.details = "Viewing Library";
-			else presenceData.details = "Browsing Manga";
-		} else {
-			if (document.location.pathname.endsWith("/random"))
-				presenceData.details = "Viewing a Random Manga:";
-			else presenceData.details = "Viewing a Manga:";
+	switch (pathArr[1]) {
+		case "title":
+			presenceData.details = `Viewing a ${
+				pathArr[2] === "random" ? "Random" : ""
+			} Manga:`;
 			presenceData.state = document
 				.querySelector("head > title")
 				.textContent.replace(" - MangaDex", "");
+			presenceData.buttons = [{ label: "View Manga", url: href }];
+			presenceData.largeImageKey =
+				document.querySelector<HTMLImageElement>("img.rounded").src;
+			break;
+		case "titles":
+			presenceData.details = {
+				"": "Browsing Manga",
+				latest: "Browsing Latest Manga",
+				feed: "Viewing Feed",
+				recent: "Browsing Recents Mangas",
+				follows: "Viewing their Library",
+			}[pathArr[2]];
+			presenceData.smallImageKey = Assets.Searching;
+			break;
+		case "chapter": {
+			const title = document.querySelector(".text-primary").textContent.trim();
+			presenceData.details = `Reading ${title}`;
+			presenceData.state = `Page ${document
+				.querySelector("head > title")
+				.textContent.replace(` - ${title} - MangaDex`, "")}`;
+			presenceData.largeImageKey = await getCoverImage(
+				document.querySelector<HTMLLinkElement>("span > a").href.split("/")[4]
+			);
+			presenceData.smallImageKey = Assets.Reading;
+			presenceData.buttons = [{ label: "Read Chapter", url: href }];
+			break;
 		}
-	} else if (document.location.pathname.startsWith("/chapter")) {
-		const title = document.querySelector(".text-primary").textContent.trim();
-		presenceData.details = `Reading ${title}`;
-		presenceData.state = `Page ${document
-			.querySelector("head > title")
-			.textContent.replace(` - ${title} - MangaDex`, "")}`;
-	} else if (document.location.pathname.startsWith("/tag")) {
-		presenceData.details = "Viewing a Tag";
-		presenceData.state = document
-			.querySelector("head > title")
-			.textContent.replace(" - MangaDex", "");
-	} else if (document.location.pathname.endsWith("/history"))
-		presenceData.details = "Viewing History";
-	else if (document.location.pathname.endsWith("/lists"))
-		presenceData.details = "Viewing Lists";
-	else if (document.location.pathname.startsWith("/list"))
-		presenceData.details = "Viewing an MDList";
-	else if (document.location.pathname.startsWith("/user")) {
-		if (document.location.pathname.endsWith("/users"))
-			presenceData.details = "Viewing Users";
-		else {
+		case "tag":
+			presenceData.details = "Viewing a Tag";
+			presenceData.state = document
+				.querySelector("head > title")
+				.textContent.replace(" - MangaDex", "");
+			break;
+		case "group":
+		case "user":
 			username = document
 				.querySelector("head > title")
 				.textContent.replace(" - MangaDex", "");
-			presenceData.details = "Viewing User Profile";
+			presenceData.details = `Viewing ${
+				pathArr[1] === "group" ? "Viewing a Group" : "User Profile"
+			}`;
 			presenceData.state = username;
-		}
-	} else if (document.location.pathname.startsWith("/group")) {
-		if (document.location.pathname.endsWith("/groups"))
-			presenceData.details = "Viewing Groups";
-		else {
-			username = document
-				.querySelector("head > title")
-				.textContent.replace(" - MangaDex", "");
-			presenceData.details = "Viewing a Group";
-			presenceData.state = username;
-		}
-	} else if (document.location.pathname.startsWith("/my/groups"))
-		presenceData.details = "Viewing Followed Groups";
+			break;
+		case "my":
+			presenceData.details = {
+				history: "Viewing History",
+				lists: "Viewing Lists",
+				groups: "Viewing Followed Groups",
+			}[pathArr[2]];
+			break;
+		default:
+			presenceData.details = {
+				"": "Viewing the Homepage",
+				settings: "Viewing the Settings Page",
+				about: "Viewing About Page",
+				rules: "Viewing Rules",
+				list: "Viewing an MDList",
+				users: "Viewing Users",
+				groups: "Viewing Groups",
+			}[pathArr[1]];
+	}
 
-	presence.setActivity(presenceData);
+	if (!showCover) presenceData.largeImageKey = Assets.Logo;
+	if (!showButtons) delete presenceData.buttons;
+
+	if (presenceData.details) presence.setActivity(presenceData);
+	else presence.setActivity();
 });


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

### Changelog

- Redo all the codebase by removing if/else statements for a switch.
- Add buttons w/ setting to disable them
- Add cover w/ setting to disable them, Resolves #6664 
- Add enum for Assets such as Logo, Searching image key, etc...
- Add a func to retrieve the cover to display with the website's API when the user is reading a chapter
- Add myself as contributor to the presence (currently discussing with the current author to swap property to me).

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![mangadex_proof_1](https://user-images.githubusercontent.com/85577959/185258859-e1bd0e76-bf1e-4f8e-826f-ccb5fd6abe93.PNG)

![mangadex_proof_6](https://user-images.githubusercontent.com/85577959/185258862-2d83a47c-126a-4941-85cc-ecbc7bdb4e3c.PNG)

![mangadex_proof_5](https://user-images.githubusercontent.com/85577959/185258864-b9134c29-20a0-48c9-a467-ea94ff4b2f2b.PNG)

![mangadex_proof_4](https://user-images.githubusercontent.com/85577959/185258865-7bb249b8-b5a3-4e47-b481-f97f6619c32b.PNG)

![mangadex_proof_3](https://user-images.githubusercontent.com/85577959/185258866-b5e0d98b-57a7-4ae5-9a8a-43cca3fe0e39.PNG)

![mangadex_proof_2](https://user-images.githubusercontent.com/85577959/185258868-38723c5a-f6df-46f4-b560-6c8893df8f80.PNG)


</details>
