### PR TITLE
chore(renovate): update config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,5 +4,6 @@
 	"automerge": false,
 	"semanticCommits": "enabled",
 	"configWarningReuseIssue": false,
+	"schedule": ["0 0 * * 0"],
 	"stabilityDays": 3
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,6 @@
 	"automerge": false,
 	"semanticCommits": "enabled",
 	"configWarningReuseIssue": false,
-	"schedule": ["0 17 * * FRI"],
+	"schedule": ["0 17 * * 5"],
 	"stabilityDays": 3
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,7 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["github>Recodive/Configs:renovate-config"],
-	"automerge": false
+	"addLabels": ["dependencies"],
+	"automerge": false,
+	"semanticCommits": "enabled",
+	"stabilityDays": 3
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,6 @@
 	"addLabels": ["dependencies"],
 	"automerge": false,
 	"semanticCommits": "enabled",
+	"configWarningReuseIssue": false,
 	"stabilityDays": 3
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,6 @@
 	"automerge": false,
 	"semanticCommits": "enabled",
 	"configWarningReuseIssue": false,
-	"schedule": ["0 0 * * 0"],
+	"schedule": ["0 17 * * FRI"],
 	"stabilityDays": 3
 }


### PR DESCRIPTION
## Description

The [PreMiD/Presences](https://github.com/PreMiD/Presences) repository works as an independent repository from the rest of the project and company repositories due to the contributing differences, hence why the config should not be an extension of the company's config. Furthermore, the reason for changing the config settings are below: 
- Removed `reviewers` and `assigneesFromCodeowners` due to what was explained in #6900 
- Disable `automerge` indefinitely in order to ensure reviewers know the dependency changes and the impact they may have-
	- Security patches shouldn't be an issue here because this is a _Presence repository_
	- Reviewers check this repository daily, if not more often so dependency PRs won't be ignored
- Added a `schedule` ([docs](https://docs.renovatebot.com/configuration-options/#schedule)) for “At 00:00 on Sunday.” as there is no dying need to have dependencies perfectly up to date on a repo which is nondependent on dependencies

`stabilityDays`, `semanticCommits`, `configWarningReuseIssue`, `addLabels` remain the same as [Recodive/Configs](https://github.com/Recodive/Configs)
