### PR TITLE
feat(Desu-Online): fix for episode title

### DIFF
--- a/websites/D/Desu-Online/metadata.json
+++ b/websites/D/Desu-Online/metadata.json
@@ -10,7 +10,7 @@
 		"pl": "Najlepsza strona z anime online pl! Anime z polskimi napisami w doskonałej jakości i bez reklam! Najlepsze odtwarzacze video."
 	},
 	"url": "desu-online.pl",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"logo": "https://i.imgur.com/KEkxfKO.png",
 	"thumbnail": "https://i.imgur.com/3XMqlXE.png",
 	"color": "#D9910F",

--- a/websites/D/Desu-Online/presence.ts
+++ b/websites/D/Desu-Online/presence.ts
@@ -127,8 +127,14 @@ presence.on("UpdateData", async () => {
 			.querySelector("li.selected > a > div.playinfo > span")
 			.textContent.split("-");
 		presenceData.state = `Odcinek:${playinfo[0].replace("Odc", "")}`;
-		if (playinfo.length > 2)
-			presenceData.state += ` - "${playinfo[1].slice(1, -1)}"`;
+		if (playinfo.length > 2) {
+			let episodetitle = "";
+			for (let i = 0; i < playinfo.length; i++) {
+				if (i !== 0 && i !== playinfo.length - 1)
+					episodetitle += `${playinfo[i]}-`;
+			}
+			presenceData.state += ` - "${episodetitle.slice(1, -2)}"`;
+		}
 		presenceData.buttons = [
 			{ label: "Oglądaj", url: document.URL },
 			{

--- a/websites/D/Desu-Online/presence.ts
+++ b/websites/D/Desu-Online/presence.ts
@@ -128,12 +128,11 @@ presence.on("UpdateData", async () => {
 			.textContent.split("-");
 		presenceData.state = `Odcinek:${playinfo[0].replace("Odc", "")}`;
 		if (playinfo.length > 2) {
-			let episodetitle = "";
-			for (let i = 0; i < playinfo.length; i++) {
-				if (i !== 0 && i !== playinfo.length - 1)
-					episodetitle += `${playinfo[i]}-`;
-			}
-			presenceData.state += ` - "${episodetitle.slice(1, -2)}"`;
+			presenceData.state += ` - "${document
+				.querySelector("li.selected > a > div.playinfo > span")
+				.textContent.match(/-.*-/gm)
+				.toString()
+				.slice(2, -2)}"`;
 		}
 		presenceData.buttons = [
 			{ label: "Oglądaj", url: document.URL },


### PR DESCRIPTION
## Description 
* If the episode title had a `-` character, it only displayed the first title segment before the `-` character in the status. This commit fixes that

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![obraz_2022-10-17_183647391](https://user-images.githubusercontent.com/42370647/196233980-3c8f2c7b-0ddd-4f30-b06a-ff9940d749d1.png)

</details>