### PR TITLE
chore: set core.quotePath to false on getDiff()

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,8 +21,6 @@ jobs:
       - name: Install dependencies
         run: HUSKY=0 npm ci
       - name: Compile changed files
-        run: |
-          git config --global core.quotePath false
-          npm run compile ${{ github.event_name }} $GITHUB_BASE_REF
+        run: npm run compile ${{ github.event_name }} $GITHUB_BASE_REF
       - name: Check Lint
         run: npm run lint:ci

--- a/tools/util.ts
+++ b/tools/util.ts
@@ -16,7 +16,7 @@ export function getDiff(
 		},
 		eventName = process.argv[2] ? validateArg(process.argv[2]) : "pull_request",
 		changedPresenceFolders = execSync(
-			`git --no-pager diff --name-only --diff-filter=${
+			`git -c core.quotePath=false --no-pager diff --name-only --diff-filter=${
 				type === "addedModified"
 					? "ACMRTU"
 					: type === "removed"


### PR DESCRIPTION
By default, git will print non-ASCII file names in quoted octal notation, and this disabled that.

![image](https://user-images.githubusercontent.com/54318514/201515804-30206332-5429-4bb0-ae04-521a6c739fff.png)
