### PR TITLE
ci: fix chalk error 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "3.0.0",
 	"author": "Timeraa",
 	"license": "MPL-2.0",
+	"type": "module",
 	"scripts": {
 		"lint": "prettier --write . && eslint --fix .",
 		"lint:ci": "prettier --check . && eslint .",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
-		"module": "CommonJS",
+		"module": "ESNext",
+		"moduleResolution": "Node",
 		"target": "ES2022",
 		"removeComments": true,
 		"noEmitOnError": true,

--- a/util/tools/auto/presenceUpdater.ts
+++ b/util/tools/auto/presenceUpdater.ts
@@ -1,7 +1,7 @@
 import "source-map-support/register";
 
 import { transformFileAsync as transform } from "@babel/core";
-import { blue, green, red, yellow } from "chalk";
+import chalk from "chalk";
 import { sync as glob } from "glob";
 import {
 	type AnyBulkWriteOperation,
@@ -67,7 +67,9 @@ const writeJS = (path: string, code: string): void =>
 		});
 		if (result?.code?.length) writeJS(file, result.code);
 		else {
-			console.error(red(`Error. File ${file} was not minified, skipping...`));
+			console.error(
+				chalk.red(`Error. File ${file} was not minified, skipping...`)
+			);
 			appCode = 1;
 		}
 	},
@@ -79,7 +81,9 @@ const writeJS = (path: string, code: string): void =>
 			writeJS(file, result.code);
 			await minify(file);
 		} else {
-			console.error(red(`Error. File ${file} was not polyfilled, skipping...`));
+			console.error(
+				chalk.red(`Error. File ${file} was not polyfilled, skipping...`)
+			);
 			appCode = 1;
 		}
 	},
