### PR TITLE
feat(Vodafone FM): add new presence

### DIFF
--- a/websites/V/Vodafone FM/metadata.json
+++ b/websites/V/Vodafone FM/metadata.json
@@ -19,5 +19,11 @@
 		"radio",
 		"vodafone",
 		"fm"
+	],
+	"settings": [
+		{
+			"id": "lang",
+			"multiLanguage": true
+		}
 	]
 }

--- a/websites/V/Vodafone FM/metadata.json
+++ b/websites/V/Vodafone FM/metadata.json
@@ -6,7 +6,8 @@
 	},
 	"service": "Vodafone FM",
 	"description": {
-		"en": "Vodafone FM Portuguese radio"
+		"en": "Vodafone FM is a portuguese radio founded in partnership with Vodafone. With the launch of this station it would transmit essentially Indie and Alternative Rock music, supporting also new portuguese music, targeting young adults. Starting in 2021, Vodafone FM added to its musical repertoire R&B, Indie Pop, Soft Hip-Hop and Soul.",
+		"pt": "A Vodafone FM é uma rádio portuguesa fundada em parceria com a Vodafone. Aquando do seu lançamento esta estação emitiu essencialmente música Indie e Rock Alternativo, apoiando também a nova música portuguesa, direccionada para um público jovem adulto. Começando em 2021, a Vodafone FM assumiu um novo repertório musical, com música composta por R&B, Indie Pop, Soft Hip-Hop e Soul."
 	},
 	"url": "vodafone.fm",
 	"version": "1.0.0",

--- a/websites/V/Vodafone FM/metadata.json
+++ b/websites/V/Vodafone FM/metadata.json
@@ -24,6 +24,12 @@
 		{
 			"id": "lang",
 			"multiLanguage": true
+		},
+		{
+			"id": "buttons",
+			"title": "Show Buttons",
+			"icon": "fas fa-compress-arrows-alt",
+			"value": true
 		}
 	]
 }

--- a/websites/V/Vodafone FM/metadata.json
+++ b/websites/V/Vodafone FM/metadata.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.premid.app/metadata/1.7",
 	"author": {
 		"id": "180867904135233536",
-		"name": "AnOmniMoose#3670"
+		"name": "AnOmniMoose"
 	},
 	"service": "Vodafone FM",
 	"description": {

--- a/websites/V/Vodafone FM/metadata.json
+++ b/websites/V/Vodafone FM/metadata.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.7",
+  "service": "Vodafone FM",
+  "author": {
+    "id": "180867904135233536",
+    "name": "AnOmniMoose#9999"
+  },
+  "description": {
+    "en": "Vodafone FM Portuguese radio"
+  },
+  "url": "vodafone.fm",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/6IUf3O6.png",
+  "thumbnail": "https://i.imgur.com/nhRns9W.png",
+  "color": "#e60000",
+  "tags": [
+    "radio",
+    "vodafone",
+    "fm"
+  ],
+  "category": "music"
+}

--- a/websites/V/Vodafone FM/metadata.json
+++ b/websites/V/Vodafone FM/metadata.json
@@ -1,22 +1,22 @@
 {
-  "$schema": "https://schemas.premid.app/metadata/1.7",
-  "service": "Vodafone FM",
-  "author": {
-    "id": "180867904135233536",
-    "name": "AnOmniMoose#9999"
-  },
-  "description": {
-    "en": "Vodafone FM Portuguese radio"
-  },
-  "url": "vodafone.fm",
-  "version": "1.0.0",
-  "logo": "https://i.imgur.com/6IUf3O6.png",
-  "thumbnail": "https://i.imgur.com/nhRns9W.png",
-  "color": "#e60000",
-  "tags": [
-    "radio",
-    "vodafone",
-    "fm"
-  ],
-  "category": "music"
+	"$schema": "https://schemas.premid.app/metadata/1.7",
+	"author": {
+		"id": "180867904135233536",
+		"name": "AnOmniMoose#9999"
+	},
+	"service": "Vodafone FM",
+	"description": {
+		"en": "Vodafone FM Portuguese radio"
+	},
+	"url": "vodafone.fm",
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/6IUf3O6.png",
+	"thumbnail": "https://i.imgur.com/nhRns9W.png",
+	"color": "#e60000",
+	"category": "music",
+	"tags": [
+		"radio",
+		"vodafone",
+		"fm"
+	]
 }

