### PR TITLE
feat(Yandex): add presence

### DIFF
--- a/websites/Y/Yandex/metadata.json
+++ b/websites/Y/Yandex/metadata.json
@@ -1,0 +1,48 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.7",
+	"author": {
+		"id": "257151906038677504",
+		"name": "SHISEN"
+	},
+	"service": "Yandex",
+	"description": {
+		"en": "Yandex is a search engine that can be employed to find a variety of information such as websites, pictures, maps.",
+		"ru": "Яндекс — это поисковая система, которую можно использовать для поиска разнообразной информации, такой как веб-сайты, изображения, карты."
+	},
+	"url": [
+		"ya.ru",
+		"yandex.ru"
+	],
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/SFXKtLF.png",
+	"thumbnail": "https://i.imgur.com/hHxU0xz.png",
+	"color": "#ff3333",
+	"category": "other",
+	"tags": [
+		"search",
+		"yandex"
+	],
+	"settings": [
+		{
+			"id": "privacy",
+			"title": "Приватный режим",
+			"icon": "fad fa-user-secret",
+			"value": false
+		},
+		{
+			"id": "logo",
+			"if": {
+				"privacy": false
+			},
+			"title": "Показывать картинки в поиске",
+			"icon": "fad fa-images",
+			"value": true
+		},
+		{
+			"id": "time",
+			"title": "Показывать время",
+			"icon": "fad fa-stopwatch",
+			"value": true
+		}
+	]
+}

--- a/websites/Y/Yandex/presence.ts
+++ b/websites/Y/Yandex/presence.ts
@@ -1,0 +1,125 @@
+const presence = new Presence({
+		clientId: "1035433850593095740",
+	}),
+	browsingTimestamp = Math.floor(Date.now() / 1000),
+	homepageInput =
+		document.querySelector<HTMLInputElement>('input[name="text"]'),
+	{ host, pathname } = document.location;
+
+let strings: Awaited<ReturnType<typeof getStrings>>;
+
+enum Assets {
+	search = "https://i.imgur.com/wYVlwJX.png",
+	view = "https://i.imgur.com/hxvvGUi.png",
+}
+
+async function getStrings() {
+	return presence.getStrings({
+		search: "general.search",
+		view: "general.viewing",
+	});
+}
+
+function textContent(tags: string) {
+	return document.querySelector(tags)?.textContent;
+}
+
+presence.on("UpdateData", async () => {
+	if (!strings) strings = await getStrings();
+
+	const presenceData: PresenceData = {
+			largeImageKey: "https://i.imgur.com/SFXKtLF.png",
+			startTimestamp: browsingTimestamp,
+		},
+		[privacy, logo, time] = await Promise.all([
+			presence.getSetting<boolean>("privacy"),
+			presence.getSetting<boolean>("logo"),
+			presence.getSetting<boolean>("time"),
+		]);
+
+	switch (host) {
+		case "ya.ru":
+			presenceData.details = "На главной странице";
+			if (homepageInput?.value !== "") {
+				presenceData.state = `Будет искать: ${homepageInput?.value}`;
+				presenceData.smallImageKey = Assets.search;
+				presenceData.smallImageText = strings.search;
+			}
+			break;
+
+		case "yandex.ru":
+			presenceData.smallImageKey = Assets.search;
+			presenceData.smallImageText = strings.search;
+			switch (pathname.split("/")[1]) {
+				case "search":
+					presenceData.details = `В поиске: ${
+						!privacy ? homepageInput?.value : ""
+					}`;
+					presenceData.state = textContent(".serp-adv__found");
+					break;
+
+				case "images":
+					presenceData.details = "Яндекс Картинки";
+					presenceData.state = `В поиске: ${homepageInput?.value}`;
+					if (document.querySelector(".CbirPreview-Preview")) {
+						presenceData.state = "В поиске по картинке";
+						if (logo && !privacy) {
+							presenceData.largeImageKey =
+								document.querySelector<HTMLImageElement>(
+									"img.CbirPreview-Image"
+								)?.src;
+						}
+					}
+					break;
+
+				case "video":
+					presenceData.details = "Яндекс Видео";
+					presenceData.state = `В поиске: ${homepageInput?.value}`;
+					break;
+
+				case "maps":
+					presenceData.details = "Яндекс Карты";
+					presenceData.state = presenceData.state = `В поиске: ${
+						document.querySelector<HTMLInputElement>("input")?.value
+					}`;
+					break;
+
+				case "products":
+					presenceData.details = "Яндекс Маркет";
+					presenceData.state = `В поиске: ${homepageInput?.value}`;
+					break;
+
+				case "blogs":
+					presenceData.details = "Яндекс Блоги";
+					presenceData.state = `В поиске: ${homepageInput?.value}`;
+					break;
+
+				case "pogoda":
+					presenceData.details = "Смотрит погоду";
+					presenceData.state = document
+						.querySelector<HTMLTitleElement>("title")
+						.textContent.replace(" — Яндекс.Погода", "");
+					presenceData.smallImageKey = Assets.view;
+					presenceData.smallImageText = strings.view;
+					break;
+
+				case "collections":
+					presenceData.details = "Смотрит избранное";
+					presenceData.state = document.querySelector(
+						".cl-cards-type-filter__button_active"
+					)?.firstChild?.textContent;
+					if (document.querySelector(".cl-board-header-title__name")) {
+						presenceData.details = "Смотрит папку в избранном";
+						presenceData.state = document.querySelector(
+							".cl-board-header-title__name"
+						)?.textContent;
+					}
+					break;
+			}
+			break;
+	}
+
+	if (!time) delete presenceData.startTimestamp;
+	if (privacy) delete presenceData.state;
+	presence.setActivity(presenceData);
+});


### PR DESCRIPTION
## Description 
Add presence for Yandex

Options:
1. Privacy.
2. Show images in search (2,3 screenshots).
3. Show timestamps.

## Acknowledgements
- [ ] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [ ] I linted the code by running `yarn format`
- [ ] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://user-images.githubusercontent.com/37224822/201493814-369b3556-3861-4550-949e-9f9b457fae32.png)
![image](https://user-images.githubusercontent.com/37224822/201493829-1911f8be-e9c9-4f05-80d4-d581ade1db66.png)
![image](https://user-images.githubusercontent.com/37224822/201493781-05e91929-77a1-4328-9039-0612942d322f.png)
![image](https://user-images.githubusercontent.com/37224822/201493879-b95a6d8d-44bd-4c9f-b20e-e80eaf40af3b.png)
![image](https://user-images.githubusercontent.com/37224822/201493940-91975d3c-974e-497e-b632-2ea80dece1d3.png)

</details>