### PR TITLE
fix(Facebook): fix fb.watch & fb.gg profile names

### DIFF
--- a/websites/F/Facebook/metadata.json
+++ b/websites/F/Facebook/metadata.json
@@ -22,7 +22,7 @@
 		"vi_VN": "Kết nối với bạn bè, người thân và những người khác bạn biết. Chia sẻ hình ảnh và video, gửi tin nhắn và nhận các thông báo."
 	},
 	"url": "www.facebook.com",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"logo": "https://i.imgur.com/nS9sZn6.png",
 	"thumbnail": "https://i.imgur.com/iftQq6r.jpg",
 	"color": "#4267B2",

--- a/websites/F/Facebook/presence.ts
+++ b/websites/F/Facebook/presence.ts
@@ -55,7 +55,7 @@ presence.on("UpdateData", async () => {
 	} else if (document.location.pathname.includes("/videos/")) {
 		const video = document.querySelector("video"),
 			isLive = !!document.querySelector(
-				"div.j83agx80.rgmg9uty.pmk7jnqg.rnx8an3s.fcg2cn6m"
+				"div.x78zum5.xxk0z11 > div.x6s0dn4 > span.x193iq5w"
 			);
 
 		if (privacyMode)
@@ -63,10 +63,9 @@ presence.on("UpdateData", async () => {
 		else {
 			presenceData.details = `Watching a ${isLive ? "live" : "video"} on:`;
 			presenceData.state = `${
-				document.querySelector("span.nc684nl6 > span")?.textContent ??
-				document.querySelector("span.nc684nl6 > a > strong > span")
-					?.textContent ??
-				document.querySelector('[href*="?__tn__=-UC*F"]')?.textContent
+				document.querySelector("span.x193iq5w > strong > span")?.textContent ??
+				document.querySelector("span.x193iq5w > h2 > span > a > strong > span")
+					?.textContent
 			}'s profile`;
 
 			if (isLive) {


### PR DESCRIPTION
## Description 
This pr fixes the following:
- Resolves #6122

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary>Facebook gaming</summary>

![image](https://user-images.githubusercontent.com/68460474/209164325-0c8fa382-8219-4128-b024-a08b962f9629.png)
</details>
<details>
<summary>Facebook watch</summary>

![image](https://user-images.githubusercontent.com/68460474/209164535-4192027f-7e38-48e3-8315-99950a6b47ce.png)
</details>

