### PR TITLE
feat(signed.host): add presence

### DIFF
--- a/websites/S/signed.host/metadata.json
+++ b/websites/S/signed.host/metadata.json
@@ -9,7 +9,7 @@
   "description": {
     "en": "Signed.host is a private media, and bio page hosting service."
   },
-  "url": ["signed.host", "bio.signed.host"],
+  "url": ["www.signed.host","signed.host", "bio.signed.host"],
   "version": "1.0.0",
   "logo": "https://i.imgur.com/0CyTL1E.png",
   "thumbnail": "https://i.imgur.com/6F2gWZR.png",

--- a/websites/S/signed.host/metadata.json
+++ b/websites/S/signed.host/metadata.json
@@ -4,7 +4,7 @@
   "altnames": ["bio.signed.host"],
   "author": {
     "id": "439084103690616844",
-    "name": "MalwarePad#0001"
+    "name": "MalwarePad"
   },
   "description": {
     "en": "Signed.host is a private media, and bio page hosting service."

--- a/websites/S/signed.host/metadata.json
+++ b/websites/S/signed.host/metadata.json
@@ -1,25 +1,31 @@
 {
-  "$schema": "https://schemas.premid.app/metadata/1.7",
-  "service": "signed.host",
-  "altnames": ["bio.signed.host"],
-  "author": {
-    "id": "439084103690616844",
-    "name": "MalwarePad"
-  },
-  "description": {
-    "en": "Signed.host is a private media, and bio page hosting service."
-  },
-  "url": ["www.signed.host","signed.host", "bio.signed.host"],
-  "version": "1.0.0",
-  "logo": "https://i.imgur.com/0CyTL1E.png",
-  "thumbnail": "https://i.imgur.com/6F2gWZR.png",
-  "color": "#37b2eb",
-  "tags": [
-    "signed",
-    "media",
-    "bio",
-    "image",
-    "hosting"
-  ],
-  "category": "socials"
+	"$schema": "https://schemas.premid.app/metadata/1.7",
+	"author": {
+		"id": "439084103690616844",
+		"name": "MalwarePad"
+	},
+	"service": "signed.host",
+	"altnames": [
+		"bio.signed.host"
+	],
+	"description": {
+		"en": "Signed.host is a private media, and bio page hosting service."
+	},
+	"url": [
+		"www.signed.host",
+		"signed.host",
+		"bio.signed.host"
+	],
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/lpLWPa4.png",
+	"thumbnail": "https://i.imgur.com/6F2gWZR.png",
+	"color": "#37b2eb",
+	"category": "socials",
+	"tags": [
+		"signed",
+		"media",
+		"bio",
+		"image",
+		"hosting"
+	]
 }

--- a/websites/S/signed.host/metadata.json
+++ b/websites/S/signed.host/metadata.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.7",
+  "service": "signed.host",
+  "altnames": ["bio.signed.host"],
+  "author": {
+    "id": "439084103690616844",
+    "name": "MalwarePad#0001"
+  },
+  "description": {
+    "en": "Signed.host is a private media, and bio page hosting service."
+  },
+  "url": ["signed.host", "bio.signed.host"],
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/0CyTL1E.png",
+  "thumbnail": "https://i.imgur.com/6F2gWZR.png",
+  "color": "#37b2eb",
+  "tags": [
+    "signed",
+    "media",
+    "bio",
+    "image",
+    "hosting"
+  ],
+  "category": "socials"
+}

--- a/websites/S/signed.host/presence.ts
+++ b/websites/S/signed.host/presence.ts
@@ -1,10 +1,6 @@
 const presence = new Presence({
-		clientId: "1000664778404016230",
-	}),
-	strings = presence.getStrings({
-		play: "presence.playback.playing",
-		pause: "presence.playback.paused",
-	});
+	clientId: "1000664778404016230",
+});
 
 let lastUnique: string | undefined,
 	lastTimestamp: number | undefined = Date.now();

