### PR TITLE
fix(WaniKani): update paths, selectors, and assets

### DIFF
--- a/websites/W/WaniKani/metadata.json
+++ b/websites/W/WaniKani/metadata.json
@@ -16,7 +16,7 @@
 		"knowledge.wanikani.com"
 	],
 	"version": "1.2.0",
-	"logo": "https://i.imgur.com/NdlB8M5.png",
+	"logo": "https://i.imgur.com/xHaJdia.png",
 	"thumbnail": "https://i.imgur.com/8OKXkxY.png",
 	"color": "#1BA0ED",
 	"category": "other",

--- a/websites/W/WaniKani/metadata.json
+++ b/websites/W/WaniKani/metadata.json
@@ -15,7 +15,7 @@
 		"community.wanikani.com",
 		"knowledge.wanikani.com"
 	],
-	"version": "1.1.5",
+	"version": "1.2.0",
 	"logo": "https://i.imgur.com/NdlB8M5.png",
 	"thumbnail": "https://i.imgur.com/8OKXkxY.png",
 	"color": "#1BA0ED",

--- a/websites/W/WaniKani/presence.ts
+++ b/websites/W/WaniKani/presence.ts
@@ -137,8 +137,9 @@ presence.on("UpdateData", () => {
 				}
 				case "/subjects/extra_study": {
 					presenceData.details = `Doing ${
-						document.querySelector<HTMLDivElement>("#menu-bar-title")
-							.textContent
+						document.querySelector<HTMLDivElement>(
+							".character-header__menu-title"
+						).textContent
 					}`;
 					Object.assign(presenceData, getReviewPresence());
 					break;

--- a/websites/W/WaniKani/presence.ts
+++ b/websites/W/WaniKani/presence.ts
@@ -50,7 +50,10 @@ function getReviewPresence(): PresenceData {
 			).classList,
 		]
 			.find(cls => cls.startsWith("character-header--"))
-			.split("--")[1];
+			.split("--")[1],
+		completeCount = document.querySelector<HTMLDivElement>(
+			'[data-quiz-statistics-target="completeCount"]'
+		);
 
 	data.state = `${
 		document.querySelector<HTMLDivElement>(
@@ -61,19 +64,17 @@ function getReviewPresence(): PresenceData {
 			'[data-quiz-input-target="questionTypeContainer"]'
 		).dataset.questionType
 	)}`;
-	data.smallImageText = `${
-		document.querySelector<HTMLDivElement>(
-			'[data-quiz-statistics-target="completeCount"]'
-		).textContent
-	} complete, ${
-		document.querySelector<HTMLDivElement>(
-			'[data-quiz-statistics-target="remainingCount"]'
-		).textContent
-	} remaining. (${
-		document.querySelector<HTMLDivElement>(
-			'[data-quiz-statistics-target="percentCorrect"]'
-		).textContent
-	}%)`;
+	if (completeCount) {
+		data.smallImageText = `${completeCount.textContent} complete, ${
+			document.querySelector<HTMLDivElement>(
+				'[data-quiz-statistics-target="remainingCount"]'
+			).textContent
+		} remaining. (${
+			document.querySelector<HTMLDivElement>(
+				'[data-quiz-statistics-target="percentCorrect"]'
+			).textContent
+		}%)`;
+	}
 	data.smallImageKey = getTypeAsset(characterType);
 	return data;
 }
