### PR TITLE
chore: add correct pnpm lockfile to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # General files
 .idea
 node_modules
-pnpm-lock.json
 pnpm-lock.yaml
 yarn.lock
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 node_modules
 pnpm-lock.json
+pnpm-lock.yaml
 yarn.lock
 .env
 


### PR DESCRIPTION
## Description 
Adds `pnpm-lock.yaml` to the gitignore

## Acknowledgements
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)