--- a/websites/S/signed.host/presence.ts
+++ b/websites/S/signed.host/presence.ts
@@ -61,7 +61,7 @@ presence.on("UpdateData", async () => {
 		case "bio.signed.host":
 			if (pathname === "/") {
 				details = "Viewing the front bio page";
-				return;
+				break;
 			}
 			details = `Viewing ${
 				document

--- a/websites/S/signed.host/presence.ts
+++ b/websites/S/signed.host/presence.ts
@@ -2,13 +2,13 @@ const presence = new Presence({
 	clientId: "1000664778404016230",
 });
 
-let lastUnique: string | undefined,
-	lastTimestamp: number | undefined = Date.now();
+let lastUnique: string,
+	lastTimestamp = Date.now();
 
 presence.on("UpdateData", async () => {
 	if (document.querySelector(".next-error-h1")) return presence.clearActivity();
 
-	const { pathname, hostname } = document.location;
+	const { pathname, hostname, href } = document.location;
 
 	if (lastUnique !== pathname) {
 		lastUnique = pathname;
@@ -16,106 +16,81 @@ presence.on("UpdateData", async () => {
 	}
 
 	let details = `Currently on ${pathname}`,
-		buttonLabel = "Visit page",
-		buttonURL = document.location.toString(),
+		buttonLabel = null,
+		buttonURL = null,
 		state = null;
 
-	const loggedUsername = document.querySelector("#premid-username")?.innerHTML;
+	const loggedUsername =
+			document.querySelector("#premid-username")?.textContent,
+		pages: Record<string, PresenceData> = {
+			"/": { details: "Viewing the front page" },
+			"/terms": { details: "Reading the terms of the service" },
+			"/login": { details: "Logging into their dashboard" },
+
+			"/dash": { details: "Watching their general statistics" },
+			"/dash/service/account": { details: "Editing account information" },
+			"/dash/service/domains": { details: "Changing their domain" },
+			"/dash/service/settings": {
+				details: "Configuring their upload preferences",
+			},
+			"/dash/service/subscription": { details: "Viewing subscription options" },
+			"/dash/service/gallery": { details: "Viewing their image gallery" },
+			"/dash/service/warns": { details: "Viewing their warns" },
+			"/dash/service/invites": { details: "Viewing their invite inventory" },
+			"/dash/service/upload": {
+				details: "Uploading file(s) with the web uploader",
+			},
+			"/dash/service/email": { details: "Configuring their email preferences" },
+			"/dash/connections/discord": {
+				details: "Modifying their Discord connection",
+			},
+			"/dash/bio/customize": { details: "Customizing their bio page" },
+			"/dash/bio/css": { details: "Editing their custom CSS" },
+		};
 
 	switch (hostname) {
 		case "signed.host":
 			if (pathname.includes("/dash")) {
-				loggedUsername
-					? (state = `Logged in as ${loggedUsername}`)
-					: (state = "Not logged in!");
-				buttonLabel = "Join signed.host";
-				buttonURL = "https://signed.host/";
+				if (loggedUsername) state = `Logged in as ${loggedUsername}`;
+				else state = "Not logged in!";
 			}
-			switch (pathname) {
-				// Design/Frontend routes
-				case "/":
-					details = "Viewing the front page";
-					break;
-				case "/terms":
-					details = "Reading the terms of the service";
-					break;
 
-				case "/login":
-					details = "Logging into their dashboard";
-					buttonLabel = "Join signed.host";
-					buttonURL = "https://signed.host/";
-					break;
+			details = pages[pathname]?.details;
 
-				// Dashboard routes
-				case "/dash":
-					details = "Watching their general statistics";
-					break;
-				case "/dash/service/account":
-					details = "Editing account information";
-					break;
-				case "/dash/service/domains":
-					details = "Changing their domain";
-					break;
-				case "/dash/service/settings":
-					details = "Configuring their upload preferances";
-					break;
-				case "/dash/service/subscription":
-					details = "Viewing subscription options";
-					break;
-				case "/dash/service/gallery":
-					details = "Viewing their image gallery";
-					break;
-				case "/dash/service/warns":
-					details = "Viewing their warns";
-					break;
-				case "/dash/service/invites":
-					details = "Viewing their invite inventory";
-					break;
-				case "/dash/service/upload":
-					details = "Uploading file(s) with the web uploader";
-					break;
-				case "/dash/service/email":
-					details = "Configuring their email preferances";
-					break;
-				case "/dash/connections/discord":
-					details = "Modifying their Discord connection";
-					break;
-				case "/dash/bio/customize":
-					details = "Customizing their bio page";
-					break;
-				case "/dash/bio/css":
-					details = "Editing their custom CSS";
-					break;
-			}
 			break;
 		case "bio.signed.host":
-			if (pathname === "/") details = "Viewing the front bio page";
-			else {
-				details = `Viewing ${
-					document
-						.querySelector("#premid-username")
-						?.innerHTML?.replace(/#.*/g, "") ?? "someone"
-				}'s bio page`;
-				state = `${
-					document.querySelector("#premid-status")?.innerHTML ?? "unknown"
-				} | ${
-					parseInt(document.querySelector("#premid-bioviews")?.innerHTML) ||
-					0 > 0
-						? document.querySelector("#premid-bioviews")?.innerHTML
-						: "no"
-				} views | uid ${
-					document.querySelector("#premid-uid")?.innerHTML ?? "no"
-				}`;
-				buttonLabel = "Visit bio";
+			if (pathname === "/") {
+				details = "Viewing the front bio page";
+				return;
 			}
+			details = `Viewing ${
+				document
+					.querySelector("#premid-username")
+					?.textContent?.replace(/#.*/g, "") ?? "someone"
+			}'s bio page`;
+			state = `${
+				document.querySelector("#premid-status")?.textContent ?? "unknown"
+			} | ${
+				parseInt(document.querySelector("#premid-bioviews")?.textContent) ||
+				0 > 0
+					? document.querySelector("#premid-bioviews")?.textContent
+					: "no"
+			} views | uid ${
+				document.querySelector("#premid-uid")?.textContent ?? "no"
+			}`;
+			buttonLabel = "Visit Bio";
+			buttonURL = href;
 			break;
 	}
 
 	presence.setActivity({
-		largeImageKey: "logo",
+		largeImageKey: "https://i.imgur.com/lpLWPa4.png",
 		state,
 		startTimestamp: lastTimestamp,
 		details,
-		buttons: [{ label: buttonLabel, url: buttonURL }],
+		buttons:
+			buttonLabel && buttonURL
+				? [{ label: buttonLabel, url: buttonURL }]
+				: null,
 	});
 });

