### PR TITLE
feat(Stack Overflow): add buttons with setting

### DIFF
--- a/websites/S/Stack Overflow/dist/metadata.json
+++ b/websites/S/Stack Overflow/dist/metadata.json
@@ -13,7 +13,7 @@
 		"nl": "Stack Overflow is een open community voor iedereen die codeert. Het helpt je om antwoorden op je moeilijkste codeervragen te krijgen, kennis met je collega's privé te delen en je volgende droombaan te vinden."
 	},
 	"url": "stackoverflow.com",
-	"version": "2.3.14",
+	"version": "2.4.0",
 	"logo": "https://i.imgur.com/iTWct8S.png",
 	"thumbnail": "https://i.imgur.com/Z4LQn2d.png",
 	"color": "#f48023",
@@ -21,5 +21,13 @@
 	"tags": [
 		"coding",
 		"help"
+	],
+	"settings": [
+		{
+			"id": "buttons",
+			"title": "Show Buttons",
+			"icon": "fas fa-compress-arrows-alt",
+			"value": true
+		}
 	]
 }

--- a/websites/S/Stack Overflow/presence.ts
+++ b/websites/S/Stack Overflow/presence.ts
@@ -2,6 +2,7 @@ const presence = new Presence({
 		clientId: "610123745033584651",
 	}),
 	browsingTimestamp = Math.floor(Date.now() / 1000);
+
 let title: HTMLAnchorElement,
 	pageNumber: HTMLElement,
 	jobPageNumber: HTMLAnchorElement,
@@ -13,9 +14,11 @@ let title: HTMLAnchorElement,
 
 presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
-		details: "Unknown page",
-		largeImageKey: "lg",
-	};
+			details: "Unknown page",
+			largeImageKey: "lg",
+			startTimestamp: browsingTimestamp,
+		},
+		showButtons = await presence.getSetting<boolean>("buttons");
 
 	title = document.querySelector("div#question-header h1 a");
 
@@ -47,15 +50,12 @@ presence.on("UpdateData", async () => {
 
 	if (title && document.location.pathname.includes("/questions/")) {
 		presenceData.details = "Reading a question.";
-
 		presenceData.state = title.textContent;
-
-		presenceData.startTimestamp = browsingTimestamp;
+		presenceData.buttons = [
+			{ label: "View Question", url: document.location.href },
+		];
 	} else if (document.location.pathname === "/") {
 		presenceData.state = "Main Page | Home";
-
-		presenceData.startTimestamp = browsingTimestamp;
-
 		delete presenceData.details;
 	} else if (
 		document.location.pathname === "/questions" &&
@@ -66,15 +66,11 @@ presence.on("UpdateData", async () => {
 
 		if (lastquestionsPageNumber > lastPageNumber) {
 			presence.info(`${lastPageNumber} --- ${lastquestionsPageNumber}`);
-
 			lastPage = pageNumber.textContent;
 		}
 
 		presenceData.details = "Browsing all the questions.";
-
 		presenceData.state = `Current page: ${pageNumber.textContent}/${lastPage}`;
-
-		presenceData.startTimestamp = browsingTimestamp;
 	} else {
 		switch (document.location.pathname) {
 			case "/jobs": {
@@ -90,9 +86,6 @@ presence.on("UpdateData", async () => {
 				presenceData.details = "Browsing jobs.";
 
 				presenceData.state = `Current page: ${jobPageNumber.textContent}/${lastPage}`;
-
-				presenceData.startTimestamp = browsingTimestamp;
-
 				break;
 			}
 			case "/users": {
@@ -109,9 +102,6 @@ presence.on("UpdateData", async () => {
 				presenceData.details = "Browsing users.";
 
 				presenceData.state = `Current page: ${usersortagsPageNumber.textContent}/${lastPage}`;
-
-				presenceData.startTimestamp = browsingTimestamp;
-
 				break;
 			}
 			case "/tags": {
@@ -126,16 +116,12 @@ presence.on("UpdateData", async () => {
 				}
 
 				presenceData.details = "Browsing tags.";
-
 				presenceData.state = `Current page: ${usersortagsPageNumber.textContent}/${lastPage}`;
-
-				presenceData.startTimestamp = browsingTimestamp;
-
 				break;
 			}
-			// No default
 		}
 	}
 
+	if (!showButtons) delete presenceData.buttons;
 	presence.setActivity(presenceData);
 });


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

Add buttons for Stack Exchange websites, as requested in the closed PR #6751. Also, I've moved the browsingTimestamp at the initialisation of the `presenceData`, to avoid repetition.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![stackoverflow_proof_1](https://user-images.githubusercontent.com/85577959/188307497-4ffc7f04-bfc5-4725-8e03-16bac72fb792.PNG)

![stackoverflow_proof_2](https://user-images.githubusercontent.com/85577959/188307498-3ffec45c-6f14-4d49-be0d-3986752947fe.PNG)

</details>
