### PR TITLE
fix(Tellingtone): fix bad display on episode name

### DIFF
--- a/websites/T/Tellingtone/dist/metadata.json
+++ b/websites/T/Tellingtone/dist/metadata.json
@@ -10,7 +10,7 @@
 		"fr": "Découvrez notre catalogue de séries audio originales, des histoires conçues dès l'écriture pour être écoutées en podcast. Plongez dans nos univers fantastiques où s'entremêlent suspense, magie et enquête…"
 	},
 	"url": "tellingtone.com",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"logo": "https://i.imgur.com/L4eWRh1.png",
 	"thumbnail": "https://i.imgur.com/6FokOfw.png",
 	"color": "#f58800",

--- a/websites/T/Tellingtone/presence.ts
+++ b/websites/T/Tellingtone/presence.ts
@@ -59,7 +59,9 @@ presence.on("UpdateData", async () => {
 			.replace("{0}", " ")
 			.replace(
 				"{1}",
-				document.querySelector<HTMLDivElement>("div.media-title").textContent
+				document.querySelector<HTMLDivElement>(
+					".reading-media > .media-infos > .media-title"
+				).textContent
 			);
 		presenceData.state =
 			document.querySelector<HTMLDivElement>("div.media-episode").textContent;


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Fix an error on the querySelector for the episode currently listened. The title displayed was always the first one and not the listened to.

## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![tellingtone_proof_1](https://user-images.githubusercontent.com/85577959/185706364-81ff6286-6e34-4c65-88f1-21df2b87cdcb.PNG)

![tellingtone_proof_2](https://user-images.githubusercontent.com/85577959/185706410-4320e8cb-03df-411e-aac4-029f79776990.PNG)


</details>
