### PR TITLE
feat(Kinopub): add presence

### DIFF
--- a/websites/K/Kinopub/iframe.ts
+++ b/websites/K/Kinopub/iframe.ts
@@ -1,0 +1,14 @@
+const iframe = new iFrame();
+
+iframe.on("UpdateData", async () => {
+	if (document.querySelector("video")) {
+		const video = document.querySelector<HTMLVideoElement>("video");
+		if (!isNaN(video?.duration)) {
+			iframe.send({
+				duration: video.duration,
+				currentTime: video.currentTime,
+				paused: video.paused,
+			});
+		}
+	}
+});

--- a/websites/K/Kinopub/metadata.json
+++ b/websites/K/Kinopub/metadata.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.premid.app/metadata/1.7",
 	"author": {
 		"id": "257151906038677504",
-		"name": "SHISEN#8023"
+		"name": "SHISEN"
 	},
 	"service": "Kinopub",
 	"description": {

--- a/websites/K/Kinopub/metadata.json
+++ b/websites/K/Kinopub/metadata.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.7",
+  "service": "Kinopub",
+  "author": {
+    "id": "257151906038677504",
+    "name": "SHISEN#8023"
+  },
+  "description": {
+    "en": "Website for online watching movies, series, sports broadcasts and concerts",
+    "ru": "Сайт для онлайн просмотра фильмов, сериалов, спортивных трансляций и концертов"
+  },
+  "url": "kinopub.net",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/HAvvvj7.png",
+  "thumbnail": "https://i.imgur.com/TFaoJbL.png",
+  "color": "#1c202b",
+	"category": "videos",
+	"tags": [
+		"kinopub",
+		"movie",
+		"video",
+		"media"
+	],
+	"iframe": true,
+	"settings": [
+		{
+			"id": "privacy",
+			"title": "Приватный режим",
+			"icon": "fad fa-user-secret",
+			"value": false
+		},
+		{
+			"id": "time",
+			"title": "Оставшееся время прослушивания/просмотра",
+			"if": {
+				"privacy": false
+			},
+			"icon": "fad fa-stopwatch",
+			"value": true
+		},
+		{
+			"id": "cover",
+			"if": {
+				"privacy": false
+			},
+			"title": "Обложки к фильмам",
+			"icon": "fad fa-images",
+			"value": true
+		},
+		{
+			"id": "buttons",
+			"if": {
+				"privacy": false
+			},
+			"title": "Показывать кнопки",
+			"icon": "fas fa-compress-arrows-alt",
+			"value": true
+		}
+	]
+}

