### PR TITLE
feat(Nix Mangas): add presence

### DIFF
--- a/websites/N/Nix Mangas/metadata.json
+++ b/websites/N/Nix Mangas/metadata.json
@@ -1,0 +1,22 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.7",
+	"author": {
+		"name": "Luscarvalho",
+		"id": "458776046184169473"
+	},
+	"service": "Nix Mangas",
+	"description": {
+		"en": "Nix Mangas is a site to read manga and manhwas without ads",
+		"pt_BR": "Nix Mangás é um site para ler mangás e manhwas sem anúncios"
+	},
+	"url": "nixmangas.com",
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/7ooKWuO.png",
+	"thumbnail": "https://i.imgur.com/IjZZNY4.png",
+	"color": "#0e0e12",
+	"category": "other",
+	"tags": [
+		"manhwa",
+		"manga"
+	]
+}

--- a/websites/N/Nix Mangas/presence.ts
+++ b/websites/N/Nix Mangas/presence.ts
@@ -1,0 +1,27 @@
+const presence = new Presence({
+		clientId: "1073255300263591946",
+	}),
+	browsingTimestamp = Math.floor(Date.now() / 1000);
+presence.on("UpdateData", () => {
+	const { pathname } = window.location,
+		presenceData: PresenceData = {
+			largeImageKey: "https://i.imgur.com/7ooKWuO.png",
+			startTimestamp: browsingTimestamp,
+		};
+	if (pathname.startsWith("/")) presenceData.details = "Na página principal";
+	if (pathname.startsWith("/obras"))
+		presenceData.details = "Visualizando Mangás";
+	if (pathname.startsWith("/obras/")) {
+		presenceData.details = "Visualizando Mangá";
+		presenceData.state = document.querySelector("header h1")?.textContent;
+		presenceData.buttons = [{ label: "Ver mangá", url: location.href }];
+	}
+	if (pathname.startsWith("/ler/")) {
+		presenceData.details = "Lendo";
+		presenceData.state = document.querySelector("header h2")?.textContent;
+		presenceData.buttons = [{ label: "Ler capítulo", url: location.href }];
+	}
+
+	if (!presenceData.details) presence.setActivity();
+	else presence.setActivity(presenceData);
+});


### PR DESCRIPTION
Add presence for  [Nix Mangas](https://nixmangas.com/)
I added a presence from a manga site that is under development, I did as in the documentation and reused attendance codes that I had already made

- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

Settings:

Show covers,
Show timestamps,
Show buttons.

<details>

| ![img1](https://cdn.discordapp.com/attachments/811749701997166613/1073272113982603294/image.png) | ![img2](https://cdn.discordapp.com/attachments/811749701997166613/1073272163446030487/image.png) |
|--|--|
| ![img3](https://cdn.discordapp.com/attachments/811749701997166613/1073272222929653871/image.png) | ![img4](https://cdn.discordapp.com/attachments/811749701997166613/1073272270920888390/image.png) |

</details>