@@ -115,18 +119,18 @@ const writeJS = (path: string, code: string): void =>
 	main = async (): Promise<void> => {
 		if (!process.env.GITHUB_ACTIONS) {
 			console.log(
-				red(
+				chalk.red(
 					"\nPlease note that this script is ONLY supposed to run on a CI environment"
 				)
 			);
 		}
 
-		console.log(blue("\nFETCHING...\n"));
+		console.log(chalk.blue("\nFETCHING...\n"));
 
 		try {
 			await client.connect();
 		} catch (err) {
-			console.error(red(err.stack || err));
+			console.error(chalk.red(err.stack || err));
 			process.exit(1);
 		}
 
@@ -144,7 +148,7 @@ const writeJS = (path: string, code: string): void =>
 						return [data, pF];
 					} else {
 						console.error(
-							red(
+							chalk.red(
 								`Error. Folder ${pF} does not include a valid metadata file, skipping...`
 							)
 						);
@@ -173,12 +177,13 @@ const writeJS = (path: string, code: string): void =>
 				),
 			dbDiff = outdatedPresences.concat(newPresences);
 
-		console.log(green(`New additions: ${newPresences.length}`));
-		console.log(yellow(`To be updated: ${outdatedPresences.length}`));
-		console.log(red(`To be deleted: ${deletedPresences.length}`));
+		console.log(chalk.green(`New additions: ${newPresences.length}`));
+		console.log(chalk.yellow(`To be updated: ${outdatedPresences.length}`));
+		console.log(chalk.red(`To be deleted: ${deletedPresences.length}`));
 
-		if (dbDiff.length) console.log(blue("\nCOMPILING...\n"));
-		if (dbDiff.length > 5) console.log(yellow("This will take some time..."));
+		if (dbDiff.length) console.log(chalk.blue("\nCOMPILING...\n"));
+		if (dbDiff.length > 5)
+			console.log(chalk.yellow("This will take some time..."));
 
 		const compiledPresences = (
 			await Promise.all(
@@ -275,7 +280,9 @@ const writeJS = (path: string, code: string): void =>
 				newPresenceResult = database.insertMany(newPresenceData);
 				for (const presence of newPresenceData) {
 					console.log(
-						green(`ADD - "${presence.name}" @ ${presence.metadata.version}`)
+						chalk.green(
+							`ADD - "${presence.name}" @ ${presence.metadata.version}`
+						)
 					);
 				}
 			}
@@ -287,7 +294,7 @@ const writeJS = (path: string, code: string): void =>
 				for (const presence of deletedPresences) {
 					if (!presence?.name) continue;
 					console.log(
-						red(`DEL - "${presence.name}" @ ${presence.metadata.version}`)
+						chalk.red(`DEL - "${presence.name}" @ ${presence.metadata.version}`)
 					);
 				}
 			}
@@ -309,7 +316,7 @@ const writeJS = (path: string, code: string): void =>
 					);
 
 					console.log(
-						yellow(
+						chalk.yellow(
 							`UPD - "${presence.name}": ${oldPresence.version} => ${presence.metadata.version}`
 						)
 					);

--- a/util/tools/auto/presenceUpdater.ts
+++ b/util/tools/auto/presenceUpdater.ts
@@ -2,7 +2,7 @@ import "source-map-support/register.js";
 
 import { transformFileAsync as transform } from "@babel/core";
 import chalk from "chalk";
-import { sync as glob } from "glob";
+import globModule from "glob";
 import {
 	type AnyBulkWriteOperation,
 	type BulkWriteResult,
@@ -23,7 +23,8 @@ import {
 
 import { isValidJSON, type Metadata, readFile, readJson } from "../util.js";
 
-const url = process.env.MONGO_URL,
+const { sync: glob } = globModule,
+	url = process.env.MONGO_URL,
 	dbName = "PreMiD",
 	client = new MongoClient(url, { appName: "PreMiD-PresenceUpdater" });
 

--- a/util/tools/auto/presenceUpdater.ts
+++ b/util/tools/auto/presenceUpdater.ts
@@ -1,4 +1,4 @@
-import "source-map-support/register";
+import "source-map-support/register.js";
 
 import { transformFileAsync as transform } from "@babel/core";
 import chalk from "chalk";
@@ -21,7 +21,7 @@ import {
 	getPreEmitDiagnostics,
 } from "typescript";
 
-import { isValidJSON, type Metadata, readFile, readJson } from "../util";
+import { isValidJSON, type Metadata, readFile, readJson } from "../util.js";
 
 const url = process.env.MONGO_URL,
 	dbName = "PreMiD",

--- a/util/tools/auto/schemaValidator.ts
+++ b/util/tools/auto/schemaValidator.ts
@@ -1,4 +1,4 @@
-import "source-map-support/register";
+import "source-map-support/register.js";
 
 import axios from "axios";
 import chalk from "chalk";
@@ -7,7 +7,7 @@ import { validate } from "jsonschema";
 import { existsSync, readFileSync } from "node:fs";
 import { compare, diff } from "semver";
 
-import { createAnnotation, getChangedFolders, type Metadata } from "../util";
+import { createAnnotation, getChangedFolders, type Metadata } from "../util.js";
 
 const latestMetadataSchema = async (): Promise<string[]> => {
 		const versions = (

--- a/util/tools/auto/schemaValidator.ts
+++ b/util/tools/auto/schemaValidator.ts
@@ -1,7 +1,7 @@
 import "source-map-support/register";
 
 import axios from "axios";
-import { blue, green, red, yellow } from "chalk";
+import chalk from "chalk";
 import ParseJSON, { ObjectNode } from "json-to-ast";
 import { validate } from "jsonschema";
 import { existsSync, readFileSync } from "node:fs";
@@ -72,16 +72,16 @@ const latestMetadataSchema = async (): Promise<string[]> => {
 		}
 	},
 	validated = (service: string): void => {
-		console.log(green(`✔ ${service}`));
+		console.log(chalk.green(`✔ ${service}`));
 		stats.validated++;
 	},
 	validatedWithWarnings = (service: string, warning: string): void => {
-		console.log(yellow(`✔ ${service}`));
+		console.log(chalk.yellow(`✔ ${service}`));
 		console.log(warning);
 		stats.validatedWithWarnings++;
 	},
 	failedToValidate = (service: string, errors: string[]): void => {
-		console.log(`::group::${red(`✖ ${service}`)}`);
+		console.log(`::group::${chalk.red(`✖ ${service}`)}`);
 		console.log(errors.join("\n"));
 		console.log("::endgroup::");
 		stats.failedToValidate++;
@@ -96,7 +96,7 @@ const latestMetadataSchema = async (): Promise<string[]> => {
 	};
 
 (async (): Promise<void> => {
-	console.log(blue("Getting changed files..."));
+	console.log(chalk.blue("Getting changed files..."));
 
 	const changedFolders = await getChangedFolders().then(f =>
 			f
@@ -105,18 +105,20 @@ const latestMetadataSchema = async (): Promise<string[]> => {
 		),
 		changedMetaFiles = changedFolders.map(p => (p += "/metadata.json"));
 
-	console.log(blue("Getting latest schema..."));
+	console.log(chalk.blue("Getting latest schema..."));
 
 	const [latestSchema, latestSchemaVersion] = await latestMetadataSchema(),
 		schema = (await axios.get(latestSchema)).data;
 
 	if (!changedMetaFiles.length) {
-		console.log(blue("There are no presences to validate, exiting..."));
+		console.log(chalk.blue("There are no presences to validate, exiting..."));
 		process.exit(0);
 	}
 
 	console.log(
-		blue(`Beginning validation of ${changedMetaFiles.length} presences...`)
+		chalk.blue(
+			`Beginning validation of ${changedMetaFiles.length} presences...`
+		)
 	);
 
 	for (const [index, metaFile] of changedMetaFiles.entries()) {
@@ -334,21 +336,25 @@ const latestMetadataSchema = async (): Promise<string[]> => {
 	}
 
 	console.log();
-	console.log(blue("Statistics:"));
+	console.log(chalk.blue("Statistics:"));
 	console.log(
-		green(`${stats.validated} fully validated\n`) +
-			yellow(`${stats.validatedWithWarnings} validated, but with warnings\n`) +
-			red(`${stats.failedToValidate} failed to validate`)
+		chalk.green(`${stats.validated} fully validated\n`) +
+			chalk.yellow(
+				`${stats.validatedWithWarnings} validated, but with warnings\n`
+			) +
+			chalk.red(`${stats.failedToValidate} failed to validate`)
 	);
 	console.log();
 
 	if (stats.failedToValidate > 0) {
-		console.log(red("One or more services failed to validate."));
+		console.log(chalk.red("One or more services failed to validate."));
 		process.exit(-1);
 	}
 
 	if (stats.validatedWithWarnings > 0)
-		console.log(yellow("One or more services validated, but with warnings."));
+		console.log(
+			chalk.yellow("One or more services validated, but with warnings.")
+		);
 })();
 
 type key = keyof Metadata;

--- a/util/tools/bumpChanged.ts
+++ b/util/tools/bumpChanged.ts
@@ -1,11 +1,11 @@
-import "source-map-support/register";
+import "source-map-support/register.js";
 
 import axios from "axios";
 import debug from "debug";
 import { join, normalize, resolve, sep } from "node:path";
 import { coerce, inc } from "semver";
 
-import { getChangedFolders, readJson, writeJson } from "./util";
+import { getChangedFolders, readJson, writeJson } from "./util.js";
 
 const log = debug("BumpChanged");
 debug.enable("BumpChanged*");

--- a/util/tools/compileChanged.ts
+++ b/util/tools/compileChanged.ts
@@ -1,7 +1,7 @@
-import "source-map-support/register";
+import "source-map-support/register.js";
 
 import chalk from "chalk";
-import { createAnnotation, execShellCommand, getChangedFolders } from "./util";
+import { createAnnotation, execShellCommand, getChangedFolders } from "./util.js";
 import { rm, writeFile } from "fs/promises";
 import { resolve } from "path";
 

--- a/util/tools/compileChanged.ts
+++ b/util/tools/compileChanged.ts
@@ -1,7 +1,11 @@
 import "source-map-support/register.js";
 
 import chalk from "chalk";
-import { createAnnotation, execShellCommand, getChangedFolders } from "./util.js";
+import {
+	createAnnotation,
+	execShellCommand,
+	getChangedFolders,
+} from "./util.js";
 import { rm, writeFile } from "fs/promises";
 import { resolve } from "path";
 

--- a/util/tools/compileChanged.ts
+++ b/util/tools/compileChanged.ts
@@ -1,6 +1,6 @@
 import "source-map-support/register";
 
-import { green, red } from "chalk";
+import chalk from "chalk";
 import { createAnnotation, execShellCommand, getChangedFolders } from "./util";
 import { rm, writeFile } from "fs/promises";
 import { resolve } from "path";
@@ -13,7 +13,7 @@ async function main() {
 	await compileFile(0);
 	const presenceErrors = Object.keys(errors).length;
 	if (presenceErrors) console.log(errors.join("\n"));
-	else console.log(green("✔ All presences compiled successfully!"));
+	else console.log(chalk.green("✔ All presences compiled successfully!"));
 
 	async function compileFile(i: number): Promise<void> {
 		if (!changedFolders[i]) return;
@@ -31,7 +31,9 @@ async function main() {
 			await rm(resolve(changedFolders[i], "tsconfig.json"));
 
 			console.log(
-				green(`✔ Successfully compiled ${changedFolders[i].split("/").at(-1)}`)
+				chalk.green(
+					`✔ Successfully compiled ${changedFolders[i].split("/").at(-1)}`
+				)
 			);
 		} catch (err) {
 			const error = (err.stderr || err.stdout || "Couldn't find error")
@@ -66,7 +68,7 @@ async function main() {
 				});
 
 			console.error(
-				red(`✘ Error on ${changedFolders[i].split("/").at(-1)}:\n`),
+				chalk.red(`✘ Error on ${changedFolders[i].split("/").at(-1)}:\n`),
 				error
 			);
 		} finally {

--- a/util/tools/massVer.ts
+++ b/util/tools/massVer.ts
@@ -1,6 +1,6 @@
 import "source-map-support/register.js";
 
-import { sync as glob } from "glob";
+import globModule from "glob";
 import { existsSync as exists } from "node:fs";
 import { coerce, inc, valid } from "semver";
 
@@ -12,7 +12,8 @@ import { isValidJSON, type Metadata, readFile, writeJson } from "./util.js";
     REQUEST UNLESS YOU'VE BEEN EXPLICITLY INSTRUCTED BY
     A DEV TO DO SO, WHICH WILL MOST LIKELY NEVER HAPPEN.  */
 
-const missingMetadata: string[] = glob("./{websites,programs}/*/*/").filter(
+const { sync: glob } = globModule,
+	missingMetadata: string[] = glob("./{websites,programs}/*/*/").filter(
 		pF => !exists(`${pF}/metadata.json`)
 	),
 	allmeta: Array<[Metadata, string]> = glob(

--- a/util/tools/massVer.ts
+++ b/util/tools/massVer.ts
@@ -1,10 +1,10 @@
-import "source-map-support/register";
+import "source-map-support/register.js";
 
 import { sync as glob } from "glob";
 import { existsSync as exists } from "node:fs";
 import { coerce, inc, valid } from "semver";
 
-import { isValidJSON, type Metadata, readFile, writeJson } from "./util";
+import { isValidJSON, type Metadata, readFile, writeJson } from "./util.js";
 
 /*  NOTE: THIS IS A TOOL THAT IS ONLY MEANT TO BE USED
     BY THE DEVS AND REVIEWERS FOR DEPLOYMENT PURPOSES,

--- a/util/tools/metadataSorter.ts
+++ b/util/tools/metadataSorter.ts
@@ -1,12 +1,13 @@
 import "source-map-support/register.js";
 
 import axios from "axios";
-import { sync as glob } from "glob";
+import globModule from "glob";
 import { existsSync as exists } from "node:fs";
 
 import { isValidJSON, type Metadata, readFile, writeJson } from "./util.js";
 
-const missingMetadata: string[] = glob("./{websites,programs}/*/*/").filter(
+const { sync: glob } = globModule,
+	missingMetadata: string[] = glob("./{websites,programs}/*/*/").filter(
 		pF => !exists(`${pF}/metadata.json`)
 	),
 	allmeta: [Metadata, string][] = glob(

--- a/util/tools/metadataSorter.ts
+++ b/util/tools/metadataSorter.ts
@@ -1,10 +1,10 @@
-import "source-map-support/register";
+import "source-map-support/register.js";
 
 import axios from "axios";
 import { sync as glob } from "glob";
 import { existsSync as exists } from "node:fs";
 
-import { isValidJSON, type Metadata, readFile, writeJson } from "./util";
+import { isValidJSON, type Metadata, readFile, writeJson } from "./util.js";
 
 const missingMetadata: string[] = glob("./{websites,programs}/*/*/").filter(
 		pF => !exists(`${pF}/metadata.json`)


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
This PR fixes CI.
* Uses chalk 5 syntax
* Converts type to `module` to enable the use of import in compiled js
* Changes `compilerOptions.module` to `esnext` to generate code using import

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)