### PR TITLE
fix(presenceUpdater): use api types in compiler options

### DIFF
--- a/util/tools/auto/presenceUpdater.ts
+++ b/util/tools/auto/presenceUpdater.ts
@@ -17,8 +17,12 @@ import { valid } from "semver";
 import { minify as terser } from "terser";
 import typescript from "typescript";
 import { type CompilerOptions } from "typescript";
-const { createProgram, flattenDiagnosticMessageText, getPreEmitDiagnostics } =
-	typescript;
+const {
+	createProgram,
+	flattenDiagnosticMessageText,
+	getPreEmitDiagnostics,
+	ModuleResolutionKind,
+} = typescript;
 
 import { isValidJSON, type Metadata, readFile, readJson } from "../util.js";
 
@@ -37,6 +41,16 @@ const writeJS = (path: string, code: string): void =>
 		fileNames: string[],
 		options: CompilerOptions
 	): Promise<void> => {
+		if (typeof options.moduleResolution === "string") {
+			options.moduleResolution =
+				ModuleResolutionKind[
+					Object.keys(ModuleResolutionKind).find(
+						key =>
+							key.toLowerCase() ===
+							(options.moduleResolution as unknown as string).toLowerCase()
+					) as keyof typeof ModuleResolutionKind
+				];
+		}
 		const program = createProgram(fileNames, options),
 			emitResult = program.emit(),
 			allDiagnostics = getPreEmitDiagnostics(program).concat(


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
* Should fix compilation of presences.
* See https://github.com/microsoft/TypeScript/issues/23564#issuecomment-383092947

## Acknowledgements
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)