### PR TITLE
fix(Facebook): url for photo on profile

### DIFF
--- a/websites/F/Facebook/dist/metadata.json
+++ b/websites/F/Facebook/dist/metadata.json
@@ -22,7 +22,7 @@
 		"vi_VN": "Kết nối với bạn bè, người thân và những người khác bạn biết. Chia sẻ hình ảnh và video, gửi tin nhắn và nhận các thông báo."
 	},
 	"url": "www.facebook.com",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"logo": "https://i.imgur.com/nS9sZn6.png",
 	"thumbnail": "https://i.imgur.com/iftQq6r.jpg",
 	"color": "#4267B2",

--- a/websites/F/Facebook/presence.ts
+++ b/websites/F/Facebook/presence.ts
@@ -63,8 +63,10 @@ presence.on("UpdateData", async () => {
 		else {
 			presenceData.details = `Watching a ${isLive ? "live" : "video"} on:`;
 			presenceData.state = `${
-				document.querySelector("span.nc684nl6 > span")?.textContent ||
-				document.querySelector("span.nc684nl6 > a > strong > span")?.textContent
+				document.querySelector("span.nc684nl6 > span")?.textContent ??
+				document.querySelector("span.nc684nl6 > a > strong > span")
+					?.textContent ??
+				document.querySelector('[href*="?__tn__=-UC*F"]')?.textContent
 			}'s profile`;
 
 			if (isLive) {
@@ -89,14 +91,16 @@ presence.on("UpdateData", async () => {
 				},
 			];
 		}
-	} else if (document.location.pathname.includes("/photo/")) {
+	} else if (document.location.pathname.includes("/photo")) {
 		if (privacyMode) presenceData.details = "Viewing a photo";
 		else {
 			presenceData.details = "Viewing a photo on:";
 			presenceData.state = `${
-				document.querySelector("span.nc684nl6 > span")?.textContent ||
-				document.querySelector("span.nc684nl6 > a > strong > span")?.textContent
-			}'s profile'`;
+				document.querySelector("span.nc684nl6 > span")?.textContent ??
+				document.querySelector("span.nc684nl6 > a > strong > span")
+					?.textContent ??
+				document.querySelector('[href*="?__tn__=-UC*F"]')?.textContent
+			}'s profile`;
 
 			presenceData.buttons = [
 				{


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Fixed the check for viewing photo's on someone's profile.
## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

<img src="https://user-images.githubusercontent.com/42322979/188269202-8ba7ec52-d00b-4e0d-be29-72b9ccb7b39a.jpg">
<img src="https://user-images.githubusercontent.com/42322979/188269203-6aeaef8c-2756-4f0a-870d-5a202e8485ba.jpg">


</details>
