### PR TITLE
feat(Yume Nikki Online Project): add presence

### DIFF
--- a/websites/Y/Yume Nikki Online Project/dist/metadata.json
+++ b/websites/Y/Yume Nikki Online Project/dist/metadata.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.7",
+  "service": "Yume Nikki Online Project",
+  "author": {
+    "id": "419892518423887903",
+    "name": "(\"pnfrlEnm\");#5550"
+  },
+  "description": {
+    "en": "Play Yume Nikki and Yume Nikki fangames in multiplayer with your friends, no account or downloads required."
+  },
+  "url": "ynoproject.net",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/wnQfBTV.png",
+  "thumbnail": "https://i.imgur.com/HIIteum.png",
+  "color": "#C191C7",
+  "tags": [
+    "multiplayer",
+    "game",
+    "online",
+    "dream",
+    "exploration",
+    "rpg",
+    "rpgmaker"
+  ],
+  "category": "games"
+}

--- a/websites/Y/Yume Nikki Online Project/dist/presence.js
+++ b/websites/Y/Yume Nikki Online Project/dist/presence.js
@@ -1,0 +1,70 @@
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var _this = this;
+var presence = new Presence({
+    clientId: "1060269808383430696"
+}), elapsed = Math.floor(Date.now() / 1000), strings = presence.getStrings({
+    play: "presence.playback.playing",
+    pause: "presence.playback.paused"
+});
+presence.on("UpdateData", function () { return __awaiter(_this, void 0, void 0, function () {
+    var presenceData;
+    return __generator(this, function (_a) {
+        presenceData = {
+            largeImageKey: "yume",
+            startTimestamp: elapsed
+        };
+        if (location.pathname === "/" || location.href.split(location.host)[1].toLowerCase() === "/index") {
+            presenceData.details = "The Nexus";
+            presenceData.state = "(Selecting Game)";
+        }
+        else if (document.title.split(" - ")[0].toString() != "YNOproject") {
+            presenceData.details = document.title.split(" - ")[0].toString();
+            if (document.getElementById("locationText").innerText) {
+                presenceData.state = document.getElementById("locationText").innerText;
+            }
+            else {
+                presenceData.state = "In Menu";
+            }
+        }
+        else {
+            presenceData.details = "Loading...";
+        }
+        presence.setActivity(presenceData);
+        return [2 /*return*/];
+    });
+}); });

--- a/websites/Y/Yume Nikki Online Project/metadata.json
+++ b/websites/Y/Yume Nikki Online Project/metadata.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.7",
+  "service": "Yume Nikki Online Project",
+  "author": {
+    "id": "419892518423887903",
+    "name": "(\"pnfrlEnm\");#5550"
+  },
+  "description": {
+    "en": "Play Yume Nikki and Yume Nikki fangames in multiplayer with your friends, no account or downloads required."
+  },
+  "url": "ynoproject.net",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/wnQfBTV.png",
+  "thumbnail": "https://i.imgur.com/HIIteum.png",
+  "color": "#C191C7",
+  "tags": [
+    "multiplayer",
+    "game",
+    "online",
+    "dream",
+    "exploration",
+    "rpg",
+    "rpgmaker"
+  ],
+  "category": "games"
+}

--- a/websites/Y/Yume Nikki Online Project/presence.ts
+++ b/websites/Y/Yume Nikki Online Project/presence.ts
@@ -1,0 +1,30 @@
+const presence = new Presence({
+		clientId: "1060269808383430696",
+	}),
+	elapsed = Math.floor(Date.now() / 1000),
+	strings = presence.getStrings({
+		play: "presence.playback.playing",
+		pause: "presence.playback.paused",
+	});
+
+presence.on("UpdateData", async () => {
+	const presenceData: PresenceData = {
+		largeImageKey: "yume",
+		startTimestamp: elapsed,
+	};
+
+	if (location.pathname === "/" || location.href.split(location.host)[1].toLowerCase() === "/index") {
+		presenceData.details = "The Nexus";
+		presenceData.state = "(Selecting Game)";
+
+	} else if (document.title.split(" - ")[0].toString() != "YNOproject") {
+		presenceData.details = document.title.split(" - ")[0].toString();
+		if (document.getElementById("locationText").innerText) {presenceData.state = document.getElementById("locationText").innerText;}
+		else {presenceData.state = "In Menu"}
+
+	} else {
+		presenceData.details = "Loading..."
+	}
+
+	presence.setActivity(presenceData);
+});

--- a/websites/Y/Yume Nikki Online Project/tsconfig.json
+++ b/websites/Y/Yume Nikki Online Project/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"extends": "../../../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist/"
+	}
+}


### PR DESCRIPTION
Signed-off-by: Ｐｎｆｒｌ　Ｅｎｍ <35457994+PnfrlEnm@users.noreply.github.com>

## Description 
Added rich presence for "Yume Nikki Online Project" (https://ynoproject.net), a multiplayer online version of Yume Nikki and a few of its fangames. The presence displays which game you are currently in, as well as the your in-game location and how long you've been playing.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>


The home page ("The Nexus" as the website calls it) where you select the game to play.
![screenshot_ynopresence1](https://user-images.githubusercontent.com/35457994/210653061-d357a26b-8dad-4281-b422-c9c7def83ca4.PNG)

Playing Yume Nikki, but still on the start menu.
![screenshot_ynopresence2](https://user-images.githubusercontent.com/35457994/210653066-a3d4d54c-833a-4357-a723-b8700328505f.PNG)

Playing Yume 2kki, currently in Urotsuki's Dream Balcony
![screenshot_ynopresence3](https://user-images.githubusercontent.com/35457994/210653878-fb8680d8-0eb3-4d35-bd08-145b4befb440.PNG)




</details>
