### PR TITLE
chore: remove ci on push

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,9 +1,5 @@
 name: Compile and Lint
-on:
-  push:
-    branches:
-      - "main"
-  pull_request:
+on: [pull_request]
 jobs:
   compileLint:
     name: Compile and Lint


### PR DESCRIPTION
This PR disables CI that would happen on the Push event, reason being that a PR already runs CI and when CI would fail on that PR the PR should not be accepted in normal circumstances. It's just double trouble for the same result.