--- a/websites/V/Vodafone FM/metadata.json
+++ b/websites/V/Vodafone FM/metadata.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.premid.app/metadata/1.7",
 	"author": {
 		"id": "180867904135233536",
-		"name": "AnOmniMoose#9999"
+		"name": "AnOmniMoose#3670"
 	},
 	"service": "Vodafone FM",
 	"description": {

--- a/websites/V/Vodafone FM/presence.ts
+++ b/websites/V/Vodafone FM/presence.ts
@@ -2,7 +2,7 @@ const presence = new Presence({
 		clientId: "1061398473368412210",
 	}),
 	strings = presence.getStrings({
-		play: "presence.playback.playing",
+		play: "general.playing",
 		pause: "general.paused",
 		listeningMusic: "general.listeningMusic",
 	});

--- a/websites/V/Vodafone FM/presence.ts
+++ b/websites/V/Vodafone FM/presence.ts
@@ -25,5 +25,10 @@ presence.on("UpdateData", async () => {
 		song = document.querySelector("#song_name")?.textContent;
 	if (artist && song) presenceData.state = `${artist} - ${song}`;
 
+	const cover = document.querySelector<HTMLImageElement>("#cover");
+	if (cover && !cover.src.includes("/images/nocover.png"))
+		presenceData.largeImageKey = cover.src;
+
+
 	presence.setActivity(presenceData);
 });

--- a/websites/V/Vodafone FM/presence.ts
+++ b/websites/V/Vodafone FM/presence.ts
@@ -12,20 +12,18 @@ presence.on("UpdateData", async () => {
 		details: "Listening to music",
 	};
 
-	const playButton = document.getElementById("play");
-	if (playButton.classList.contains("hidden")) {
+	if (document.querySelector("#play").classList.contains("hidden")) {
 		presenceData.smallImageKey = "play";
-		presenceData.smallImageText = (await strings).play
+		presenceData.smallImageText = (await strings).play;
 	} else {
 		presenceData.smallImageKey = "pause";
 		presenceData.smallImageText = (await strings).pause;
 	}
 
-	const artistElement = document.getElementById("artist_name");
-	if (artistElement) {
-		const songElement = document.getElementById("song_name");
+	const artistElement = document.querySelector("#artist_name"),
+		songElement = document.querySelector("#song_name");
+	if (artistElement && songElement)
 		presenceData.state = `${artistElement.title} - ${songElement.title}`;
-	}
 
 	presence.setActivity(presenceData);
 });

--- a/websites/V/Vodafone FM/presence.ts
+++ b/websites/V/Vodafone FM/presence.ts
@@ -13,7 +13,7 @@ presence.on("UpdateData", async () => {
 	};
 
 	if (document.querySelector("#play").classList.contains("hidden")) {
-		presenceData.smallImageKey = "play";
+		presenceData.smallImageKey = "https://i.imgur.com/xiZprpt.png";
 		presenceData.smallImageText = (await strings).play;
 	} else {
 		presenceData.smallImageKey = "pause";

--- a/websites/V/Vodafone FM/presence.ts
+++ b/websites/V/Vodafone FM/presence.ts
@@ -10,7 +10,7 @@ const presence = new Presence({
 presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
 		largeImageKey: "https://i.imgur.com/6IUf3O6.png",
-		details: "Listening to music",
+		details: (await strings).listeningMusic,
 	};
 
 	if (document.querySelector("#play").classList.contains("hidden")) {

--- a/websites/V/Vodafone FM/presence.ts
+++ b/websites/V/Vodafone FM/presence.ts
@@ -4,20 +4,24 @@ const presence = new Presence({
 	getStrings = async () =>
 		presence.getStrings(
 			{
-				play: "general.playing",
-				pause: "general.paused",
+				buttonListenAlong: "general.buttonListenAlong",
 				listeningMusic: "general.listeningMusic",
+				pause: "general.paused",
+				play: "general.playing",
+				viewPage: "general.viewPage",
 			},
 			await presence.getSetting<string>("lang").catch(() => "en")
 		);
-let strings: Awaited<ReturnType<typeof getStrings>>;
 
 presence.on("UpdateData", async () => {
-	strings = await getStrings();
-	const presenceData: PresenceData = {
-		largeImageKey: "https://i.imgur.com/6IUf3O6.png",
-		details: strings.listeningMusic,
-	};
+	const [strings, buttons] = await Promise.all([
+			getStrings(),
+			presence.getSetting<boolean>("buttons"),
+		]),
+		presenceData: PresenceData = {
+			largeImageKey: "https://i.imgur.com/6IUf3O6.png",
+			details: strings.listeningMusic,
+		};
 
 	if (document.querySelector("#play").classList.contains("hidden")) {
 		presenceData.smallImageKey = "https://i.imgur.com/xiZprpt.png";
@@ -37,6 +41,15 @@ presence.on("UpdateData", async () => {
 	const cover = document.querySelector<HTMLImageElement>("#cover");
 	if (cover && !cover.src.includes("/images/nocover.png"))
 		presenceData.largeImageKey = cover.src;
+
+	if (buttons) {
+		presenceData.buttons = [
+			{
+				label: strings.buttonListenAlong,
+				url: document.URL,
+			},
+		];
+	}
 
 	presence.setActivity(presenceData);
 });

--- a/websites/V/Vodafone FM/presence.ts
+++ b/websites/V/Vodafone FM/presence.ts
@@ -29,6 +29,5 @@ presence.on("UpdateData", async () => {
 	if (cover && !cover.src.includes("/images/nocover.png"))
 		presenceData.largeImageKey = cover.src;
 
-
 	presence.setActivity(presenceData);
 });

--- a/websites/V/Vodafone FM/presence.ts
+++ b/websites/V/Vodafone FM/presence.ts
@@ -20,10 +20,9 @@ presence.on("UpdateData", async () => {
 		presenceData.smallImageText = (await strings).pause;
 	}
 
-	const artistElement = document.querySelector("#artist_name"),
-		songElement = document.querySelector("#song_name");
-	if (artistElement && songElement)
-		presenceData.state = `${artistElement.title} - ${songElement.title}`;
+	const artist = document.querySelector("#artist_name")?.textContent,
+		song = document.querySelector("#song_name")?.textContent;
+	if (artist && song) presenceData.state = `${artist} - ${song}`;
 
 	presence.setActivity(presenceData);
 });

--- a/websites/V/Vodafone FM/presence.ts
+++ b/websites/V/Vodafone FM/presence.ts
@@ -8,7 +8,7 @@ const presence = new Presence({
 
 presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
-		largeImageKey: "logo_512",
+		largeImageKey: "https://i.imgur.com/6IUf3O6.png",
 		details: "Listening to music",
 	};
 

--- a/websites/V/Vodafone FM/presence.ts
+++ b/websites/V/Vodafone FM/presence.ts
@@ -1,0 +1,17 @@
+const presence = new Presence({
+		clientId: "1061398473368412210",
+	}),
+	strings = presence.getStrings({
+		play: "presence.playback.playing",
+		pause: "presence.playback.paused",
+	});
+
+presence.on("UpdateData", async () => {
+	const presenceData: PresenceData = {
+		largeImageKey: "logo_512",
+		details: "Jamming fr fr...",
+		startTimestamp: Math.floor(Date.now() / 1000),
+	};
+
+	presence.setActivity(presenceData);
+});

--- a/websites/V/Vodafone FM/presence.ts
+++ b/websites/V/Vodafone FM/presence.ts
@@ -7,7 +7,7 @@ const presence = new Presence({
 				buttonListenAlong: "general.buttonListenAlong",
 				listeningMusic: "general.listeningMusic",
 				pause: "general.paused",
-				play: "general.playing",
+				live: "general.live",
 				viewPage: "general.viewPage",
 			},
 			await presence.getSetting<string>("lang").catch(() => "en")
@@ -25,7 +25,7 @@ presence.on("UpdateData", async () => {
 
 	if (document.querySelector("#play").classList.contains("hidden")) {
 		presenceData.smallImageKey = "https://i.imgur.com/xiZprpt.png";
-		presenceData.smallImageText = strings.play;
+		presenceData.smallImageText = strings.live;
 	} else {
 		presenceData.smallImageKey = "https://i.imgur.com/w1jwJTh.png";
 		presenceData.smallImageText = strings.pause;

--- a/websites/V/Vodafone FM/presence.ts
+++ b/websites/V/Vodafone FM/presence.ts
@@ -1,24 +1,30 @@
 const presence = new Presence({
 		clientId: "1061398473368412210",
 	}),
-	strings = presence.getStrings({
-		play: "general.playing",
-		pause: "general.paused",
-		listeningMusic: "general.listeningMusic",
-	});
+	getStrings = async () =>
+		presence.getStrings(
+			{
+				play: "general.playing",
+				pause: "general.paused",
+				listeningMusic: "general.listeningMusic",
+			},
+			await presence.getSetting<string>("lang").catch(() => "en")
+		);
+let strings: Awaited<ReturnType<typeof getStrings>>;
 
 presence.on("UpdateData", async () => {
+	strings = await getStrings();
 	const presenceData: PresenceData = {
 		largeImageKey: "https://i.imgur.com/6IUf3O6.png",
-		details: (await strings).listeningMusic,
+		details: strings.listeningMusic,
 	};
 
 	if (document.querySelector("#play").classList.contains("hidden")) {
 		presenceData.smallImageKey = "https://i.imgur.com/xiZprpt.png";
-		presenceData.smallImageText = (await strings).play;
+		presenceData.smallImageText = strings.play;
 	} else {
 		presenceData.smallImageKey = "https://i.imgur.com/w1jwJTh.png";
-		presenceData.smallImageText = (await strings).pause;
+		presenceData.smallImageText = strings.pause;
 	}
 
 	const artist = document.querySelector("#artist_name")?.textContent,

--- a/websites/V/Vodafone FM/presence.ts
+++ b/websites/V/Vodafone FM/presence.ts
@@ -3,7 +3,8 @@ const presence = new Presence({
 	}),
 	strings = presence.getStrings({
 		play: "presence.playback.playing",
-		pause: "presence.playback.paused",
+		pause: "general.paused",
+		listeningMusic: "general.listeningMusic",
 	});
 
 presence.on("UpdateData", async () => {

--- a/websites/V/Vodafone FM/presence.ts
+++ b/websites/V/Vodafone FM/presence.ts
@@ -16,7 +16,7 @@ presence.on("UpdateData", async () => {
 		presenceData.smallImageKey = "https://i.imgur.com/xiZprpt.png";
 		presenceData.smallImageText = (await strings).play;
 	} else {
-		presenceData.smallImageKey = "pause";
+		presenceData.smallImageKey = "https://i.imgur.com/w1jwJTh.png";
 		presenceData.smallImageText = (await strings).pause;
 	}
 

--- a/websites/V/Vodafone FM/presence.ts
+++ b/websites/V/Vodafone FM/presence.ts
@@ -9,9 +9,23 @@ const presence = new Presence({
 presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
 		largeImageKey: "logo_512",
-		details: "Jamming fr fr...",
-		startTimestamp: Math.floor(Date.now() / 1000),
+		details: "Listening to music",
 	};
+
+	const playButton = document.getElementById("play");
+	if (playButton.classList.contains("hidden")) {
+		presenceData.smallImageKey = "play";
+		presenceData.smallImageText = (await strings).play
+	} else {
+		presenceData.smallImageKey = "pause";
+		presenceData.smallImageText = (await strings).pause;
+	}
+
+	const artistElement = document.getElementById("artist_name");
+	if (artistElement) {
+		const songElement = document.getElementById("song_name");
+		presenceData.state = `${artistElement.title} - ${songElement.title}`;
+	}
 
 	presence.setActivity(presenceData);
 });

--- a/websites/V/Vodafone FM/presence.ts
+++ b/websites/V/Vodafone FM/presence.ts
@@ -29,7 +29,10 @@ presence.on("UpdateData", async () => {
 
 	const artist = document.querySelector("#artist_name")?.textContent,
 		song = document.querySelector("#song_name")?.textContent;
-	if (artist && song) presenceData.state = `${artist} - ${song}`;
+	if (artist && song) {
+		presenceData.details = song;
+		presenceData.state = artist;
+	}
 
 	const cover = document.querySelector<HTMLImageElement>("#cover");
 	if (cover && !cover.src.includes("/images/nocover.png"))


### PR DESCRIPTION
## Description 
Added a new Presence for [Vodafone FM](https://vodafone.fm), a famous Portuguese FM radio.

Do let me know if this qualifies as a valid Presence as the Contribution guide wasn't fully clear for me.
```
Presences for online radios are only allowed if the radio has at least 100 weekly listeners and 15 concurrent
and must have some features other than just showing album/song title, etc.
```
Are the mentioned features about the radio or the Presence?

Thanks in advance!

## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

### Playing
![image](https://user-images.githubusercontent.com/39736248/215266644-1987deb8-c4b6-4c5f-be2b-c1ea8c4b89cd.png)
### Paused
![image](https://user-images.githubusercontent.com/39736248/215266666-e3ec6215-5824-4f9b-9b58-1b80915893d6.png)
### No song info
![image](https://user-images.githubusercontent.com/39736248/215266722-91a4ce32-509b-4bff-a0bc-eecc4892ce52.png)
</details>
