### PR TITLE
fix(presenceUpdater): correctly detect changed folders

### DIFF
--- a/tools/auto/presenceUpdater.ts
+++ b/tools/auto/presenceUpdater.ts
@@ -96,17 +96,19 @@ for (const presenceFolderName of changedPresenceFolders) {
 	});
 }
 
-await collection!.bulkWrite(
-	dbPresences.map(p => ({
-		updateOne: {
-			filter: { name: p.name },
-			update: {
-				$set: p,
+if (dbPresences.length) {
+	await collection!.bulkWrite(
+		dbPresences.map(p => ({
+			updateOne: {
+				filter: { name: p.name },
+				update: {
+					$set: p,
+				},
+				upsert: true,
 			},
-			upsert: true,
-		},
-	}))
-);
+		}))
+	);
+}
 
 const deletedPresences = getDiff("removed");
 if (deletedPresences.length) {

--- a/tools/util.ts
+++ b/tools/util.ts
@@ -10,8 +10,8 @@ export function getDiff(
 	type: "addedModified" | "removed" | "all" = "addedModified"
 ): string[] {
 	const commands: Record<ValidEventName, string> = {
-			push: "HEAD HEAD^",
-			pull_request: `HEAD origin/${process.argv[3] ? process.argv[3] : "main"}`,
+			push: "HEAD^ HEAD",
+			pull_request: `origin/${process.argv[3] ? process.argv[3] : "main"} HEAD`,
 			uncommitted: "HEAD",
 		},
 		eventName = process.argv[2] ? validateArg(process.argv[2]) : "pull_request",


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
* Corrects the order of sources in getting diffs
  * Allows new presences to be detected and uploaded
  * Allows deleted presences to be detected and deleted
* Adds a check for changed presences before writing
  * Avoids preventing a presence from being deleted

## Acknowledgements
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)