### PR TITLE
feat(myCanal): add Show Cover setting

### DIFF
--- a/websites/M/myCANAL/dist/metadata.json
+++ b/websites/M/myCANAL/dist/metadata.json
@@ -12,6 +12,10 @@
 		{
 			"name": "Alexx",
 			"id": "604182077088202784"
+		},
+		{
+			"name": "Kozou",
+			"id": "379362415428632576"
 		}
 	],
 	"service": "myCANAL",
@@ -20,7 +24,7 @@
 		"nl": "Canal + is een Franse abonnementsaanbieder die is gekoppeld aan het kanaal met dezelfde naam. Het is eigendom van Vivendi met een aandeel van honderd procent."
 	},
 	"url": "www.canalplus.com",
-	"version": "1.1.19",
+	"version": "1.2.0",
 	"logo": "https://i.imgur.com/H3IXznl.png",
 	"thumbnail": "https://i.imgur.com/xRKwqvI.png",
 	"color": "#000",
@@ -29,5 +33,13 @@
 		"mycanal",
 		"video",
 		"media"
+	],
+	"settings": [
+		{
+			"id": "cover",
+			"title": "Show Cover",
+			"icon": "fad fa-images",
+			"value": true
+		}
 	]
 }

--- a/websites/M/myCANAL/dist/metadata.json
+++ b/websites/M/myCANAL/dist/metadata.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "https://schemas.premid.app/metadata/1.7",
 	"author": {
-		"name": "Dark_Ville",
-		"id": "638080361179512853"
+		"name": "Kozou",
+		"id": "379362415428632576"
 	},
 	"contributors": [
 		{
@@ -14,8 +14,8 @@
 			"id": "604182077088202784"
 		},
 		{
-			"name": "Kozou",
-			"id": "379362415428632576"
+			"name": "Dark_Ville",
+			"id": "638080361179512853"
 		}
 	],
 	"service": "myCANAL",

--- a/websites/M/myCANAL/presence.ts
+++ b/websites/M/myCANAL/presence.ts
@@ -13,6 +13,7 @@ presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
 			largeImageKey: "logo",
 		},
+		showCover = await presence.getSetting<boolean>("cover"),
 		video: HTMLVideoElement = document.querySelector(".aPWk0-TaQEzvggxIT6qvP");
 	if (video && !isNaN(video.duration)) {
 		if (!document.querySelector("._3uUpH58Juk_Qbizq6j5ThG")) {
@@ -23,8 +24,8 @@ presence.on("UpdateData", async () => {
 				presenceData.startTimestamp = browsingTimestamp;
 			} else {
 				title = `${
-					document.querySelector("._3tdt8zwgvMCJ6v_sElXneQ").textContent
-				} ${document.querySelector("._3pyJlyeeH9KBKeFd4nFAmt").textContent}`;
+					document.querySelector("._3tdt8zwgvMCJ6v_sElXneQ")?.textContent
+				} ${document.querySelector("._3pyJlyeeH9KBKeFd4nFAmt")?.textContent}`;
 
 				presenceData.smallImageKey = video.paused ? "pause" : "play";
 				presenceData.smallImageText = video.paused
@@ -34,6 +35,16 @@ presence.on("UpdateData", async () => {
 					Math.floor(video.currentTime),
 					Math.floor(video.duration)
 				);
+
+				if (showCover) {
+					presenceData.largeImageKey =
+						document.querySelector<HTMLImageElement>(
+							"#binder_mediaCardHeader > div > img"
+						)?.src ||
+						document.querySelector<HTMLImageElement>(
+							"#episodeGrid-Épisode\\ 1\\ -\\ Les\\ Héritiers\\ du\\ Dragon_onclick_toFocus > div.poster___Cbuef.card__poster___cb98P.poster--dark___UyYiC > img"
+						)?.src;
+				}
 			}
 			const subtitle = document.querySelector(
 				"._39WJKEhrSYo7ftwMlFjZtA  ._3tdt8zwgvMCJ6v_sElXneQ"


### PR DESCRIPTION
## Description 
Added functionality that allows the user to choose whether or not to display a show's or movie's cover. I also fixed some tiny presence bugs 

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![Discord_cT8EDqZG10](https://user-images.githubusercontent.com/72155852/186268619-6123d0fa-cff9-4c8b-a290-0d697e9fb2cf.png)


</details>
