### PR TITLE
fix(metadataSorter): fix not sorting metadata

### DIFF
--- a/util/tools/metadataSorter.ts
+++ b/util/tools/metadataSorter.ts
@@ -10,7 +10,7 @@ const missingMetadata: string[] = glob("./{websites,programs}/*/*/").filter(
 		pF => !exists(`${pF}/metadata.json`)
 	),
 	allmeta: [Metadata, string][] = glob(
-		"./{websites,programs}/*/*/*/metadata.json"
+		"./{websites,programs}/*/*/metadata.json"
 	).reduce((result, pF) => {
 		const file = readFile(pF);
 		if (isValidJSON(file)) result.push([JSON.parse(file), pF]);


### PR DESCRIPTION
## Description 
Fixes a problem in the metadata sorter that prevents it from actually sorting the correct metadata file.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
