### PR TITLE
Feat(Mangas-Origines): new site support

### DIFF
--- a/websites/M/Mangas-Origines/metadata.json
+++ b/websites/M/Mangas-Origines/metadata.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.7",
+  "service": "Mangas-Origines",
+  "author": {
+    "id": "470569212453191698",
+    "name": "Onelots.#0007"
+  },
+  "description": {
+    "en": "Read Comics on Mangas-Origines."
+  },
+  "url": [
+    "mangas-origines.fr",
+    "x.mangas-origines.fr"
+  ],
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/MqvvhSw.png",
+  "thumbnail": "https://i.imgur.com/NInXya0.png",
+  "color": "#eb11ee",
+  "tags": [
+    "comics",
+    "manga",
+    "scantrad",
+    "origines",
+    "scans"
+  ],
+  "category": "other"
+}

--- a/websites/M/Mangas-Origines/presence.ts
+++ b/websites/M/Mangas-Origines/presence.ts
@@ -1,0 +1,62 @@
+const presence = new Presence({
+    clientId: "1059611780520874044"
+  }),
+  browsingTimestamp = Math.floor(Date.now() / 1000);
+
+const url = "https://mangas-origines.fr"
+
+presence.on("UpdateData", () => {
+	const { pathname, href } = window.location,
+		presenceData: PresenceData = {
+			startTimestamp: browsingTimestamp,
+			largeImageKey: "https://i.imgur.com/MqvvhSw.png",
+		};
+
+	if (/^\/(page\/\d+\/?)?$/.test(pathname))
+		presenceData.details = "Sur la Page d'Accueil";
+	else if (/^\/catalogues\/?$/.test(pathname))
+		presenceData.details = "Sur la Page des Mangas";
+	else if (href.startsWith("https://mangas-origines.fr/manga/") && href.split("/").length == 6) {
+		presenceData.details = "Consulte la Page d'une Oeuvre";
+		presenceData.state =
+			document.querySelector<HTMLDivElement>(".post-title h1").textContent;
+		presenceData.buttons = [
+			{
+				label: "Voir l'oeuvre",
+				url: href,
+			},
+		];
+
+
+	} else if (/\/chapitre-[0-9]+\/?$/i.test(pathname)) {
+		const progress =
+			(document.documentElement.scrollTop /
+				(document.querySelector<HTMLDivElement>(".reading-content").scrollHeight -
+					window.innerHeight)) *
+			100;
+		presenceData.details = "En Train de Lire";
+		presenceData.state = `${
+			document.querySelector<HTMLHeadingElement>("#chapter-heading").textContent
+		} - ${(progress > 100 ? 100 : progress).toFixed(1)}%`;
+    const allLinks = document.querySelectorAll<HTMLAnchorElement>(".c-breadcrumb > .breadcrumb > li > a");
+    const linkElem = allLinks[allLinks.length - 1];
+    const ComicLink = linkElem.href;
+		presenceData.buttons = [
+			{
+				label: "Voir l'Oeuvre",
+				url: ComicLink,
+			},
+			{
+				label: "Accéder au Chapitre",
+				url: href,
+			},
+		];
+	} 
+	else {
+		presenceData.details = "Navigue sur Mangas-Origines.fr";
+		presenceData.state = document.title;
+	}
+
+	if (presenceData.details) presence.setActivity(presenceData);
+	else presence.setActivity();
+});


### PR DESCRIPTION
Created presence for the website Mangas-Origines.fr.

Signed-off-by: Onelots <54822802+Oneloutre@users.noreply.github.com>

## Description 
Added support for Mangas-Origines, a new website.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 

-->
![Capture d’écran 2023-01-06 à 00 10 41](https://user-images.githubusercontent.com/54822802/210897599-b475a7c9-c5dd-4d15-9053-bbb69f7bbb7f.png)

![Capture d’écran 2023-01-06 à 00 11 22](https://user-images.githubusercontent.com/54822802/210897703-5092682e-4c44-492f-874e-8c5d86e9db2e.png)

![Capture d’écran 2023-01-06 à 00 11 55](https://user-images.githubusercontent.com/54822802/210897782-e954035d-2b2c-4fe6-a1e9-4321d8f5582f.png)

![Capture d’écran 2023-01-06 à 00 13 19](https://user-images.githubusercontent.com/54822802/210897937-2f123fa4-3b72-40c7-a859-5396d66afbea.png)


</details>
