### PR TITLE
Update metadata.json

### DIFF
--- a/websites/H/HBO Max/metadata.json
+++ b/websites/H/HBO Max/metadata.json
@@ -11,13 +11,13 @@
 		"vi_VN": "Nền tảng phát trực tuyến đem tất cả của HBO với nhiều phim và chương trình truyền hình hơn nữa, thêm các bộ Max Originals."
 	},
 	"url": [
-		"hbomax.com",
-		"www.hbomax.com",
-		"play.hbomax.com",
-		"help.hbomax.com"
+		"max.com",
+		"www.max.com",
+		"play.max.com",
+		"help.max.com"
 	],
 	"version": "2.2.3",
-	"logo": "https://i.imgur.com/UxH7DDE.png",
+	"logo": "https://pbs.twimg.com/media/Fth6aQMXwQEb4NU?format=jpg&name=900x900",
 	"thumbnail": "https://i.imgur.com/d1bktD4.jpg",
 	"color": "#c600ff",
 	"category": "videos",


### PR DESCRIPTION
HBO Max recently changed its service name to Max. The supported URLs and logo need to be updated accordingly, as the presence in its current state is not detected by PreMiD. If you happen to find a more suitable logo image, feel free to change it. I have not changed anything to the original code. The only thing I modified was the supported URLs and logo image link.

## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [ ] I linted the code by running `yarn format`
- [ ] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