--- a/websites/K/Kinopub/metadata.json
+++ b/websites/K/Kinopub/metadata.json
@@ -1,19 +1,19 @@
 {
-  "$schema": "https://schemas.premid.app/metadata/1.7",
-  "service": "Kinopub",
-  "author": {
-    "id": "257151906038677504",
-    "name": "SHISEN#8023"
-  },
-  "description": {
-    "en": "Website for online watching movies, series, sports broadcasts and concerts",
-    "ru": "Сайт для онлайн просмотра фильмов, сериалов, спортивных трансляций и концертов"
-  },
-  "url": "kinopub.net",
-  "version": "1.0.0",
-  "logo": "https://i.imgur.com/HAvvvj7.png",
-  "thumbnail": "https://i.imgur.com/TFaoJbL.png",
-  "color": "#1c202b",
+	"$schema": "https://schemas.premid.app/metadata/1.7",
+	"author": {
+		"id": "257151906038677504",
+		"name": "SHISEN#8023"
+	},
+	"service": "Kinopub",
+	"description": {
+		"en": "Website for online watching movies, series, sports broadcasts and concerts",
+		"ru": "Сайт для онлайн просмотра фильмов, сериалов, спортивных трансляций и концертов"
+	},
+	"url": "kinopub.net",
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/HAvvvj7.png",
+	"thumbnail": "https://i.imgur.com/TFaoJbL.png",
+	"color": "#1c202b",
 	"category": "videos",
 	"tags": [
 		"kinopub",

--- a/websites/K/Kinopub/presence.ts
+++ b/websites/K/Kinopub/presence.ts
@@ -1,0 +1,237 @@
+const presence = new Presence({
+	clientId: "1054755173198737458",
+});
+
+enum Assets {
+	Play = "https://i.imgur.com/6s4WyWY.png",
+	Pause = "https://i.imgur.com/PrYtpQb.png",
+	Read = "https://i.imgur.com/wPUmqu5.png",
+	View = "https://i.imgur.com/hxvvGUi.png",
+	Search = "https://i.imgur.com/wYVlwJX.png",
+}
+
+enum Strings {
+	Home = "На главной странице",
+	View = "Смотрит",
+	Search = "Ищет",
+	Read = "Читает",
+	New = "новинки",
+	Sports = "спортивные трансляции",
+	NewEpisodes = "новые эпизоды",
+	Bookmarks = "закладки",
+	History = "историю просмотров",
+	SelectionOne = "подборку",
+	Awards = "награды",
+	Kinoblog = "Киноблог",
+	Post = "пост",
+	Instructions = "инструкции",
+	Settings = "В настройках",
+	Notifications = "оповещения",
+}
+
+let video = {
+	duration: 0,
+	currentTime: 0,
+	paused: true,
+};
+
+function textContent(tags: string) {
+	return document.querySelector(tags)?.textContent?.trim();
+}
+
+presence.on(
+	"iFrameData",
+	(data: { duration: number; currentTime: number; paused: boolean }) => {
+		video = data;
+	}
+);
+
+presence.on("UpdateData", async () => {
+	const presenceData: PresenceData = {
+			details: "Где-то на сайте",
+			largeImageKey: "https://i.imgur.com/HAvvvj7.png",
+			smallImageText: "Kinopub",
+		},
+		[privacy, time, buttons, cover] = await Promise.all([
+			presence.getSetting<boolean>("privacy"),
+			presence.getSetting<boolean>("time"),
+			presence.getSetting<boolean>("buttons"),
+			presence.getSetting<boolean>("cover"),
+		]),
+		serieName = textContent(".jw-title-primary");
+
+	switch (document.location.pathname.split("/")[1]) {
+		case "":
+			presenceData.details = Strings.Home;
+			break;
+
+		case "popular":
+		case "new":
+		case "hot":
+			presenceData.details = `${Strings.Search} ${Strings.New}`;
+			presenceData.state = textContent(
+				".btn.btn-outline-success.rounded.active"
+			);
+			presenceData.smallImageKey = Assets.Search;
+			presenceData.smallImageText = Strings.Search;
+			break;
+
+		case "movie":
+		case "serial":
+		case "3d":
+		case "concert":
+		case "documovie":
+		case "docuserial":
+		case "tvshow":
+			presenceData.details = `${Strings.Search} ${textContent(
+				".page-content h3:first-child"
+			).toLowerCase()}`;
+			presenceData.smallImageKey = Assets.Search;
+			presenceData.smallImageText = Strings.Search;
+			break;
+
+		case "sport":
+			presenceData.details = `${Strings.View} ${Strings.Sports}`;
+			presenceData.smallImageKey = Assets.View;
+			presenceData.smallImageText = Strings.View;
+			break;
+
+		case "watchlist":
+			presenceData.details = `${Strings.View} ${Strings.NewEpisodes}`;
+			presenceData.state = "Обновления просмотренного";
+			presenceData.smallImageKey = Assets.View;
+			presenceData.smallImageText = Strings.View;
+			break;
+
+		case "favorites":
+			presenceData.details = `${Strings.View} ${Strings.Bookmarks}`;
+			presenceData.state = document
+				.querySelector(".page-content h3")
+				?.childNodes[1]?.textContent.split(": ")[1];
+			presenceData.smallImageKey = Assets.View;
+			presenceData.smallImageText = Strings.View;
+			break;
+
+		case "history":
+			presenceData.details = `${Strings.View} ${Strings.History}`;
+			presenceData.state = textContent(".nav-link.active");
+			presenceData.smallImageKey = Assets.View;
+			presenceData.smallImageText = Strings.View;
+			break;
+		case "media":
+			presenceData.details = `${Strings.View} ${Strings.NewEpisodes}`;
+			presenceData.state = "Обновления сайта";
+			presenceData.smallImageKey = Assets.View;
+			presenceData.smallImageText = Strings.View;
+			break;
+
+		case "selection":
+			presenceData.details = `${Strings.View} ${textContent(
+				".page-content h3:first-child"
+			).toLowerCase()}`;
+			presenceData.state = textContent(".nav-link.active");
+			if (document.location.pathname.split("/")[2] === "view" && !privacy) {
+				presenceData.details = `${Strings.View} ${Strings.SelectionOne}`;
+				presenceData.state = textContent(".page-content h3:first-child");
+			}
+			presenceData.smallImageKey = Assets.View;
+			presenceData.smallImageText = Strings.View;
+			break;
+
+		case "award":
+			presenceData.details = `${Strings.View} ${Strings.Awards}`;
+			presenceData.state = `${textContent(".page-content h4")} (${
+				textContent(".page-content h5").split(": ")[1]
+			})`;
+			presenceData.smallImageKey = Assets.View;
+			presenceData.smallImageText = Strings.View;
+			break;
+
+		case "kinoblog":
+			presenceData.details = `${Strings.View} ${Strings.Kinoblog}`;
+			presenceData.smallImageKey = Assets.View;
+			presenceData.smallImageText = Strings.View;
+			presenceData.state = textContent(".nav-link.active");
+			if (document.location.pathname.split("/")[2] === "view") {
+				presenceData.details = `${Strings.Read} ${Strings.Post}`;
+				presenceData.state = textContent(".text-success");
+				presenceData.smallImageKey = Assets.Read;
+				presenceData.smallImageText = Strings.Read;
+			}
+			break;
+
+		case "plugin":
+			presenceData.details = `${Strings.View} ${Strings.Instructions}`;
+			break;
+
+		case "users":
+			presenceData.details = `${Strings.View} страницу ${
+				!privacy ? textContent(".page-title span") : "пользователя"
+			}`;
+			presenceData.state = textContent(".nav-link.active");
+			break;
+
+		case "user":
+			presenceData.details = Strings.Settings;
+			presenceData.state = textContent(".nav-item.active");
+			break;
+
+		case "notification":
+			presenceData.details = `${Strings.View} ${Strings.Notifications}`;
+			presenceData.state = textContent(".nav-link.active");
+			break;
+
+		case "item":
+			if (document.location.pathname.split("/")[2] === "search") {
+				presenceData.details = `${Strings.Search}: ${
+					document.querySelector<HTMLInputElement>('input[name="query"]').value
+				}`;
+			} else {
+				presenceData.details = `${Strings.View} страницу ${
+					serieName ? "сериала" : "фильма"
+				}`;
+				presenceData.state =
+					document.querySelector(
+						".page-content h3"
+					)?.childNodes[0]?.textContent;
+				if (!privacy && cover) {
+					presenceData.largeImageKey = document.querySelector<HTMLImageElement>(
+						".item-poster-relative"
+					).src;
+				}
+				presenceData.smallImageKey = Assets.View;
+				presenceData.smallImageText = Strings.View;
+				presenceData.buttons = [
+					{
+						label: "Открыть страницу",
+						url: document.location.href,
+					},
+				];
+
+				if (!privacy && video.duration) {
+					presenceData.details =
+						document.querySelector(
+							".page-content h3"
+						)?.childNodes[0]?.textContent;
+					presenceData.state = serieName;
+					presenceData.smallImageKey = video.paused
+						? Assets.Pause
+						: Assets.Play;
+					presenceData.smallImageText = video.paused ? "На паузе" : "Смотрит";
+
+					if (video.paused || !time) {
+						delete presenceData.startTimestamp;
+						delete presenceData.endTimestamp;
+					} else {
+						[presenceData.startTimestamp, presenceData.endTimestamp] =
+							presence.getTimestamps(video.currentTime, video.duration);
+					}
+				}
+			}
+			break;
+	}
+
+	if (privacy) delete presenceData.state;
+	if (privacy || !buttons) delete presenceData.buttons;
+	presence.setActivity(presenceData);
+});

--- a/websites/K/Kinopub/presence.ts
+++ b/websites/K/Kinopub/presence.ts
@@ -11,6 +11,8 @@ enum Assets {
 }
 
 enum Strings {
+	Play = "Смотрит",
+	Pause = "На паузе",
 	Home = "На главной странице",
 	View = "Смотрит",
 	Search = "Ищет",
@@ -27,6 +29,11 @@ enum Strings {
 	Instructions = "инструкции",
 	Settings = "В настройках",
 	Notifications = "оповещения",
+	OpenLink = "Открыть страницу",
+	Page = "страницу",
+	Serial = "сериала",
+	Movie = "фильма",
+	User = "пользователя",
 }
 
 let video = {
@@ -58,9 +65,10 @@ presence.on("UpdateData", async () => {
 			presence.getSetting<boolean>("buttons"),
 			presence.getSetting<boolean>("cover"),
 		]),
-		serieName = textContent(".jw-title-primary");
+		serieName = textContent(".jw-title-primary"),
+		{ pathname, href } = document.location;
 
-	switch (document.location.pathname.split("/")[1]) {
+	switch (pathname.split("/")[1]) {
 		case "":
 			presenceData.details = Strings.Home;
 			break;
@@ -96,13 +104,6 @@ presence.on("UpdateData", async () => {
 			presenceData.smallImageText = Strings.View;
 			break;
 
-		case "watchlist":
-			presenceData.details = `${Strings.View} ${Strings.NewEpisodes}`;
-			presenceData.state = "Обновления просмотренного";
-			presenceData.smallImageKey = Assets.View;
-			presenceData.smallImageText = Strings.View;
-			break;
-
 		case "favorites":
 			presenceData.details = `${Strings.View} ${Strings.Bookmarks}`;
 			presenceData.state = document
@@ -118,9 +119,13 @@ presence.on("UpdateData", async () => {
 			presenceData.smallImageKey = Assets.View;
 			presenceData.smallImageText = Strings.View;
 			break;
+
+		case "watchlist":
 		case "media":
 			presenceData.details = `${Strings.View} ${Strings.NewEpisodes}`;
-			presenceData.state = "Обновления сайта";
+			presenceData.state = `Обновления ${
+				pathname.split("/")[1] === "media" ? "сайта" : "просмотренного"
+			}`;
 			presenceData.smallImageKey = Assets.View;
 			presenceData.smallImageText = Strings.View;
 			break;
@@ -130,7 +135,7 @@ presence.on("UpdateData", async () => {
 				".page-content h3:first-child"
 			).toLowerCase()}`;
 			presenceData.state = textContent(".nav-link.active");
-			if (document.location.pathname.split("/")[2] === "view" && !privacy) {
+			if (pathname.split("/")[2] === "view" && !privacy) {
 				presenceData.details = `${Strings.View} ${Strings.SelectionOne}`;
 				presenceData.state = textContent(".page-content h3:first-child");
 			}
@@ -149,10 +154,10 @@ presence.on("UpdateData", async () => {
 
 		case "kinoblog":
 			presenceData.details = `${Strings.View} ${Strings.Kinoblog}`;
+			presenceData.state = textContent(".nav-link.active");
 			presenceData.smallImageKey = Assets.View;
 			presenceData.smallImageText = Strings.View;
-			presenceData.state = textContent(".nav-link.active");
-			if (document.location.pathname.split("/")[2] === "view") {
+			if (pathname.split("/")[2] === "view") {
 				presenceData.details = `${Strings.Read} ${Strings.Post}`;
 				presenceData.state = textContent(".text-success");
 				presenceData.smallImageKey = Assets.Read;
@@ -161,34 +166,44 @@ presence.on("UpdateData", async () => {
 			break;
 
 		case "plugin":
-			presenceData.details = `${Strings.View} ${Strings.Instructions}`;
+			presenceData.details = `${Strings.Read} ${Strings.Instructions}`;
+			presenceData.smallImageKey = Assets.Read;
+			presenceData.smallImageText = Strings.Read;
 			break;
 
 		case "users":
-			presenceData.details = `${Strings.View} страницу ${
-				!privacy ? textContent(".page-title span") : "пользователя"
+			presenceData.details = `${Strings.View} ${Strings.Page} ${
+				!privacy ? textContent(".page-title span") : Strings.User
 			}`;
 			presenceData.state = textContent(".nav-link.active");
+			presenceData.smallImageKey = Assets.View;
+			presenceData.smallImageText = Strings.View;
 			break;
 
 		case "user":
 			presenceData.details = Strings.Settings;
 			presenceData.state = textContent(".nav-item.active");
+			presenceData.smallImageKey = Assets.View;
+			presenceData.smallImageText = Strings.View;
 			break;
 
 		case "notification":
 			presenceData.details = `${Strings.View} ${Strings.Notifications}`;
 			presenceData.state = textContent(".nav-link.active");
+			presenceData.smallImageKey = Assets.View;
+			presenceData.smallImageText = Strings.View;
 			break;
 
 		case "item":
-			if (document.location.pathname.split("/")[2] === "search") {
+			if (pathname.split("/")[2] === "search") {
 				presenceData.details = `${Strings.Search}: ${
 					document.querySelector<HTMLInputElement>('input[name="query"]').value
 				}`;
+				presenceData.smallImageKey = Assets.Search;
+				presenceData.smallImageText = Strings.Search;
 			} else {
-				presenceData.details = `${Strings.View} страницу ${
-					serieName ? "сериала" : "фильма"
+				presenceData.details = `${Strings.View} ${Strings.Page} ${
+					serieName ? Strings.Serial : Strings.Movie
 				}`;
 				presenceData.state =
 					document.querySelector(
@@ -203,8 +218,8 @@ presence.on("UpdateData", async () => {
 				presenceData.smallImageText = Strings.View;
 				presenceData.buttons = [
 					{
-						label: "Открыть страницу",
-						url: document.location.href,
+						label: Strings.OpenLink,
+						url: href,
 					},
 				];
 
@@ -217,7 +232,9 @@ presence.on("UpdateData", async () => {
 					presenceData.smallImageKey = video.paused
 						? Assets.Pause
 						: Assets.Play;
-					presenceData.smallImageText = video.paused ? "На паузе" : "Смотрит";
+					presenceData.smallImageText = video.paused
+						? Strings.Pause
+						: Strings.Play;
 
 					if (video.paused || !time) {
 						delete presenceData.startTimestamp;

--- a/websites/K/Kinopub/presence.ts
+++ b/websites/K/Kinopub/presence.ts
@@ -3,6 +3,7 @@ const presence = new Presence({
 });
 
 enum Assets {
+	Logo = "https://i.imgur.com/HAvvvj7.png",
 	Play = "https://i.imgur.com/6s4WyWY.png",
 	Pause = "https://i.imgur.com/PrYtpQb.png",
 	Read = "https://i.imgur.com/wPUmqu5.png",
@@ -56,8 +57,7 @@ presence.on(
 presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
 			details: "Где-то на сайте",
-			largeImageKey: "https://i.imgur.com/HAvvvj7.png",
-			smallImageText: "Kinopub",
+			largeImageKey: Assets.Logo,
 		},
 		[privacy, time, buttons, cover] = await Promise.all([
 			presence.getSetting<boolean>("privacy"),


### PR DESCRIPTION
## Description 
Add presence for Kinopub

Settings:
1. Private mode.
2. Show remaining listening/viewing time.
3. Showing movie/serial covers.
4. Show buttons.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://user-images.githubusercontent.com/37224822/208912145-5cef7da2-3e5f-485d-a27d-890eba2f2720.png)
![image](https://user-images.githubusercontent.com/37224822/208912237-fb019021-1aa3-4bd0-9d7e-4c9ac2148e5e.png)
![image](https://user-images.githubusercontent.com/37224822/208912301-719c62b3-376d-4e00-a835-9489e5595fa5.png)

</details>