--- a/websites/S/signed.host/presence.ts
+++ b/websites/S/signed.host/presence.ts
@@ -1,0 +1,125 @@
+const presence = new Presence({
+		clientId: "1000664778404016230",
+	}),
+	strings = presence.getStrings({
+		play: "presence.playback.playing",
+		pause: "presence.playback.paused",
+	});
+
+let lastUnique: string | undefined,
+	lastTimestamp: number | undefined = Date.now();
+
+presence.on("UpdateData", async () => {
+	if (document.querySelector(".next-error-h1")) return presence.clearActivity();
+
+	const { pathname, hostname } = document.location;
+
+	if (lastUnique !== pathname) {
+		lastUnique = pathname;
+		lastTimestamp = Date.now();
+	}
+
+	let details = `Currently on ${pathname}`,
+		buttonLabel = "Visit page",
+		buttonURL = document.location.toString(),
+		state = null;
+
+	const loggedUsername = document.querySelector("#premid-username")?.innerHTML;
+
+	switch (hostname) {
+		case "signed.host":
+			if (pathname.includes("/dash")) {
+				loggedUsername
+					? (state = `Logged in as ${loggedUsername}`)
+					: (state = "Not logged in!");
+				buttonLabel = "Join signed.host";
+				buttonURL = "https://signed.host/";
+			}
+			switch (pathname) {
+				// Design/Frontend routes
+				case "/":
+					details = "Viewing the front page";
+					break;
+				case "/terms":
+					details = "Reading the terms of the service";
+					break;
+
+				case "/login":
+					details = "Logging into their dashboard";
+					buttonLabel = "Join signed.host";
+					buttonURL = "https://signed.host/";
+					break;
+
+				// Dashboard routes
+				case "/dash":
+					details = "Watching their general statistics";
+					break;
+				case "/dash/service/account":
+					details = "Editing account information";
+					break;
+				case "/dash/service/domains":
+					details = "Changing their domain";
+					break;
+				case "/dash/service/settings":
+					details = "Configuring their upload preferances";
+					break;
+				case "/dash/service/subscription":
+					details = "Viewing subscription options";
+					break;
+				case "/dash/service/gallery":
+					details = "Viewing their image gallery";
+					break;
+				case "/dash/service/warns":
+					details = "Viewing their warns";
+					break;
+				case "/dash/service/invites":
+					details = "Viewing their invite inventory";
+					break;
+				case "/dash/service/upload":
+					details = "Uploading file(s) with the web uploader";
+					break;
+				case "/dash/service/email":
+					details = "Configuring their email preferances";
+					break;
+				case "/dash/connections/discord":
+					details = "Modifying their Discord connection";
+					break;
+				case "/dash/bio/customize":
+					details = "Customizing their bio page";
+					break;
+				case "/dash/bio/css":
+					details = "Editing their custom CSS";
+					break;
+			}
+			break;
+		case "bio.signed.host":
+			if (pathname === "/") details = "Viewing the front bio page";
+			else {
+				details = `Viewing ${
+					document
+						.querySelector("#premid-username")
+						?.innerHTML?.replace(/#.*/g, "") ?? "someone"
+				}'s bio page`;
+				state = `${
+					document.querySelector("#premid-status")?.innerHTML ?? "unknown"
+				} | ${
+					parseInt(document.querySelector("#premid-bioviews")?.innerHTML) ||
+					0 > 0
+						? document.querySelector("#premid-bioviews")?.innerHTML
+						: "no"
+				} views | uid ${
+					document.querySelector("#premid-uid")?.innerHTML ?? "no"
+				}`;
+				buttonLabel = "Visit bio";
+			}
+			break;
+	}
+
+	presence.setActivity({
+		largeImageKey: "logo",
+		state,
+		startTimestamp: lastTimestamp,
+		details,
+		buttons: [{ label: buttonLabel, url: buttonURL }],
+	});
+});


### PR DESCRIPTION
## Description 
Addition of signed.host, a private media, and bio page hosting service.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://user-images.githubusercontent.com/42353172/224429420-bd80558b-e42f-416d-8995-79c328259b8f.png)

![image](https://user-images.githubusercontent.com/42353172/224429569-c694a356-9534-4714-bf6b-4dbb9a7ae046.png)

![image](https://user-images.githubusercontent.com/42353172/224429805-316e682a-fbd4-457d-9ed2-8a94c86288d1.png)

</details>

I'll be happy to provide additional information in order for the process be sped up.