### PR TITLE
fix(Disney+): add new domain

### DIFF
--- a/websites/D/Disney+/metadata.json
+++ b/websites/D/Disney+/metadata.json
@@ -19,7 +19,10 @@
 		"da_DK": "Disney+ er det eksklusive hjem for dine yndlingsfilm og -tv-serier fra Disney, Pixar, Marvel, Star Wars, National Geographic og Star. Begynd at se i dag.",
 		"pt_BR": "O Disney+ é o serviço exclusivo para ver os seus filmes e programas preferidos da Disney, Pixar, Marvel, Star Wars e National Geographic. Comece a assistir hoje mesmo."
 	},
-	"url": ["www.disneyplus.com", "www.hotstar.com"],
+	"url": [
+		"www.disneyplus.com",
+		"www.hotstar.com"
+	],
 	"regExp": "([a-z0-9-]+[.])*disneyplus[.]com[/]|([a-z0-9-]+[.])*hotstar[.]com[/]",
 	"version": "1.4.19",
 	"logo": "https://i.imgur.com/KIZSYhc.png",

--- a/websites/D/Disney+/metadata.json
+++ b/websites/D/Disney+/metadata.json
@@ -19,7 +19,7 @@
 		"da_DK": "Disney+ er det eksklusive hjem for dine yndlingsfilm og -tv-serier fra Disney, Pixar, Marvel, Star Wars, National Geographic og Star. Begynd at se i dag.",
 		"pt_BR": "O Disney+ é o serviço exclusivo para ver os seus filmes e programas preferidos da Disney, Pixar, Marvel, Star Wars e National Geographic. Comece a assistir hoje mesmo."
 	},
-	"url": "www.disneyplus.com",
+	"url": ["www.disneyplus.com", "www.hotstar.com"],
 	"regExp": "([a-z0-9-]+[.])*disneyplus[.]com[/]|([a-z0-9-]+[.])*hotstar[.]com[/]",
 	"version": "1.4.19",
 	"logo": "https://i.imgur.com/KIZSYhc.png",


### PR DESCRIPTION
## Description 
Added `www.hotstar.com` domain. As in India, whenever you try to open the website using `www.disneyplus.com` it redirects to `www.hotstar.com/in` and the presence stops by saying `Browsing...` even if I start watching a video. 

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)
