### PR TITLE
fix(Youtube): wrong uploader after short

### DIFF
--- a/websites/Y/YouTube/metadata.json
+++ b/websites/Y/YouTube/metadata.json
@@ -67,7 +67,7 @@
 		"www.youtube.com",
 		"studio.youtube.com"
 	],
-	"version": "5.3.1",
+	"version": "5.3.2",
 	"logo": "https://i.imgur.com/o5injgg.png",
 	"thumbnail": "https://i.imgur.com/3QfIc5v.jpg",
 	"color": "#E40813",

--- a/websites/Y/YouTube/presence.ts
+++ b/websites/Y/YouTube/presence.ts
@@ -233,7 +233,7 @@ presence.on("UpdateData", async () => {
 			);
 		}
 
-		if (!YoutubeShorts) uploaderShorts = void 0;
+		if (!YoutubeShorts) uploaderShorts = null;
 		const uploader =
 				uploaderShorts ??
 				(uploaderMiniPlayer && uploaderMiniPlayer.textContent.length > 0

--- a/websites/Y/YouTube/presence.ts
+++ b/websites/Y/YouTube/presence.ts
@@ -183,7 +183,13 @@ presence.on("UpdateData", async () => {
 		//* Due to differences between old and new YouTube, we should add different selectors.
 		// Get title
 		YouTubeEmbed
-			? (title = document.querySelector("div.ytp-title-text > a"))
+			? (title = document
+					.querySelector(
+						'[class="reel-video-in-sequence style-scope ytd-shorts"]'
+					)
+					?.querySelector(
+						'[class="title style-scope ytd-reel-player-header-renderer"]'
+					))
 			: YoutubeShorts
 			? (title = document.querySelector(
 					'[class="ytp-title-link yt-uix-sessionlink"]'
@@ -227,6 +233,7 @@ presence.on("UpdateData", async () => {
 			);
 		}
 
+		if (!YoutubeShorts) uploaderShorts = void 0;
 		const uploader =
 				uploaderShorts ??
 				(uploaderMiniPlayer && uploaderMiniPlayer.textContent.length > 0


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Resolves #6842 Fixed bug that uploader was used after watching a short.
## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img src="https://user-images.githubusercontent.com/42322979/193450738-d84593b2-e0ba-4f79-a634-fc08ef9d8cff.jpg">


</details>