@@ -149,7 +150,7 @@ presence.on("UpdateData", () => {
 					Object.assign(presenceData, getReviewPresence());
 					break;
 				}
-				case "/subjectss/lesson/quiz": {
+				case "/subjects/lesson/quiz": {
 					presenceData.details = "Practicing Lessons";
 					Object.assign(presenceData, getReviewPresence());
 					break;

--- a/websites/W/WaniKani/presence.ts
+++ b/websites/W/WaniKani/presence.ts
@@ -3,23 +3,6 @@ const presence: Presence = new Presence({
 	}),
 	browsingTimestamp = Math.floor(Date.now() / 1000);
 
-function capitalize(string: string) {
-	return string.charAt(0).toUpperCase() + string.slice(1);
-}
-
-function getTypeAsset(string: string) {
-	switch (string.toLowerCase()) {
-		case "kanji":
-			return Assets.Kanji;
-		case "radical":
-			return Assets.Radical;
-		case "vocabulary":
-			return Assets.Vocabulary;
-		default:
-			return null;
-	}
-}
-
 const enum Assets {
 	Logo = "https://i.imgur.com/NdlB8M5.png",
 	Avatar = "https://i.imgur.com/WktQVUN.png",
@@ -40,6 +23,23 @@ const enum Assets {
 	Reviews250 = "https://i.imgur.com/t5bywqD.png",
 	Reviews500 = "https://i.imgur.com/5ZzUjZC.png",
 	Reviews1000 = "https://i.imgur.com/FANzfMN.png",
+}
+
+function capitalize(string: string) {
+	return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+function getTypeAsset(string: string) {
+	switch (string.toLowerCase()) {
+		case "kanji":
+			return Assets.Kanji;
+		case "radical":
+			return Assets.Radical;
+		case "vocabulary":
+			return Assets.Vocabulary;
+		default:
+			return null;
+	}
 }
 
 presence.on("UpdateData", () => {

--- a/websites/W/WaniKani/presence.ts
+++ b/websites/W/WaniKani/presence.ts
@@ -1,23 +1,53 @@
 const presence: Presence = new Presence({
 		clientId: "800166344023867443",
 	}),
-	largeImageKey = "logo",
 	browsingTimestamp = Math.floor(Date.now() / 1000);
 
 function capitalize(string: string) {
 	return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
+function getTypeAsset(string: string) {
+	switch (string.toLowerCase()) {
+		case "kanji":
+			return Assets.Kanji;
+		case "radical":
+			return Assets.Radical;
+		case "vocabulary":
+			return Assets.Vocabulary;
+		default:
+			return null;
+	}
+}
+
+const enum Assets {
+	Logo = "https://i.imgur.com/NdlB8M5.png",
+	Avatar = "https://i.imgur.com/WktQVUN.png",
+	Kanji = "https://i.imgur.com/3VQ6BhT.png",
+	Radical = "https://i.imgur.com/k9mTFJ6.png",
+	Vocabulary = "https://i.imgur.com/eyykDXt.png",
+	Lessons0 = "https://i.imgur.com/p8sMdUY.png",
+	Lessons1 = "https://i.imgur.com/XbtRrhO.png",
+	Lessons25 = "https://i.imgur.com/m4rS03b.png",
+	Lessons50 = "https://i.imgur.com/cbFgaEd.png",
+	Lessons100 = "https://i.imgur.com/MduMzt8.png",
+	Lessons250 = "https://i.imgur.com/bOmgrNx.png",
+	Lessons500 = "https://i.imgur.com/0IOnYWQ.png",
+	Reviews0 = "https://i.imgur.com/ObYQyy4.png",
+	Reviews1 = "https://i.imgur.com/wyokDrz.png",
+	Reviews50 = "https://i.imgur.com/JX6TIer.png",
+	Reviews100 = "https://i.imgur.com/zkb6BKC.png",
+	Reviews250 = "https://i.imgur.com/t5bywqD.png",
+	Reviews500 = "https://i.imgur.com/5ZzUjZC.png",
+	Reviews1000 = "https://i.imgur.com/FANzfMN.png",
+}
+
 presence.on("UpdateData", () => {
-	const { hostname, pathname } = window.location,
+	const { hostname, pathname } = document.location,
 		presenceData: PresenceData = {
+			largeImageKey: Assets.Logo,
 			startTimestamp: browsingTimestamp,
 		};
-
-	let details: string,
-		state: string,
-		smallImageKey: string,
-		smallImageText: string;
 
 	switch (hostname) {
 		case "wanikani.com":
@@ -34,35 +64,45 @@ presence.on("UpdateData", () => {
 								+buttons[0].querySelector<HTMLSpanElement>("span").textContent,
 							reviews =
 								+buttons[1].querySelector<HTMLSpanElement>("span").textContent;
-						details = "Viewing Dashboard";
-						state = `${lessons} lessons | ${reviews} reviews`;
-						smallImageText = document.querySelector<HTMLAnchorElement>(
-							".user-summary__attribute > a"
-						).textContent;
+						presenceData.details = "Viewing Dashboard";
+						presenceData.state = `${lessons} lessons | ${reviews} reviews`;
+						presenceData.smallImageText =
+							document.querySelector<HTMLAnchorElement>(
+								".user-summary__attribute > a"
+							).textContent;
 						if (lessons > reviews) {
-							if (lessons < 25) smallImageKey = "lessons-1";
-							else if (lessons < 50) smallImageKey = "lessons-25";
-							else if (lessons < 100) smallImageKey = "lessons-50";
-							else if (lessons < 250) smallImageKey = "lessons-100";
-							else if (lessons < 500) smallImageKey = "lessons-250";
-							else smallImageKey = "lessons-500";
-						} else if (reviews < 1) smallImageKey = "reviews-0";
-						else if (reviews < 50) smallImageKey = "reviews-1";
-						else if (reviews < 100) smallImageKey = "reviews-50";
-						else if (reviews < 250) smallImageKey = "reviews-100";
-						else if (reviews < 500) smallImageKey = "reviews-250";
-						else if (reviews < 1000) smallImageKey = "reviews-500";
-						else smallImageKey = "reviews-1000";
+							if (lessons < 25) presenceData.smallImageKey = Assets.Lessons1;
+							else if (lessons < 50)
+								presenceData.smallImageKey = Assets.Lessons25;
+							else if (lessons < 100)
+								presenceData.smallImageKey = Assets.Lessons50;
+							else if (lessons < 250)
+								presenceData.smallImageKey = Assets.Lessons100;
+							else if (lessons < 500)
+								presenceData.smallImageKey = Assets.Lessons250;
+							else presenceData.smallImageKey = Assets.Lessons500;
+						} else if (reviews < 1)
+							presenceData.smallImageKey = Assets.Reviews0;
+						else if (reviews < 50) presenceData.smallImageKey = Assets.Reviews1;
+						else if (reviews < 100)
+							presenceData.smallImageKey = Assets.Reviews50;
+						else if (reviews < 250)
+							presenceData.smallImageKey = Assets.Reviews100;
+						else if (reviews < 500)
+							presenceData.smallImageKey = Assets.Reviews250;
+						else if (reviews < 1000)
+							presenceData.smallImageKey = Assets.Reviews500;
+						else presenceData.smallImageKey = Assets.Reviews1000;
 					} else {
-						details = "Browsing...";
-						state = "Viewing Home Page";
+						presenceData.details = "Browsing";
+						presenceData.state = "Viewing Home Page";
 					}
 					break;
 				}
 				case "/review":
 				case "/lesson": {
-					details = "Browsing...";
-					state =
+					presenceData.details = "Browsing";
+					presenceData.state =
 						pathname === "/lesson"
 							? "Viewing Lesson Summary"
 							: "Viewing Reviews Summary";
@@ -72,16 +112,16 @@ presence.on("UpdateData", () => {
 					const characterElement =
 							document.querySelector<HTMLDivElement>("#character"),
 						characterType = characterElement.className;
-					details = `Doing ${
+					presenceData.details = `Doing ${
 						document.querySelector<HTMLDivElement>("#menu-bar-title")
 							.textContent
 					}`;
-					state = `${characterElement.textContent} | ${capitalize(
+					presenceData.state = `${characterElement.textContent} | ${capitalize(
 						characterType
 					)} ${capitalize(
 						document.querySelector<HTMLDivElement>("#question-type").className
 					)}`;
-					smallImageText = `${
+					presenceData.smallImageText = `${
 						document.querySelector<HTMLSpanElement>("#completed-count")
 							.textContent
 					} complete, ${
@@ -90,20 +130,20 @@ presence.on("UpdateData", () => {
 					} remaining. (${
 						document.querySelector<HTMLSpanElement>("#correct-rate").textContent
 					}%)`;
-					smallImageKey = characterType;
+					presenceData.smallImageKey = getTypeAsset(characterType);
 					break;
 				}
 				case "/review/session": {
 					const characterElement =
 							document.querySelector<HTMLDivElement>("#character"),
 						characterType = characterElement.className;
-					details = "Doing Reviews";
-					state = `${characterElement.textContent} | ${capitalize(
+					presenceData.details = "Doing Reviews";
+					presenceData.state = `${characterElement.textContent} | ${capitalize(
 						characterType
 					)} ${capitalize(
 						document.querySelector<HTMLDivElement>("#question-type").className
 					)}`;
-					smallImageText = `${
+					presenceData.smallImageText = `${
 						document.querySelector<HTMLSpanElement>("#completed-count")
 							.textContent
 					} complete, ${
@@ -112,23 +152,26 @@ presence.on("UpdateData", () => {
 					} remaining. (${
 						document.querySelector<HTMLSpanElement>("#correct-rate").textContent
 					}%)`;
-					smallImageKey = characterType;
+					presenceData.smallImageKey = getTypeAsset(characterType);
 					break;
 				}
 				case "/lesson/session": {
 					try {
 						const totalStats = document.querySelectorAll("#stats li > span");
-						details = "Learning Lessons";
-						state = `${
+						presenceData.details = "Learning Lessons";
+						presenceData.state = `${
 							document.querySelector<HTMLDivElement>("#character").textContent
 						} - ${
 							document.querySelector<HTMLDivElement>("#meaning").textContent
 						}`;
-						smallImageKey =
-							document.querySelector<HTMLDivElement>("#main-info").className;
-						smallImageText = `${totalStats[0].textContent} radicals | ${
-							totalStats[1].textContent
-						} kanji | ${totalStats[2].textContent} vocab | ${
+						presenceData.smallImageKey = getTypeAsset(
+							document.querySelector<HTMLDivElement>("#main-info").className
+						);
+						presenceData.smallImageText = `${
+							totalStats[0].textContent
+						} radicals | ${totalStats[1].textContent} kanji | ${
+							totalStats[2].textContent
+						} vocab | ${
 							document.querySelector<HTMLSpanElement>("#completed-count")
 								.textContent
 						} complete`;
@@ -137,16 +180,18 @@ presence.on("UpdateData", () => {
 						const characterType =
 								document.querySelector<HTMLDivElement>("#main-info").className,
 							totalStats = document.querySelectorAll("#stats li > span");
-						details = "Practicing Lessons";
-						state = `${
+						presenceData.details = "Practicing Lessons";
+						presenceData.state = `${
 							document.querySelector<HTMLDivElement>("#character").textContent
 						} | ${capitalize(characterType)} ${capitalize(
 							document.querySelector<HTMLDivElement>("#question-type").className
 						)}`;
-						smallImageKey = characterType;
-						smallImageText = `${totalStats[0].textContent} radicals | ${
-							totalStats[1].textContent
-						} kanji | ${totalStats[2].textContent} vocab | ${
+						presenceData.smallImageKey = getTypeAsset(characterType);
+						presenceData.smallImageText = `${
+							totalStats[0].textContent
+						} radicals | ${totalStats[1].textContent} kanji | ${
+							totalStats[2].textContent
+						} vocab | ${
 							document.querySelector<HTMLSpanElement>("#completed-count")
 								.textContent
 						} complete`;
@@ -163,8 +208,8 @@ presence.on("UpdateData", () => {
 					if (textDescription.length >= 50)
 						textDescription = `${textDescription.substring(0, 50)}...`;
 
-					details = `Browsing ${capitalize(type)}`;
-					state = `${
+					presenceData.details = `Browsing ${capitalize(type)}`;
+					presenceData.state = `${
 						document.querySelector<HTMLSpanElement>(
 							`.${type.replace(/s$/, "")}-icon`
 						).textContent
@@ -173,52 +218,45 @@ presence.on("UpdateData", () => {
 							`.${type.replace(/s$/, "")}-icon`
 						).parentNode.childNodes[4].textContent
 					}`;
-					smallImageText = textDescription;
-					smallImageKey = type.replace(/s$/, "");
+					presenceData.smallImageText = textDescription;
+					presenceData.smallImageKey = getTypeAsset(type.replace(/s$/, ""));
 					break;
 				}
 				case (pathname.match(/^\/users\/.+$/) || {}).input: {
-					details = "Viewing User Profile";
-					state =
+					presenceData.details = "Viewing User Profile";
+					presenceData.state =
 						document.querySelector<HTMLSpanElement>(".username").textContent;
-					smallImageKey = "avatar";
+					presenceData.smallImageKey = Assets.Avatar;
 					break;
 				}
 				default: {
-					details = "Browsing...";
-					state = `Viewing ${document.title.split(" / ").slice(1).join(" / ")}`;
+					presenceData.details = "Browsing";
+					presenceData.state = `Viewing ${document.title
+						.split(" / ")
+						.slice(1)
+						.join(" / ")}`;
 				}
 			}
 			break;
 		}
 		case "knowledge.wanikani.com": {
-			details = "Browsing WaniKani Knowledge...";
-			[state] = document.title.split(" | ");
+			presenceData.details = "Browsing WaniKani Knowledge";
+			presenceData.state = document.title.split(" | ")[0];
 			break;
 		}
 		case "community.wanikani.com": {
 			if (/^\/u\/.+$/.test(pathname)) {
-				details = "Viewing User Profile";
-				smallImageKey = "avatar";
-				state =
+				presenceData.details = "Viewing User Profile";
+				presenceData.smallImageKey = Assets.Avatar;
+				presenceData.state =
 					document.querySelector<HTMLHeadingElement>(".username").textContent;
 				break;
 			}
-			details = "Browsing WaniKani Community...";
-			[state] = document.title.split(" - ");
+			presenceData.details = "Browsing WaniKani Community";
+			presenceData.state = document.title.split(" - ")[0];
 			break;
 		}
 	}
-
-	if (details) presenceData.details = details;
-
-	if (state) presenceData.state = state;
-
-	if (smallImageKey) presenceData.smallImageKey = smallImageKey;
-
-	if (smallImageText) presenceData.smallImageText = smallImageText;
-
-	presenceData.largeImageKey = largeImageKey;
 
 	presence.setActivity(presenceData);
 });

--- a/websites/W/WaniKani/presence.ts
+++ b/websites/W/WaniKani/presence.ts
@@ -42,6 +42,42 @@ function getTypeAsset(string: string) {
 	}
 }
 
+function getReviewPresence(): PresenceData {
+	const data: PresenceData = {},
+		characterType = [
+			...document.querySelector<HTMLDivElement>(
+				'[data-quiz-header-base-class="character-header"]'
+			).classList,
+		]
+			.find(cls => cls.startsWith("character-header--"))
+			.split("--")[1];
+
+	data.state = `${
+		document.querySelector<HTMLDivElement>(
+			'[data-quiz-header-target="characters"]'
+		).textContent
+	} | ${capitalize(characterType)} ${capitalize(
+		document.querySelector<HTMLDivElement>(
+			'[data-quiz-input-target="questionTypeContainer"]'
+		).dataset.questionType
+	)}`;
+	data.smallImageText = `${
+		document.querySelector<HTMLDivElement>(
+			'[data-quiz-statistics-target="completeCount"]'
+		).textContent
+	} complete, ${
+		document.querySelector<HTMLDivElement>(
+			'[data-quiz-statistics-target="remainingCount"]'
+		).textContent
+	} remaining. (${
+		document.querySelector<HTMLDivElement>(
+			'[data-quiz-statistics-target="percentCorrect"]'
+		).textContent
+	}%)`;
+	data.smallImageKey = getTypeAsset(characterType);
+	return data;
+}
+
 presence.on("UpdateData", () => {
 	const { hostname, pathname } = document.location,
 		presenceData: PresenceData = {
@@ -100,53 +136,19 @@ presence.on("UpdateData", () => {
 					break;
 				}
 				case "/subjects/extra_study": {
-					const characterElement =
-							document.querySelector<HTMLDivElement>("#character"),
-						characterType = characterElement.className;
 					presenceData.details = `Doing ${
 						document.querySelector<HTMLDivElement>("#menu-bar-title")
 							.textContent
 					}`;
-					presenceData.state = `${characterElement.textContent} | ${capitalize(
-						characterType
-					)} ${capitalize(
-						document.querySelector<HTMLDivElement>("#question-type").className
-					)}`;
-					presenceData.smallImageText = `${
-						document.querySelector<HTMLSpanElement>("#completed-count")
-							.textContent
-					} complete, ${
-						document.querySelector<HTMLSpanElement>("#available-count")
-							.textContent
-					} remaining. (${
-						document.querySelector<HTMLSpanElement>("#correct-rate").textContent
-					}%)`;
-					presenceData.smallImageKey = getTypeAsset(characterType);
+					Object.assign(presenceData, getReviewPresence());
 					break;
 				}
 				case "/subjects/review": {
-					const characterElement =
-							document.querySelector<HTMLDivElement>("#character"),
-						characterType = characterElement.className;
 					presenceData.details = "Doing Reviews";
-					presenceData.state = `${characterElement.textContent} | ${capitalize(
-						characterType
-					)} ${capitalize(
-						document.querySelector<HTMLDivElement>("#question-type").className
-					)}`;
-					presenceData.smallImageText = `${
-						document.querySelector<HTMLSpanElement>("#completed-count")
-							.textContent
-					} complete, ${
-						document.querySelector<HTMLSpanElement>("#available-count")
-							.textContent
-					} remaining. (${
-						document.querySelector<HTMLSpanElement>("#correct-rate").textContent
-					}%)`;
-					presenceData.smallImageKey = getTypeAsset(characterType);
+					Object.assign(presenceData, getReviewPresence());
 					break;
 				}
-				case "/subjects/lesson": {
+				case (pathname.match(/^\/subjects\/\d+\/lesson$/) || {}).input: {
 					try {
 						const totalStats = document.querySelectorAll("#stats li > span");
 						presenceData.details = "Learning Lessons";
@@ -168,24 +170,8 @@ presence.on("UpdateData", () => {
 						} complete`;
 					} catch (err) {
 						// Likely practicing
-						const characterType =
-								document.querySelector<HTMLDivElement>("#main-info").className,
-							totalStats = document.querySelectorAll("#stats li > span");
 						presenceData.details = "Practicing Lessons";
-						presenceData.state = `${
-							document.querySelector<HTMLDivElement>("#character").textContent
-						} | ${capitalize(characterType)} ${capitalize(
-							document.querySelector<HTMLDivElement>("#question-type").className
-						)}`;
-						presenceData.smallImageKey = getTypeAsset(characterType);
-						presenceData.smallImageText = `${
-							totalStats[0].textContent
-						} radicals | ${totalStats[1].textContent} kanji | ${
-							totalStats[2].textContent
-						} vocab | ${
-							document.querySelector<HTMLSpanElement>("#completed-count")
-								.textContent
-						} complete`;
+						Object.assign(presenceData, getReviewPresence());
 					}
 					break;
 				}

--- a/websites/W/WaniKani/presence.ts
+++ b/websites/W/WaniKani/presence.ts
@@ -99,16 +99,7 @@ presence.on("UpdateData", () => {
 					}
 					break;
 				}
-				case "/review":
-				case "/lesson": {
-					presenceData.details = "Browsing";
-					presenceData.state =
-						pathname === "/lesson"
-							? "Viewing Lesson Summary"
-							: "Viewing Reviews Summary";
-					break;
-				}
-				case "/extra_study/session": {
+				case "/subjects/extra_study": {
 					const characterElement =
 							document.querySelector<HTMLDivElement>("#character"),
 						characterType = characterElement.className;
@@ -133,7 +124,7 @@ presence.on("UpdateData", () => {
 					presenceData.smallImageKey = getTypeAsset(characterType);
 					break;
 				}
-				case "/review/session": {
+				case "/subjects/review": {
 					const characterElement =
 							document.querySelector<HTMLDivElement>("#character"),
 						characterType = characterElement.className;
@@ -155,7 +146,7 @@ presence.on("UpdateData", () => {
 					presenceData.smallImageKey = getTypeAsset(characterType);
 					break;
 				}
-				case "/lesson/session": {
+				case "/subjects/lesson": {
 					try {
 						const totalStats = document.querySelectorAll("#stats li > span");
 						presenceData.details = "Learning Lessons";

--- a/websites/W/WaniKani/presence.ts
+++ b/websites/W/WaniKani/presence.ts
@@ -4,7 +4,7 @@ const presence: Presence = new Presence({
 	browsingTimestamp = Math.floor(Date.now() / 1000);
 
 const enum Assets {
-	Logo = "https://i.imgur.com/NdlB8M5.png",
+	Logo = "https://i.imgur.com/xHaJdia.png",
 	Avatar = "https://i.imgur.com/WktQVUN.png",
 	Kanji = "https://i.imgur.com/3VQ6BhT.png",
 	Radical = "https://i.imgur.com/k9mTFJ6.png",

--- a/websites/W/WaniKani/presence.ts
+++ b/websites/W/WaniKani/presence.ts
@@ -149,31 +149,35 @@ presence.on("UpdateData", () => {
 					Object.assign(presenceData, getReviewPresence());
 					break;
 				}
+				case "/subjectss/lesson/quiz": {
+					presenceData.details = "Practicing Lessons";
+					Object.assign(presenceData, getReviewPresence());
+					break;
+				}
 				case (pathname.match(/^\/subjects\/\d+\/lesson$/) || {}).input: {
-					try {
-						const totalStats = document.querySelectorAll("#stats li > span");
-						presenceData.details = "Learning Lessons";
-						presenceData.state = `${
-							document.querySelector<HTMLDivElement>("#character").textContent
-						} - ${
-							document.querySelector<HTMLDivElement>("#meaning").textContent
-						}`;
-						presenceData.smallImageKey = getTypeAsset(
-							document.querySelector<HTMLDivElement>("#main-info").className
-						);
-						presenceData.smallImageText = `${
-							totalStats[0].textContent
-						} radicals | ${totalStats[1].textContent} kanji | ${
-							totalStats[2].textContent
-						} vocab | ${
-							document.querySelector<HTMLSpanElement>("#completed-count")
-								.textContent
-						} complete`;
-					} catch (err) {
-						// Likely practicing
-						presenceData.details = "Practicing Lessons";
-						Object.assign(presenceData, getReviewPresence());
-					}
+					presenceData.details = "Learning Lessons";
+					const totalStats = document.querySelector<HTMLDivElement>(
+						'[data-controller="subject-count-statistics"]'
+					).children;
+					presenceData.state = `${
+						document.querySelector<HTMLDivElement>(
+							'[data-quiz-header-target="characters"]'
+						).textContent
+					} - ${
+						document.querySelector<HTMLDivElement>(
+							'[data-quiz-header-target="meaning"]'
+						).textContent
+					}`;
+					presenceData.smallImageKey = getTypeAsset(
+						[
+							...document.querySelector<HTMLDivElement>(
+								'[data-quiz-header-base-class="character-header"]'
+							).classList,
+						]
+							.find(cls => cls.startsWith("character-header--"))
+							.split("--")[1]
+					);
+					presenceData.smallImageText = `${totalStats[0].textContent} radicals | ${totalStats[1].textContent} kanji | ${totalStats[2].textContent} vocab`;
 					break;
 				}
 				case (pathname.match(/^\/(radicals|kanji|vocabulary)\/.+$/) || {})

--- a/websites/W/WaniKani/presence.ts
+++ b/websites/W/WaniKani/presence.ts
@@ -157,9 +157,9 @@ presence.on("UpdateData", () => {
 				}
 				case (pathname.match(/^\/subjects\/\d+\/lesson$/) || {}).input: {
 					presenceData.details = "Learning Lessons";
-					const totalStats = document.querySelector<HTMLDivElement>(
-						'[data-controller="subject-count-statistics"]'
-					).children;
+					const totalStats = document.querySelectorAll<HTMLDivElement>(
+						'[data-controller="subject-count-statistics"] [data-subject-count-statistics-target="count"]'
+					);
 					presenceData.state = `${
 						document.querySelector<HTMLDivElement>(
 							'[data-quiz-header-target="characters"]'


### PR DESCRIPTION
## Description 
* Uses Imgur links instead of Discord asset names
* Updates paths and selectors for the lessons/reviews

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![2023-05-22 11_17_29](https://github.com/PreMiD/Presences/assets/32113157/4c50aa16-5129-433f-8e24-2f3aff2abb5c)
![2023-05-22 11_22_04](https://github.com/PreMiD/Presences/assets/32113157/8d8a9901-2fb6-471c-88a5-fcf686316080)
![2023-05-22 11_24_44](https://github.com/PreMiD/Presences/assets/32113157/93d808df-a020-4dd2-a115-8bce556f1d90)
![2023-05-22 11_28_43](https://github.com/PreMiD/Presences/assets/32113157/20ddc9c6-94f7-4208-aab5-6d763547c509)


</details>
