### PR TITLE
feat(Phind): add presence

### DIFF
--- a/websites/P/Phind/metadata.json
+++ b/websites/P/Phind/metadata.json
@@ -35,6 +35,12 @@
 			"value": true
 		},
 		{
+			"id": "cycleSearch",
+			"title": "Cycle search queries",
+			"icon": "fa-duotone fa-line-height",
+			"value": true
+		},
+		{
 			"id": "shareSearch",
 			"title": "Share search",
 			"icon": "fa-duotone fa-share-from-square",

--- a/websites/P/Phind/metadata.json
+++ b/websites/P/Phind/metadata.json
@@ -1,0 +1,50 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.7",
+	"author": {
+		"id": "242621043561201666",
+		"name": "GreenMan36"
+	},
+	"service": "Phind",
+	"description": {
+		"en": "Phind is an AI-powered search engine that provides immediate, detailed answers to various questions. Drawing from multiple internet sources, it ensures up-to-date and accurate information, making the search for answers as simple and interactive as having a conversation with a friend."
+	},
+	"url": "www.phind.com",
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/6fdQsQJ.png",
+	"thumbnail": "https://i.imgur.com/QtMoo9B.png",
+	"color": "#000000",
+	"category": "other",
+	"tags": [
+		"search",
+		"coding",
+		"programming",
+		"ai",
+		"gpt"
+	],
+	"settings": [
+		{
+			"id": "displayTime",
+			"title": "Display time spent",
+			"icon": "fa-duotone fa-clock",
+			"value": true
+		},
+		{
+			"id": "displaySearch",
+			"title": "Display search query",
+			"icon": "fa-duotone fa-align-left",
+			"value": true
+		},
+		{
+			"id": "shareSearch",
+			"title": "Share search",
+			"icon": "fa-duotone fa-share-from-square",
+			"value": true
+		},
+		{
+			"id": "privateMode",
+			"title": "Hide all activity",
+			"icon": "fa-duotone fa-user-secret",
+			"value": false
+		}
+	]
+}

