### PR TITLE
refactor(SOAP2DAY): change code structure and add setting

### DIFF
--- a/websites/S/SOAP2DAY/dist/metadata.json
+++ b/websites/S/SOAP2DAY/dist/metadata.json
@@ -4,6 +4,12 @@
 		"name": "fun",
 		"id": "217348698294714370"
 	},
+	"contributors": [
+		{
+			"name": "RisingSunLight",
+			"id": "240521747852558347"
+		}
+	],
 	"service": "SOAP2DAY",
 	"description": {
 		"en": "You can watch all videos without logging in or registration. Soap2day is free all the time, but there are few ads on videoplayer page."
@@ -18,7 +24,7 @@
 		"s2dfree.de",
 		"s2dfree.is"
 	],
-	"version": "2.0.0",
+	"version": "3.0.0",
 	"logo": "https://i.imgur.com/WAOvAe6.png",
 	"thumbnail": "https://i.imgur.com/AEHBaRS.png",
 	"color": "#9eeae7",
@@ -29,5 +35,13 @@
 		"movies",
 		"tv",
 		"friends"
+	],
+	"settings": [
+		{
+			"id": "title",
+			"title": "Show Title",
+			"icon": "fas fa-comment-alt-edit",
+			"value": false
+		}
 	]
 }


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

### Changelog

- Resolves #6687 by adding a setting to display the name of the show/movie/etc currently viewed if enable (disabled by default !)
_Note : when the title of the show/movie/etc... is the same as the one in the video, it will be deleted from the `presenceData.state`._
- Change code structure to avoid useless indent and lines
- Remove some variables in consequence
- Remove useless comment
- Add myself as contributor

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![soap2day_proof_4](https://user-images.githubusercontent.com/85577959/186010557-64129bf3-5fc0-49e8-a9d7-615ca954afca.PNG)

![soap2day_proof_3](https://user-images.githubusercontent.com/85577959/186010564-58bbc41c-39cd-40a8-9d15-b7aa4dd932a3.PNG)

![soap2day_proof_2](https://user-images.githubusercontent.com/85577959/186010572-415009ec-9600-4e27-ab8d-e72e94d0bae2.PNG)

![soap2day_proof_1](https://user-images.githubusercontent.com/85577959/186010545-e1b9f64c-a321-4190-8d48-3fd26531a62f.PNG)

</details>
