### PR TITLE
fix(YouTube): fix wrong channel name display

### DIFF
--- a/websites/Y/YouTube/dist/metadata.json
+++ b/websites/Y/YouTube/dist/metadata.json
@@ -67,7 +67,7 @@
 		"www.youtube.com",
 		"studio.youtube.com"
 	],
-	"version": "5.2.5",
+	"version": "5.2.6",
 	"logo": "https://i.imgur.com/o5injgg.png",
 	"thumbnail": "https://i.imgur.com/3QfIc5v.jpg",
 	"color": "#E40813",

--- a/websites/Y/YouTube/presence.ts
+++ b/websites/Y/YouTube/presence.ts
@@ -217,6 +217,7 @@ presence.on("UpdateData", async () => {
 		}
 		if (
 			!uploader &&
+			!uploaderTV &&
 			document.querySelector(".style-scope.ytd-channel-name > a")
 		) {
 			finalUploader = document.querySelector(


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

- Resolves #6678 

### Explaining why this bug was occuring

For some reasons when browsing YouTube (there's multiple cases, for me it was when you're at your subscriptions page, you go home, and you choose a random vid), the wrong channel name was displayed.
It's due to this part of the code : 

![image](https://user-images.githubusercontent.com/85577959/185980203-e6eba9d7-cf00-4145-a14a-351a085f928a.png)
In fact, for some reason, the `uploader` value can be null, but not the `uploaderTV`. OR, when the `finalUploader` variable is initialized, it takes the `uploaderTV` value before the `uploader` one.
So It cause this behavior : 

![image](https://user-images.githubusercontent.com/85577959/185980426-c6b74d6e-2965-4f8a-9f2f-c7f7ceeaf8a2.png)

The `finalUploader` is okay first, the `uploaderTV` is okay too BUT the `uploader` is null. It triggers the `if` statement, changing the `finalUploader` to a wrong value.
So I've edited the if to check the `uploaderTV` too.



## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
Screen one, with the patch :

![youtube_proof_1](https://user-images.githubusercontent.com/85577959/185980707-bfd01273-ccac-4bc9-a03e-c8fc943db0ef.PNG)

We can see that everything is fine, in the console, the value of `finalUploader` is not unchanged.

![youtube_proof_2](https://user-images.githubusercontent.com/85577959/185980777-83d7edf3-d70e-4812-9220-76b0d97659ef.PNG)

![youtube_proof_3](https://user-images.githubusercontent.com/85577959/185980821-1e2b9cb8-7fc4-4785-a4bb-4372c2bde191.PNG)


</details>
