### PR TITLE
chore: fix invalid renovate cron

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,6 @@
 	"automerge": false,
 	"semanticCommits": "enabled",
 	"configWarningReuseIssue": false,
-	"schedule": ["* 17 * * 5"],
+	"schedule": ["0 17 * * 5"],
 	"stabilityDays": 3
 }


### PR DESCRIPTION
previous cron was "At _every minute_ past hour 17 on Friday.", this is "At 17:00 on Friday."