### PR TITLE
fix(Github): show in all PR tabs

### DIFF
--- a/websites/G/GitHub/metadata.json
+++ b/websites/G/GitHub/metadata.json
@@ -29,7 +29,7 @@
 		"github.com",
 		"gist.github.com"
 	],
-	"version": "2.11.0",
+	"version": "2.11.1",
 	"logo": "https://i.imgur.com/cr3bzXB.png",
 	"thumbnail": "https://i.imgur.com/G816tlo.png",
 	"color": "#000000",

--- a/websites/G/GitHub/presence.ts
+++ b/websites/G/GitHub/presence.ts
@@ -72,7 +72,7 @@ presence.on("UpdateData", async () => {
 				const searchParam = new URLSearchParams(search).get("tab"),
 					profileName = document
 						.querySelector("span.p-nickname")
-						.textContent.trim();
+						?.textContent.trim();
 				presenceData.buttons = [{ label: "View Profile", url: href }];
 				if (cover) {
 					presenceData.largeImageKey = `${
@@ -125,7 +125,7 @@ presence.on("UpdateData", async () => {
 					presenceData.details = `Browsing repository ${repository.owner}/${repository.name}`;
 					presenceData.state = `Viewing file ${document
 						.querySelector("h2#blob-path > strong")
-						.textContent.trim()} at ${repository.target}`;
+						?.textContent.trim()} at ${repository.target}`;
 				} else if (pathname.includes("/issues")) {
 					if (pathname.includes("/issues/")) {
 						if (pathname.includes("new")) {
@@ -145,11 +145,13 @@ presence.on("UpdateData", async () => {
 							}
 							presenceData.details = `Looking at issue #${repository.id}`;
 							presenceData.state = `${
-								document.querySelectorAll<HTMLAnchorElement>("a.author")[0]
-									.textContent
+								document
+									.querySelector<HTMLAnchorElement>("a.author")
+									?.textContent?.trim() ??
+								document.querySelector('[href="#top"]')?.textContent?.trim()
 							} - ${
 								document.querySelector<HTMLHeadingElement>("h1.gh-header-title")
-									.textContent
+									?.textContent
 							}`;
 							presenceData.buttons = [{ label: "View Issue", url: href }];
 						}
@@ -181,12 +183,12 @@ presence.on("UpdateData", async () => {
 					}
 					presenceData.details = `Looking at pull request #${repository.id}`;
 					presenceData.state = `${
-						document.querySelectorAll<HTMLAnchorElement>(
-							"a.author.Link--primary"
-						)[0].textContent
+						document.querySelector<HTMLAnchorElement>("a.author.Link--primary")
+							?.textContent ??
+						document.querySelector('[class*="author Link"]')?.textContent
 					} - ${
 						document.querySelector<HTMLHeadingElement>("h1.gh-header-title")
-							.textContent
+							?.textContent
 					}`;
 					presenceData.buttons = [{ label: "View Pull Request", url: href }];
 				} else if (pathname.endsWith("/discussions")) {
@@ -208,10 +210,10 @@ presence.on("UpdateData", async () => {
 					presenceData.details = `Looking at discussion #${repository.id}`;
 					presenceData.state = `${
 						document.querySelectorAll<HTMLAnchorElement>("a.author")[0]
-							.textContent
+							?.textContent
 					} - ${
 						document.querySelector<HTMLHeadingElement>("h1.gh-header-title")
-							.textContent
+							?.textContent
 					}`;
 					presenceData.buttons = [{ label: "View Discussion", url: href }];
 				} else if (
@@ -235,7 +237,7 @@ presence.on("UpdateData", async () => {
 
 					presenceData.state = document.querySelector<HTMLAnchorElement>(
 						"nav a.js-selected-navigation-item.selected.menu-item"
-					).textContent;
+					)?.textContent;
 				} else {
 					if (privacy) {
 						presenceData.details = "Browsing a repository";
@@ -258,7 +260,7 @@ presence.on("UpdateData", async () => {
 				}
 				presenceData.details = "Viewing an organization";
 				presenceData.state =
-					document.querySelector<HTMLHeadingElement>("h1").textContent;
+					document.querySelector<HTMLHeadingElement>("h1")?.textContent;
 				if (cover) {
 					presenceData.largeImageKey = `${
 						document.querySelector<HTMLImageElement>("div > img").src
@@ -309,7 +311,7 @@ presence.on("UpdateData", async () => {
 				const searchParam = new URLSearchParams(search).get("tab"),
 					profileName = document
 						.querySelector("span.p-nickname")
-						.textContent.trim();
+						?.textContent.trim();
 				presenceData.buttons = [{ label: "View Profile", url: href }];
 				if (cover) {
 					presenceData.largeImageKey = `${


### PR DESCRIPTION
Closes #7070
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Fixed the code bugging when showing a pr outisde of the discussions tab.
## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img src="https://user-images.githubusercontent.com/42322979/209427070-fca371b2-79b8-46dc-8659-7736e656d901.png">



</details>
