### PR TITLE
fix(VLC): fix formatting error and display

### DIFF
--- a/websites/V/VLC/dist/metadata.json
+++ b/websites/V/VLC/dist/metadata.json
@@ -15,7 +15,7 @@
 		"localhost",
 		"127.0.0.1"
 	],
-	"version": "1.4.30",
+	"version": "1.4.31",
 	"logo": "https://i.imgur.com/WuzLOQu.png",
 	"thumbnail": "https://i.imgur.com/Bg2AFYN.png",
 	"color": "#ff7c00",

--- a/websites/V/VLC/presence.ts
+++ b/websites/V/VLC/presence.ts
@@ -65,9 +65,9 @@ presence.on("UpdateData", async () => {
 					media.album = null;
 
 				presenceData.details =
-					(media.title ?? media.trackNumber
-						? `Track N°${media.trackNumber}`
-						: "A song") + (media.album ? ` on ${media.album}` : "");
+					((media.title ?? "") +
+						(media.trackNumber ? ` Track N°${media.trackNumber}` : "") ||
+						"A song") + (media.album ? ` on ${media.album}` : "");
 				media.artist
 					? (presenceData.state = `by ${media.artist}`)
 					: media.filename
@@ -292,6 +292,8 @@ const getStatus = setLoop(function () {
 							media.episodeNumber = null;
 						}
 					}
+					for (const key of Object.keys(media))
+						media[key] = media[key]?.replace("&#39;", "'");
 				} else {
 					i++;
 					if (i > 4) {
@@ -336,4 +338,5 @@ interface MediaObj {
 	showName?: string;
 	seasonNumber?: string;
 	episodeNumber?: string;
+	[key: string]: string;
 }


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Fix an error on formatting for `'`. Quite ugly (since it's a for loop on all values of `media`), but I didn't achieve a better way to avoid the problem.
Also fix a bad displaying : title of a song and some other things were not displayed in some cases.

Thanks to Sammie on Discord (@Sammie0210 on Github) for the help on what should be normally displayed !

_Version 1.4.31 xD_

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![vlc_proof_1](https://user-images.githubusercontent.com/85577959/185486026-53e511e7-8242-4600-904f-c6ba55e172b1.PNG)

![vlc_proof_2](https://user-images.githubusercontent.com/85577959/185486048-b57c0fc6-55b3-4f2e-912f-cdf8cc89dfbc.PNG)
</details>
