### PR TITLE
fix(CD): add an empty line after sourcemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"json-to-ast": "2.1.0",
 		"jsonschema": "1.4.1",
 		"mongodb": "4.11.0",
-		"pmd": "github:PreMiD/pmd#1.0.4",
+		"pmd": "github:PreMiD/pmd#1.1.1",
 		"semver": "7.3.8",
 		"ts-loader": "9.4.1",
 		"typescript": "4.8.4",

--- a/tools/classes/PresenceCompiler.ts
+++ b/tools/classes/PresenceCompiler.ts
@@ -62,6 +62,19 @@ export default class PresenceCompiler {
 						filename: "[name].js",
 				  }
 				: undefined,
+			plugins: [
+				{
+					apply(compiler) {
+						compiler.hooks.emit.tap("PresenceCompiler", compilation => {
+							//* Add empty line after file content to prevent errors from PreMiD
+							for (const file in compilation.assets) {
+								//@ts-expect-error - This is defined. (ConcatSource class)
+								compilation.assets[file].add("\n");
+							}
+						});
+					},
+				},
+			],
 			module: {
 				rules: [
 					{

--- a/tools/util.ts
+++ b/tools/util.ts
@@ -4,7 +4,7 @@ import { basename, dirname, extname } from "node:path";
 import actions from "@actions/core";
 import got from "got";
 
-export type ValidEventName = "push" | "pull_request";
+export type ValidEventName = "push" | "pull_request" | "uncommitted";
 
 export function getDiff(
 	type: "addedModified" | "removed" | "all" = "addedModified"
@@ -12,6 +12,7 @@ export function getDiff(
 	const commands: Record<ValidEventName, string> = {
 			push: "HEAD HEAD^",
 			pull_request: `HEAD origin/${process.argv[3] ? process.argv[3] : "main"}`,
+			uncommitted: "HEAD",
 		},
 		eventName = process.argv[2] ? validateArg(process.argv[2]) : "pull_request",
 		changedPresenceFolders = execSync(
@@ -35,7 +36,7 @@ export function getDiff(
 }
 
 function validateArg(arg: string): ValidEventName {
-	if (!["push", "pull_request"].includes(arg))
+	if (!["push", "pull_request", "uncommitted"].includes(arg))
 		throw new Error(`CI was not called with a valid event name: ${arg}`);
 	return arg as ValidEventName;
 }


### PR DESCRIPTION
This PR addresses the issue mentioned by @theusaf in #6923 and solves it by adding an empty line after the compiled file:
![image](https://user-images.githubusercontent.com/29104008/198997669-b29f8bc6-7233-481a-8942-b3fedbbb2545.png)

This PR also adds back the uncommitted "event option" as this makes running the script locally for testing/development possible.