### PR TITLE
Feat(Mangas-Origines): add website support

### DIFF
--- a/websites/M/Mangas-Origines/metadata.json
+++ b/websites/M/Mangas-Origines/metadata.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.7",
+	"author": {
+		"id": "470569212453191698",
+		"name": "Onelots.#0007"
+	},
+	"service": "Mangas-Origines",
+	"description": {
+		"en": "Read Comics on Mangas-Origines."
+	},
+	"url": [
+		"mangas-origines.fr",
+		"x.mangas-origines.fr"
+	],
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/MqvvhSw.png",
+	"thumbnail": "https://i.imgur.com/NInXya0.png",
+	"color": "#eb11ee",
+	"category": "other",
+	"tags": [
+		"comics",
+		"manga",
+		"scantrad",
+		"origines",
+		"scans"
+	]
+}

--- a/websites/M/Mangas-Origines/metadata.json
+++ b/websites/M/Mangas-Origines/metadata.json
@@ -13,7 +13,7 @@
 		"x.mangas-origines.fr"
 	],
 	"version": "1.0.0",
-	"logo": "https://i.imgur.com/MqvvhSw.png",
+	"logo": "https://i.imgur.com/KZ3FSWl.png",
 	"thumbnail": "https://i.imgur.com/KZ3FSWl.png",
 	"color": "#eb11ee",
 	"category": "other",

--- a/websites/M/Mangas-Origines/metadata.json
+++ b/websites/M/Mangas-Origines/metadata.json
@@ -14,7 +14,7 @@
 	],
 	"version": "1.0.0",
 	"logo": "https://i.imgur.com/MqvvhSw.png",
-	"thumbnail": "https://i.imgur.com/NInXya0.png",
+	"thumbnail": "https://i.imgur.com/KZ3FSWl.png",
 	"color": "#eb11ee",
 	"category": "other",
 	"tags": [

--- a/websites/M/Mangas-Origines/presence.ts
+++ b/websites/M/Mangas-Origines/presence.ts
@@ -7,7 +7,7 @@ presence.on("UpdateData", () => {
 	const { pathname, href } = window.location,
 		presenceData: PresenceData = {
 			startTimestamp: browsingTimestamp,
-			largeImageKey: "https://i.imgur.com/MqvvhSw.png",
+			largeImageKey: "https://i.imgur.com/KZ3FSWl.png",
 		};
 
 	if (/^\/(page\/\d+\/?)?$/.test(pathname))

--- a/websites/M/Mangas-Origines/presence.ts
+++ b/websites/M/Mangas-Origines/presence.ts
@@ -1,0 +1,62 @@
+const presence = new Presence({
+		clientId: "1059611780520874044",
+	}),
+	browsingTimestamp = Math.floor(Date.now() / 1000);
+
+presence.on("UpdateData", () => {
+	const { pathname, href } = window.location,
+		presenceData: PresenceData = {
+			startTimestamp: browsingTimestamp,
+			largeImageKey: "https://i.imgur.com/MqvvhSw.png",
+		};
+
+	if (/^\/(page\/\d+\/?)?$/.test(pathname))
+		presenceData.details = "Sur la Page d'Accueil";
+	else if (/^\/catalogues\/?$/.test(pathname))
+		presenceData.details = "Sur la Page des Mangas";
+	else if (
+		href.startsWith("https://mangas-origines.fr/manga/") &&
+		href.split("/").length === 6
+	) {
+		presenceData.details = "Consulte la Page d'une Oeuvre";
+		presenceData.state =
+			document.querySelector<HTMLDivElement>(".post-title h1").textContent;
+		presenceData.buttons = [
+			{
+				label: "Voir l'oeuvre",
+				url: href,
+			},
+		];
+	} else if (/\/chapitre-[0-9]+\/?$/i.test(pathname)) {
+		const progress =
+			(document.documentElement.scrollTop /
+				(document.querySelector<HTMLDivElement>(".reading-content")
+					.scrollHeight -
+					window.innerHeight)) *
+			100;
+		presenceData.details = "En Train de Lire";
+		presenceData.state = `${
+			document.querySelector<HTMLHeadingElement>("#chapter-heading").textContent
+		} - ${(progress > 100 ? 100 : progress).toFixed(1)}%`;
+		const allLinks = document.querySelectorAll<HTMLAnchorElement>(
+			".c-breadcrumb > .breadcrumb > li > a"
+		);
+
+		presenceData.buttons = [
+			{
+				label: "Voir l'Oeuvre",
+				url: allLinks[allLinks.length - 1].href,
+			},
+			{
+				label: "Accéder au Chapitre",
+				url: href,
+			},
+		];
+	} else {
+		presenceData.details = "Navigue sur Mangas-Origines.fr";
+		presenceData.state = document.title;
+	}
+
+	if (presenceData.details) presence.setActivity(presenceData);
+	else presence.setActivity();
+});


### PR DESCRIPTION
Adding Mangas-Origines to supported websites

Signed-off-by: Onelots <54822802+Oneloutre@users.noreply.github.com>

## Description 
Adding support for mangas-origines website

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 

<img src= "https://user-images.githubusercontent.com/54822802/211059076-57c93d90-15d5-4f14-a38d-fe171f4f5550.png">

<img src= "https://user-images.githubusercontent.com/54822802/211059363-412f0f11-977d-4266-8aa2-886fa8ab90b2.png">

<img src= "https://user-images.githubusercontent.com/54822802/211059512-ce57e3ab-f8b6-4b8b-8a15-356c79484f3f.png">

<img src="https://user-images.githubusercontent.com/54822802/211059664-e1894dd5-e528-416f-afbd-d8d8080fe093.png">



-->



</details>
