### PR TITLE
chore: set moduleResolution to nodenext

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"module": "ESNext",
-		"moduleResolution": "node",
+		"moduleResolution": "nodenext",
 		"target": "ES2022",
 		"removeComments": true,
 		"noEmitOnError": true,


### PR DESCRIPTION
Ref: https://www.typescriptlang.org/tsconfig#moduleResolution

## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

turns out module esnext needs this I think?