### PR TITLE
fix(Shikimori): update url

### DIFF
--- a/websites/S/Shikimori/metadata.json
+++ b/websites/S/Shikimori/metadata.json
@@ -6,8 +6,8 @@
 	},
 	"service": "Shikimori",
 	"description": {
-		"en": "Shikimori is online encyclopedia of anime and manga. The full list of popular manga in Russian. Shikimori.one is the best anime forum to communicate in.",
-		"ru": "Шикимори — онлайн энциклопедия аниме и манги. Полный список популярной манги на русском. Shikimori.one — лучший аниме-форум для общения."
+		"en": "Shikimori is online encyclopedia of anime and manga. The full list of popular manga in Russian. Shikimori is the best anime forum to communicate in.",
+		"ru": "Шикимори — онлайн энциклопедия аниме и манги. Полный список популярной манги на русском. Shikimori — лучший аниме-форум для общения."
 	},
 	"url": "shikimori.me",
 	"version": "1.1.5",

--- a/websites/S/Shikimori/metadata.json
+++ b/websites/S/Shikimori/metadata.json
@@ -9,8 +9,8 @@
 		"en": "Shikimori is online encyclopedia of anime and manga. The full list of popular manga in Russian. Shikimori.one is the best anime forum to communicate in.",
 		"ru": "Шикимори — онлайн энциклопедия аниме и манги. Полный список популярной манги на русском. Shikimori.one — лучший аниме-форум для общения."
 	},
-	"url": "shikimori.one",
-	"version": "1.1.4",
+	"url": "shikimori.me",
+	"version": "1.1.5",
 	"logo": "https://i.imgur.com/7tlc7or.png",
 	"thumbnail": "https://i.imgur.com/jS5LyDW.png",
 	"color": "#4f4f4f",


### PR DESCRIPTION
## Description 
Changed URL of [Shikimori](https://shikimori.me/): shikimori.one -> shikimori.me

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)


## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

| Home | User's Page | Anime Page |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/37224822/236697400-6b98c4e5-b410-4436-914c-fadd1c55e6d8.png) | ![image](https://user-images.githubusercontent.com/37224822/236697280-e2a94b56-1f9c-4033-9295-338ea63409ea.png) | ![image](https://user-images.githubusercontent.com/37224822/236697437-f96c1ade-9fc0-4e03-9395-ef0e40b2d7a9.png) |

</details>
