### PR TITLE
chore: delete codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,0 @@
-@types/** @PreMiD/administrators @PreMiD/presence-verifiers
-.eslintrc.json @PreMiD/administrators @PreMiD/presence-verifiers
-.github/CODEOWNERS @PreMiD/administrators
-.github/CONTRIBUTING.md @PreMiD/administrators @PreMiD/presence-verifiers
-util/tools/translator.ts @PreMiD/presence-verifiers
-util/tools/auto/** @PreMiD/presence-verifiers


### PR DESCRIPTION
Signed-off-by: Rhys Rakoff <64903135+EncryptedDev@users.noreply.github.com>

CODEOWNERs are not needed on this repo because we have a different process of requesting reviews by maintainers to reduce crossover