### PR TITLE
fix(ITVX): fix live channel presence due to data structure change

### DIFF
--- a/websites/I/ITVX/metadata.json
+++ b/websites/I/ITVX/metadata.json
@@ -13,7 +13,7 @@
 		"www.itv.com",
 		"itv.com"
 	],
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"logo": "https://i.imgur.com/XisKvdg.png",
 	"thumbnail": "https://i.imgur.com/jqV7iTp.jpg",
 	"color": "#102C3D",

--- a/websites/I/ITVX/metadata.json
+++ b/websites/I/ITVX/metadata.json
@@ -14,7 +14,7 @@
 		"itv.com"
 	],
 	"version": "1.0.4",
-	"logo": "https://i.imgur.com/XisKvdg.png",
+	"logo": "https://i.imgur.com/xUkE69G.png",
 	"thumbnail": "https://i.imgur.com/jqV7iTp.jpg",
 	"color": "#102C3D",
 	"category": "videos",

--- a/websites/I/ITVX/presence.ts
+++ b/websites/I/ITVX/presence.ts
@@ -86,10 +86,9 @@ presence.on("UpdateData", async () => {
 			case "/watch": {
 				const nextData = fetchNextData<LiveChannelNextData>(),
 					// When you first go to watch a channel, the slug is null and the default channel is ITV1
-					currentChannelMetadata =
-						nextData.props.pageProps.channels.find(
-							x => x.slug === (nextData.props.pageProps.channelSlug || "itv")
-						);
+					currentChannelMetadata = nextData.props.pageProps.channels.find(
+						x => x.slug === (nextData.props.pageProps.channelSlug || "itv")
+					);
 
 				// At the moment, it doesn't seem the title of the current programme changes when it transitions from one programme
 				// to the next. Use the channel slot data start and end times to determine which title to show.

--- a/websites/I/ITVX/presence.ts
+++ b/websites/I/ITVX/presence.ts
@@ -51,7 +51,7 @@ interface ProgrammeNextData {
 }
 
 const enum Assets {
-	Logo = "https://i.imgur.com/XisKvdg.png",
+	Logo = "https://i.imgur.com/xUkE69G.png",
 }
 
 const presence = new Presence({

--- a/websites/I/ITVX/presence.ts
+++ b/websites/I/ITVX/presence.ts
@@ -20,9 +20,7 @@ interface LiveChannelNextData {
 	props: {
 		pageProps: {
 			channelSlug: string;
-			channelsMetaData: {
-				channels: ChannelMetadata[];
-			};
+			channels: ChannelMetadata[];
 		};
 	};
 }
@@ -89,7 +87,7 @@ presence.on("UpdateData", async () => {
 				const nextData = fetchNextData<LiveChannelNextData>(),
 					// When you first go to watch a channel, the slug is null and the default channel is ITV1
 					currentChannelMetadata =
-						nextData.props.pageProps.channelsMetaData.channels.find(
+						nextData.props.pageProps.channels.find(
 							x => x.slug === (nextData.props.pageProps.channelSlug || "itv")
 						);
 


### PR DESCRIPTION
## Description 
ITVX has slightly changed the structure of the NEXT_DATA page props, and as a result broke the ability to correctly display the presence when viewing live channels.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://user-images.githubusercontent.com/37845774/234045123-60608b00-4aa0-46ac-b74f-3b63516d4e21.png)



</details>
