### PR TITLE
fix(Soundcloud): startTimestamp & prevURL broke presence on brave

### DIFF
--- a/websites/S/SoundCloud/metadata.json
+++ b/websites/S/SoundCloud/metadata.json
@@ -26,7 +26,7 @@
 		"vi_VN": "SoundCloud là nền tảng phát nhạc và podcast trực tuyến nơi bạn có thể nghe hàng triệu bài hát từ khắp thế giới, hoặc tự đăng tải tác phẩm của riêng mình."
 	},
 	"url": "soundcloud.com",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"logo": "https://i.imgur.com/KgOkfIz.png",
 	"thumbnail": "https://i.imgur.com/eZyrvbS.jpg",
 	"color": "#FF7E30",

--- a/websites/S/SoundCloud/presence.ts
+++ b/websites/S/SoundCloud/presence.ts
@@ -26,11 +26,10 @@ const presence = new Presence({
 	},
 	capitalize = (text: string): string => {
 		return text.charAt(0).toUpperCase() + text.slice(1);
-	};
+	},
+	elapsed = Math.floor(Date.now() / 1000);
 
-let elapsed = Math.floor(Date.now() / 1000),
-	prevUrl = document.location.href,
-	strings: Awaited<ReturnType<typeof getStrings>>,
+let strings: Awaited<ReturnType<typeof getStrings>>,
 	oldLang: string = null;
 
 const statics = {
@@ -132,11 +131,6 @@ presence.on("UpdateData", async () => {
 		largeImageKey: "soundcloud",
 		startTimestamp: elapsed,
 	};
-
-	if (document.location.href !== prevUrl) {
-		prevUrl = document.location.href;
-		elapsed = Math.floor(Date.now() / 1000);
-	}
 
 	if ((playing || (!playing && !showBrowsing)) && showSong) {
 		presenceData.details = getElement(


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
The let use of previous url and elapsedTimestamp break the presence for Brave.

## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img src="https://user-images.githubusercontent.com/42322979/197511478-c248e48a-47f6-42b1-8b26-b01c91b4045c.png">



</details>
