### PR TITLE
fix(Animes Vision): logo

### DIFF
--- a/websites/A/Animes Vision/metadata.json
+++ b/websites/A/Animes Vision/metadata.json
@@ -20,7 +20,7 @@
 		"vi_VN": "Animes Vision là một trong những trang anime lớn nhất Brazil."
 	},
 	"url": "animes.vision",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"logo": "https://i.imgur.com/mzqXcKZ.png",
 	"thumbnail": "https://i.imgur.com/OIHNhHg.png",
 	"color": "#0EAFC1",

--- a/websites/A/Animes Vision/presence.ts
+++ b/websites/A/Animes Vision/presence.ts
@@ -4,7 +4,7 @@ const presence = new Presence({
 	browsingTimestamps = Math.floor(Date.now() / 1000);
 
 enum Assets {
-	Logo = "https://i.imgur.com/CSan6Ae.png",
+	Logo = "https://i.imgur.com/mzqXcKZ.png",
 	Playing = "https://i.imgur.com/KNneWuF.png",
 	Paused = "https://i.imgur.com/BtWUfrZ.png",
 }
@@ -72,9 +72,6 @@ presence.on("UpdateData", async () => {
 				presence.getTimestamps(video.currentTime, video.duration);
 			presenceData.smallImageKey = Assets.Playing;
 			presenceData.smallImageText = strings.playing;
-			presenceData.largeImageKey = document
-				.querySelector('meta[property="og:image"]')
-				.getAttribute("content");
 
 			presenceData.buttons = [
 				{ label: strings.buttonViewEpisode, url: href },


### PR DESCRIPTION
## Description 
Animes Vision has a big logo for discord presence on pages like home and for pages like episode, the logo don't exist

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
old version

![image](https://user-images.githubusercontent.com/37979213/221438936-00dd746a-4ffb-4e8b-b66a-dffe13ce322e.png)

new version
![image](https://user-images.githubusercontent.com/37979213/221438918-af03abb5-9d2e-4429-bae1-bd17aec9e577.png)
</details>
