### PR TITLE
fix(Tidal): fix artists not being seperated after update

### DIFF
--- a/websites/T/Tidal/metadata.json
+++ b/websites/T/Tidal/metadata.json
@@ -22,7 +22,7 @@
 		"listen.tidal.com",
 		"tidal.com"
 	],
-	"version": "3.1.10",
+	"version": "3.1.11",
 	"logo": "https://i.imgur.com/i9pIvqR.png",
 	"thumbnail": "https://i.imgur.com/xNeJ8oq.png",
 	"color": "#000000",

--- a/websites/T/Tidal/presence.ts
+++ b/websites/T/Tidal/presence.ts
@@ -1,6 +1,5 @@
-const presence = new Presence({
-	clientId: "901591802342150174",
-});
+const LOGO_URL = "https://i.imgur.com/i9pIvqR.png",
+	presence = new Presence({ clientId: "901591802342150174" });
 
 async function getStrings() {
 	return presence.getStrings(
@@ -18,7 +17,7 @@ let strings: Awaited<ReturnType<typeof getStrings>>,
 
 presence.on("UpdateData", async () => {
 	if (!document.querySelector("#footerPlayer"))
-		return presence.setActivity({ largeImageKey: "logo" });
+		return presence.setActivity({ largeImageKey: LOGO_URL });
 
 	const [newLang, timestamps, cover, buttons] = await Promise.all([
 		presence.getSetting<string>("lang").catch(() => "en"),
@@ -32,7 +31,7 @@ presence.on("UpdateData", async () => {
 		strings = await getStrings();
 	}
 	const presenceData: PresenceData = {
-			largeImageKey: "https://i.imgur.com/i9pIvqR.png",
+			largeImageKey: LOGO_URL,
 		},
 		songTitle = document.querySelector<HTMLAnchorElement>(
 			'div[data-test="footer-track-title"] > a'

--- a/websites/T/Tidal/presence.ts
+++ b/websites/T/Tidal/presence.ts
@@ -57,9 +57,11 @@ presence.on("UpdateData", async () => {
 
 	presenceData.details = songTitle.textContent;
 	// get artists
-	presenceData.state = document.querySelector(
-		'div[data-test="left-column-footer-player"] > div:nth-child(2) > div:nth-child(2) > span > span > span'
-	).textContent;
+	presenceData.state = Array.from(
+		document.querySelectorAll<HTMLAnchorElement>("#footerPlayer .artist-link a")
+	)
+		.map(artist => artist.textContent)
+		.join(", ");
 
 	if (cover) {
 		presenceData.largeImageKey = document


### PR DESCRIPTION
## Description 
I recently noticed that the artist list looked like this:
![grafik](https://user-images.githubusercontent.com/58221423/226118566-ec9aa989-b3c0-4e3e-981c-6cb1dede3ef5.png)
notice how there are no commas seperating the artists.

This pull request fixes the formatting of artists.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
After changes:
![grafik](https://user-images.githubusercontent.com/58221423/226118674-f4cc4644-81e5-4f61-a07a-d0113d418e43.png)
</details>
