### PR TITLE
fix(svtplay): update query selectors

### DIFF
--- a/websites/S/SVT Play/metadata.json
+++ b/websites/S/SVT Play/metadata.json
@@ -11,7 +11,7 @@
 		"sv_SE": "Se dina favoritprogram när du vill i SVT Play - fri television på nätet."
 	},
 	"url": "www.svtplay.se",
-	"version": "1.2.19",
+	"version": "1.2.20",
 	"logo": "https://i.imgur.com/QckmKnj.png",
 	"thumbnail": "https://i.imgur.com/QggYFa4.png",
 	"color": "#00c901",

--- a/websites/S/SVT Play/presence.ts
+++ b/websites/S/SVT Play/presence.ts
@@ -70,9 +70,7 @@ presence.on("UpdateData", async () => {
 			title = document.querySelector(
 				'[data-rt="program-info-title"] > a'
 			).textContent;
-			user = document.querySelector(
-				'[data-rt="episode-link"]'
-			).textContent;
+			user = document.querySelector('[data-rt="episode-link"]').textContent;
 			if (video) {
 				if (!video.duration) {
 					time = false;

--- a/websites/S/SVT Play/presence.ts
+++ b/websites/S/SVT Play/presence.ts
@@ -25,13 +25,13 @@ presence.on("UpdateData", async () => {
 			presenceData.details = "Navigerar program kategorier";
 		} else if (document.location.pathname.includes("/kanaler/")) {
 			const video = document.querySelector<HTMLVideoElement>(
-				"#play_main-content > article > div.play_channels-video--show > div > div > div.play_video-player.lp_video.play_channels__active-video > div > video"
+				'[data-rt="video-player-channels"]'
 			);
 			title = document.querySelector(
-				"#play_main-content > article > div.play_channels-video--show > div > div > div.play_channels__active-video-info > h2"
+				"#play_main-content > div > div.sc-b35938a7-1.bTCBgw > div > div > div.sc-2c367a6f-0.dxLhHV > h2"
 			).textContent;
 			user = document.querySelector(
-				"#play_main-content > article > div.play_channels-video--show > div > div > div.play_channels__active-video-info > p.play_channels__active-subheader"
+				"#play_main-content > div > div.sc-b35938a7-1.bTCBgw > div > div > div.sc-2c367a6f-0.dxLhHV > p"
 			).textContent;
 			if (video) {
 				presenceData.smallImageKey = "live";
@@ -65,13 +65,13 @@ presence.on("UpdateData", async () => {
 				live: boolean,
 				timestamps: number[];
 			const video = document.querySelector<HTMLVideoElement>(
-				"#js-play_video__fullscreen-container > div > div > video"
+				'[data-rt="video-player"]'
 			);
 			title = document.querySelector(
-				"#titel > h1 > span:nth-child(1)"
+				'[data-rt="program-info-title"] > a'
 			).textContent;
 			user = document.querySelector(
-				"#titel > h1 > span:nth-child(2)"
+				'[data-rt="episode-link"]'
 			).textContent;
 			if (video) {
 				if (!video.duration) {
@@ -129,9 +129,9 @@ presence.on("UpdateData", async () => {
 		} else if (document.location.pathname.includes("/sok")) {
 			presenceData.startTimestamp = browsingTimestamp;
 			presenceData.details = "Searching for:";
-			presenceData.details = " Söker på:";
+			presenceData.details = "Söker på:";
 			presenceData.state = document.querySelector(
-				"#play_main-content > section > h2.play_search-page__header.play_search-page__header--match > span"
+				'[data-rt="header-search-result"] > span:nth-child(1)'
 			).textContent;
 			presenceData.smallImageKey = Assets.Search;
 		}

--- a/websites/S/SVT Play/presence.ts
+++ b/websites/S/SVT Play/presence.ts
@@ -28,10 +28,10 @@ presence.on("UpdateData", async () => {
 				'[data-rt="video-player-channels"]'
 			);
 			title = document.querySelector(
-				"#play_main-content > div > div.sc-b35938a7-1.bTCBgw > div > div > div.sc-2c367a6f-0.dxLhHV > h2"
+				"#play_main-content > div > div > div > div > div > h2"
 			).textContent;
 			user = document.querySelector(
-				"#play_main-content > div > div.sc-b35938a7-1.bTCBgw > div > div > div.sc-2c367a6f-0.dxLhHV > p"
+				"#play_main-content > div > div > div > div > div > p"
 			).textContent;
 			if (video) {
 				presenceData.smallImageKey = "live";


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

Since the current presence version of the website doesn't work with the old query selectors, they have now been fixed to work with the latest changes to the SVT Play website.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

### Watching via "/video/"
![Showcasing "watching via /video/"](https://github.com/PreMiD/Presences/assets/56734956/7a8fa6f0-f65b-4bb0-a653-534009ca0a0a)

### Watching live via "/video/"

> COMMENT: SVT Play seems to now use a set duration/timecode when watching live broadcasts via "/video/" instead of showing how much time has passed since the broadcast started. This means that for live material watched through the "/video/" path, the "fetched" time will be a "left" time.

![Showcasing "live via /video/"](https://github.com/PreMiD/Presences/assets/56734956/b11a632e-26d3-4438-8a0d-44ca92f3e270)

### Live via "/kanaler/"
![Showcasing "live via kanaler"](https://github.com/PreMiD/Presences/assets/56734956/538cd68c-fc8a-40b3-a0ec-51448a970455)

### Search
![Showcasing "search"](https://github.com/PreMiD/Presences/assets/56734956/69bddee7-46b4-4364-88c0-d6d455c77c74)
</details>
