### PR TITLE
feat(Stack Exchange): add buttons with setting

### DIFF
--- a/websites/S/Stack Exchange/dist/metadata.json
+++ b/websites/S/Stack Exchange/dist/metadata.json
@@ -14,7 +14,7 @@
 		"superuser.com"
 	],
 	"regExp": "(.*\\.)*(stackexchange\\.com|superuser\\.com|serverfault\\.com)",
-	"version": "1.0.8",
+	"version": "1.1.0",
 	"logo": "https://i.imgur.com/WCho2QO.png",
 	"thumbnail": "https://i.imgur.com/Xax7CJQ.png",
 	"color": "#1E5397",
@@ -26,5 +26,13 @@
 		"forum",
 		"question",
 		"answer"
+	],
+	"settings": [
+		{
+			"id": "buttons",
+			"title": "Show Buttons",
+			"icon": "fas fa-compress-arrows-alt",
+			"value": true
+		}
 	]
 }

--- a/websites/S/Stack Exchange/presence.ts
+++ b/websites/S/Stack Exchange/presence.ts
@@ -8,7 +8,8 @@ presence.on("UpdateData", async () => {
 			largeImageKey: "stackexchange",
 			startTimestamp: browsingTimestamp,
 		},
-		{ pathname, hostname } = window.location;
+		{ pathname, hostname, href } = window.location,
+		showButtons = await presence.getSetting<boolean>("buttons");
 
 	switch (hostname) {
 		case "stackexchange.com": {
@@ -18,25 +19,21 @@ presence.on("UpdateData", async () => {
 		case "serverfault.com": {
 			presenceData.largeImageKey = "serverfault";
 			presenceData.details = "Server Fault";
-
 			break;
 		}
 		case "meta.serverfault.com": {
 			presenceData.largeImageKey = "serverfault";
 			presenceData.details = "Server Fault Meta";
-
 			break;
 		}
 		case "superuser.com": {
 			presenceData.largeImageKey = "superuser";
 			presenceData.details = "Super User";
-
 			break;
 		}
 		case "meta.superuser.com": {
 			presenceData.largeImageKey = "superuser";
 			presenceData.details = "Super User Meta";
-
 			break;
 		}
 		default: {
@@ -48,8 +45,15 @@ presence.on("UpdateData", async () => {
 				.querySelector("meta[property='og:site_name']")
 				.getAttribute("content")
 				.replace("Stack Exchange", "");
-			if (pathname.includes("/questions"))
+			if (pathname.includes("/questions")) {
 				presenceData.details = "Reading a question";
+				presenceData.buttons = [
+					{
+						label: "View Question",
+						url: href,
+					},
+				];
+			}
 		}
 	}
 
@@ -78,6 +82,8 @@ presence.on("UpdateData", async () => {
 	)
 		presenceData.state = "Browsing";
 	else presenceData.details = "Browsing";
+
+	if (!showButtons) delete presenceData.buttons;
 
 	if (presenceData.details) presence.setActivity(presenceData);
 	else presence.setActivity();


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

Add buttons for Stack Exchange websites, as requested in the closed PR #6751.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![stackexchange_proof_2](https://user-images.githubusercontent.com/85577959/188306700-e8d8cfa2-e1ad-4b6a-ac33-da42fd1c7927.PNG)

![stackexchange_proof_1](https://user-images.githubusercontent.com/85577959/188306701-457db3fa-6e9f-4677-b246-78af43d4cbd8.PNG)


</details>