--- a/websites/P/Phind/presence.ts
+++ b/websites/P/Phind/presence.ts
@@ -31,11 +31,11 @@ presence.on("UpdateData", async () => {
 		searchResults = document.querySelectorAll("div.row[name^='answer-']"),
 		[displayTime, displaySearch, cycleSearch, shareSearch, privateMode] =
 			await Promise.all([
-				presence.getSetting("displayTime"), // shows/hides the time spent on the site
-				presence.getSetting("displaySearch"), // shows/hides your search query text
-				presence.getSetting("cycleSearch"), // cycles through all the search query on the page
-				presence.getSetting("shareSearch"), // shares your search with a button
-				presence.getSetting("privateMode"), // hides the querry, button and what exact page you are on
+				presence.getSetting("displayTime"),
+				presence.getSetting("displaySearch"),
+				presence.getSetting("cycleSearch"),
+				presence.getSetting("shareSearch"),
+				presence.getSetting("privateMode"),
 			]);
 
 	if (displayTime) presenceData.startTimestamp = browsingTimestamp;
@@ -45,13 +45,11 @@ presence.on("UpdateData", async () => {
 		presenceData.state = pathname; // display /path
 		slideshow.deleteAllSlides();
 	} else if (searchResults.length > 0 && !privateMode) {
-		// we must be on /search and arn't in private mode
-		// presenceData.details = "Searching";
+		// we must be on /search
 		presenceData.details = displaySearch ? "Searching for:" : "Searching";
 		presenceData.smallImageKey = assets.search;
 		presenceData.smallImageText = "Searching";
 		if (shareSearch) {
-			// share search query with button
 			presenceData.buttons = [
 				{
 					label: "Open Search Result",
@@ -60,7 +58,6 @@ presence.on("UpdateData", async () => {
 			];
 		}
 		if (displaySearch && cycleSearch) {
-			// share search query text using slideshow
 			for (const [i, result] of searchResults.entries()) {
 				const newPresenceData: PresenceData = { ...presenceData };
 				newPresenceData.state = `${i + 1}. ${
@@ -69,7 +66,6 @@ presence.on("UpdateData", async () => {
 				slideshow.addSlide(i.toString(), newPresenceData, 5000);
 			}
 		} else if (displaySearch) {
-			// share search query text
 			presenceData.state = searchResults[0].querySelector(
 				"span.fw-bold.fs-3.mb-3"
 			).textContent;

--- a/websites/P/Phind/presence.ts
+++ b/websites/P/Phind/presence.ts
@@ -1,0 +1,78 @@
+const presence = new Presence({
+		clientId: "1106990410838065172",
+	}),
+	browsingTimestamp = Math.floor(Date.now() / 1000);
+
+presence.on("UpdateData", async () => {
+	const assets = {
+			phindLogo: "https://i.imgur.com/fakWcYA.png",
+			search: "https://i.imgur.com/a5qsEbL.png",
+		},
+		presenceData: PresenceData = {
+			largeImageKey: assets.phindLogo,
+			details: "Browsing Phind",
+		},
+		pathDetailsMap = {
+			"/default": "Viewing how to set Phind as default",
+			"/bangs": "Viewing !Bangs",
+			"/mobile": "Viewing Mobile Page",
+			"/hotkeys": "Viewing Hotkeys",
+			"/history": "Viewing Search History",
+			"/about": "Viewing About Page",
+			"/tutorial": "Viewing Tutorial",
+			"/privacy": "Viewing Privacy Policy",
+			"/terms": "Viewing Terms",
+		},
+		{ pathname, href } = document.location,
+		pathDetails = Object.entries(pathDetailsMap).find(([pathPrefix]) =>
+			pathname.startsWith(pathPrefix)
+		),
+		searchResults = document.querySelectorAll("div.row[name^='answer-']"),
+		[displayTime, displaySearch, shareSearch, privateMode] = await Promise.all([
+			presence.getSetting("displayTime"), // shows/hides the time spent on the site
+			presence.getSetting("displaySearch"), // shows/hides your search query text
+			presence.getSetting("shareSearch"), // shares your search with a button
+			presence.getSetting("privateMode"), // hides the querry, button and what exact page you are on
+		]);
+
+	if (displayTime) presenceData.startTimestamp = browsingTimestamp;
+
+	if (pathDetails) {
+		presenceData.details = pathDetails[1]; // display text of /path
+		presenceData.state = pathname; // display /path
+	} else if (searchResults.length > 0 && !privateMode) {
+		// we must be on /search and arn't in private mode
+		// presenceData.details = "Searching";
+		presenceData.details = displaySearch ? "Searching for:" : "Searching";
+		presenceData.smallImageKey = assets.search;
+		presenceData.smallImageText = "Searching";
+		if (displaySearch) {
+			// share search query text
+			presenceData.state = searchResults[
+				searchResults.length - 1
+			].querySelector("span.fw-bold.fs-3.mb-3").textContent;
+		}
+		if (shareSearch) {
+			// share search query with button
+			presenceData.buttons = [
+				{
+					label: "Open Search Result",
+					url: href,
+				},
+			];
+		}
+	}
+
+	if (privateMode) {
+		// hide everything except the large image and site name
+		presenceData.details = "Browsing Phind";
+		delete presenceData.state;
+		delete presenceData.smallImageKey;
+		delete presenceData.smallImageText;
+		delete presenceData.buttons;
+		delete presenceData.startTimestamp;
+		delete presenceData.endTimestamp;
+	}
+
+	presence.setActivity(presenceData);
+});

--- a/websites/P/Phind/presence.ts
+++ b/websites/P/Phind/presence.ts
@@ -57,7 +57,7 @@ presence.on("UpdateData", async () => {
 				},
 			];
 		}
-		if (displaySearch && cycleSearch) {
+		if (displaySearch && cycleSearch && searchResults.length > 1) {
 			for (const [i, result] of searchResults.entries()) {
 				const newPresenceData: PresenceData = { ...presenceData };
 				newPresenceData.state = `${i + 1}. ${
@@ -66,6 +66,7 @@ presence.on("UpdateData", async () => {
 				slideshow.addSlide(i.toString(), newPresenceData, 5000);
 			}
 		} else if (displaySearch) {
+			slideshow.deleteAllSlides();
 			presenceData.state = searchResults[0].querySelector(
 				"span.fw-bold.fs-3.mb-3"
 			).textContent;
@@ -84,7 +85,6 @@ presence.on("UpdateData", async () => {
 		delete presenceData.endTimestamp;
 		slideshow.deleteAllSlides();
 	}
-
-	if (slideshow.getSlides().length > 0) presence.setActivity(slideshow);
+	if (slideshow.getSlides().length > 1) presence.setActivity(slideshow);
 	else presence.setActivity(presenceData);
 });


### PR DESCRIPTION
## Description 
I added support for [phind.com](https://www.phind.com/), an AI powered search engine. It can take in huge pieces of information, will automatically generate a search querry based off of that and combine the search results with the input to give you an AI generated output. It will automatically detect if GPT-3 or GPT-4 should be used (This used to be manual).

Its really great for programming but it can be used for normal searches as well.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![DiscordCanary_OEOskRl4IA](https://github.com/PreMiD/Presences/assets/5887406/e1952c4f-9c44-4c6b-a5c9-2f412ac7b36a)
*NOTE:* The "Visit Phind" button has been removed since recording this, instead it will not show any button. This was done to follow the guidelines that state "Redirects to main page are prohibited.".
![image](https://github.com/PreMiD/Presences/assets/5887406/ad5daf11-6747-4d1d-8f60-381b62d602fa)
![image](https://github.com/PreMiD/Presences/assets/5887406/2e071817-92ad-46f8-8e9f-55e00fe0cce2)

</details>
