### PR TITLE
chore: bump presences to update store versions

### DIFF
--- a/websites/0-9/9anime/metadata.json
+++ b/websites/0-9/9anime/metadata.json
@@ -15,7 +15,7 @@
 	},
 	"url": "9anime.to",
 	"regExp": "([a-z0-9-]+[.])?(9anime[.][a-z]+)",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"logo": "https://i.imgur.com/jPl7EfZ.png",
 	"thumbnail": "https://i.imgur.com/RIGfshD.png",
 	"color": "#694ba1",

--- a/websites/B/Buienalarm/metadata.json
+++ b/websites/B/Buienalarm/metadata.json
@@ -10,7 +10,7 @@
 		"nl": "Direct zien wanneer en hoeveel neerslag er gaat vallen? Stel de gewenste locatie in en volg het in de grafiek, de buien radar en check de weersverwachting."
 	},
 	"url": "www.buienalarm.nl",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"logo": "https://i.imgur.com/R29E1DX.png",
 	"thumbnail": "https://i.imgur.com/TPno0Cc.png",
 	"color": "#2a59b5",

--- a/websites/D/Desu-Online/metadata.json
+++ b/websites/D/Desu-Online/metadata.json
@@ -10,7 +10,7 @@
 		"pl": "Najlepsza strona z anime online pl! Anime z polskimi napisami w doskonałej jakości i bez reklam! Najlepsze odtwarzacze video."
 	},
 	"url": "desu-online.pl",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"logo": "https://i.imgur.com/KEkxfKO.png",
 	"thumbnail": "https://i.imgur.com/3XMqlXE.png",
 	"color": "#D9910F",

--- a/websites/M/myCANAL/metadata.json
+++ b/websites/M/myCANAL/metadata.json
@@ -21,7 +21,7 @@
 		"nl": "Canal + is een Franse abonnementsaanbieder die is gekoppeld aan het kanaal met dezelfde naam. Het is eigendom van Vivendi met een aandeel van honderd procent."
 	},
 	"url": "www.canalplus.com",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"logo": "https://i.imgur.com/H3IXznl.png",
 	"thumbnail": "https://i.imgur.com/xRKwqvI.png",
 	"color": "#000",

--- a/websites/R/RTL+/metadata.json
+++ b/websites/R/RTL+/metadata.json
@@ -17,7 +17,7 @@
 		"de": "RTL+ bietet Dir spannende Filme und Serien. Auch viele Shows und Dokus sind im Online-Stream zu finden! Deine Lieblingssendung jetzt online anschauen!"
 	},
 	"url": "www.tvnow.de",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"logo": "https://i.imgur.com/fMMsZfV.png",
 	"thumbnail": "https://i.imgur.com/ciqmYEY.jpg",
 	"color": "#ffbc2d",

--- a/websites/S/Shikimori/metadata.json
+++ b/websites/S/Shikimori/metadata.json
@@ -10,7 +10,7 @@
 		"ru": "Шикимори — онлайн энциклопедия аниме и манги. Полный список популярной манги на русском. Shikimori.one — лучший аниме-форум для общения."
 	},
 	"url": "shikimori.one",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"logo": "https://i.imgur.com/7tlc7or.png",
 	"thumbnail": "https://i.imgur.com/jS5LyDW.png",
 	"color": "#4f4f4f",

--- a/websites/S/Shoob/metadata.json
+++ b/websites/S/Shoob/metadata.json
@@ -27,7 +27,7 @@
 		"vi_VN": "Bot Waifu ?! Game bài Anime của Anime Soul Discord! Kết nối với tất cả cộng đồng Anime ngay hôm nay!"
 	},
 	"url": "shoob.gg",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"logo": "https://i.imgur.com/aI1Qn8s.png",
 	"thumbnail": "https://i.imgur.com/9uCvSeC.png",
 	"color": "#da9c72",

--- a/websites/S/Stake/metadata.json
+++ b/websites/S/Stake/metadata.json
@@ -10,7 +10,7 @@
 		"de": "Stake.com ist die führende online Krypto-Casino und Sportwetten-Plattform."
 	},
 	"url": "stake.com",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"logo": "https://i.imgur.com/D4d2JSH.png",
 	"thumbnail": "https://i.imgur.com/ttxjIJA.png",
 	"color": "#1a2c3a",

--- a/websites/S/SteamDB/metadata.json
+++ b/websites/S/SteamDB/metadata.json
@@ -22,7 +22,7 @@
 		"steamdb.info",
 		"steamstat.us"
 	],
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"logo": "https://i.imgur.com/QUPRec4.png",
 	"thumbnail": "https://i.imgur.com/Unwz9QQ.png",
 	"color": "#3871C8",

--- a/websites/V/Videoland/metadata.json
+++ b/websites/V/Videoland/metadata.json
@@ -15,7 +15,7 @@
 		"videoland.com",
 		"www.videoland.com"
 	],
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"logo": "https://i.imgur.com/eq7dxH3.png",
 	"thumbnail": "https://i.imgur.com/E9XoF0u.png",
 	"color": "#FF3746",


### PR DESCRIPTION
## Description 
This Pull Request bumps the version on a few presences which were merged when the `CD`/`DePloY`/`Update Presences` action began to fail. 
|  Presence  | Displayed Version  | Original PR Version   | Bumped Version  | PR Reference  |
|---|---|---|---|---|
| Buienalarm  | New Presence  | `1.0.0`  | `1.0.1`  | #6874  |
| Stake  | New Presence   | `1.0.0`  | `1.0.1`  | #6875   |
| SteamDB  | `1.0.10`   | `1.1.0`  | `1.1.1`  | #6908 |
| VideoLand | `1.1.0` | `1.2.0`| `1.2.1` | #6912
| Desu-Online | `1.0.0`| `1.0.1` | `1.0.2` | #6913
| 9anime | `1.3.1` | `1.4.0` | `1.4.1` | #6935
| myCANAL | `1.2.1` | `2.0.0` | `2.0.1` | #6895
| TVNOW  | Deleted | N/A | N/A | #6928 
| RTL+ | New Presence | `1.0.0` | `1.0.1` | #6928 
| Shikimori | `1.0.3` |`1.1.0` | `1.1.1` | #6921
| Shoob | New Presence | `1.0.0` | `1.0.1` |  #6891 

where *Presence* is the service name, *Displayed Version* is the version availiable on the store (if applicable), *Original PR Version* is the version the Presence was bumped to in the referenced PR, *Bumped Version* is the version this PR is bumping the Presence to in order for `UpdatePresences` to recognise the change and *PR Reference* is the reference to the PR where the change was first proposed.

I've double checked all PRs merged since October 16, where CI first started to fail. 

