### PR TITLE
feat(Songsterr): add presence

### DIFF
--- a/websites/S/Songsterr/metadata.json
+++ b/websites/S/Songsterr/metadata.json
@@ -14,7 +14,7 @@
 		"songsterr.com"
 	],
 	"version": "1.0.0",
-	"logo": "https://i.imgur.com/MXQP0Lq.png",
+	"logo": "https://i.imgur.com/FbLdpEW.png",
 	"thumbnail": "https://i.imgur.com/GXVbnX5.png",
 	"color": "#138CF6",
 	"category": "music",

--- a/websites/S/Songsterr/metadata.json
+++ b/websites/S/Songsterr/metadata.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.7",
+	"author": {
+		"id": "263735224221827072",
+		"name": "AlperShal"
+	},
+	"service": "Songsterr",
+	"description": {
+		"en": "Songsterr is one of the most popular sites to find and play guitar or any instrument's tabs.",
+		"tr": "Songsterr gitar ya da herhangi bir çalgının tablarını bulmak ya da çalmak için en popüler sitelerden birisi."
+	},
+	"url": [
+		"www.songsterr.com",
+		"songsterr.com"
+	],
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/MXQP0Lq.png",
+	"thumbnail": "https://i.imgur.com/GXVbnX5.png",
+	"color": "#138CF6",
+	"category": "music",
+	"tags": [
+		"guitar",
+		"drums",
+		"song",
+		"music",
+		"tabs"
+	]
+}

--- a/websites/S/Songsterr/presence.ts
+++ b/websites/S/Songsterr/presence.ts
@@ -4,7 +4,7 @@ const presence = new Presence({
 
 presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
-		largeImageKey: "https://i.imgur.com/MXQP0Lq.png",
+		largeImageKey: "https://i.imgur.com/FbLdpEW.png",
 	};
 
 	switch (document.location.pathname) {

--- a/websites/S/Songsterr/presence.ts
+++ b/websites/S/Songsterr/presence.ts
@@ -1,0 +1,37 @@
+const presence = new Presence({
+	clientId: "1112463096368353300",
+});
+
+presence.on("UpdateData", async () => {
+	const presenceData: PresenceData = {
+		largeImageKey: "https://i.imgur.com/MXQP0Lq.png",
+	};
+
+	if (document.location.pathname === "/") {
+		presenceData.details = "Searching";
+	} else if (document.location.pathname === "/a/wa/favorites") {
+		presenceData.details = "Viewing Favorite Tabs";
+	} else if (document.location.pathname === "/a/wa/mytabs") {
+		presenceData.details = "Viewing Owned Tabs";
+	} else if (document.location.pathname === "/a/wa/submit") {
+		presenceData.details = "Submitting Tabs";
+	} else if (document.location.pathname === "/a/wa/account") {
+		presenceData.details = "Editing Account Settings";
+	} else if (document.location.pathname === "/a/wa/plus") {
+		presenceData.details = "Viewing Plans";
+	} else if (document.location.pathname === "/a/wa/help") {
+		presenceData.details = "Viewing Q&A";
+	} else if (document.location.pathname === "/a/wa/account") {
+		presenceData.details = "Viewing Account Settings";
+	} else if (document.location.pathname.startsWith("/a/wsa/")) {
+		presenceData.details = document.querySelector(
+			'[aria-label="title"]'
+		).textContent;
+
+		presenceData.state = document.querySelector(
+			'[aria-label="artist"]'
+		).textContent;
+	}
+
+	presence.setActivity(presenceData);
+});

--- a/websites/S/Songsterr/presence.ts
+++ b/websites/S/Songsterr/presence.ts
@@ -10,37 +10,30 @@ presence.on("UpdateData", async () => {
 	switch (document.location.pathname) {
 		case "/": {
 			presenceData.details = "Searching";
-
 			break;
 		}
 		case "/a/wa/favorites": {
 			presenceData.details = "Viewing Favorite Tabs";
-
 			break;
 		}
 		case "/a/wa/mytabs": {
 			presenceData.details = "Viewing Owned Tabs";
-
 			break;
 		}
 		case "/a/wa/submit": {
 			presenceData.details = "Submitting Tabs";
-
 			break;
 		}
 		case "/a/wa/plus": {
 			presenceData.details = "Viewing Plans";
-
 			break;
 		}
 		case "/a/wa/help": {
 			presenceData.details = "Viewing Q&A";
-
 			break;
 		}
 		case "/a/wa/account": {
 			presenceData.details = "Viewing Account Settings";
-
 			break;
 		}
 		default:

--- a/websites/S/Songsterr/presence.ts
+++ b/websites/S/Songsterr/presence.ts
@@ -7,30 +7,52 @@ presence.on("UpdateData", async () => {
 		largeImageKey: "https://i.imgur.com/MXQP0Lq.png",
 	};
 
-	if (document.location.pathname === "/") {
-		presenceData.details = "Searching";
-	} else if (document.location.pathname === "/a/wa/favorites") {
-		presenceData.details = "Viewing Favorite Tabs";
-	} else if (document.location.pathname === "/a/wa/mytabs") {
-		presenceData.details = "Viewing Owned Tabs";
-	} else if (document.location.pathname === "/a/wa/submit") {
-		presenceData.details = "Submitting Tabs";
-	} else if (document.location.pathname === "/a/wa/account") {
-		presenceData.details = "Editing Account Settings";
-	} else if (document.location.pathname === "/a/wa/plus") {
-		presenceData.details = "Viewing Plans";
-	} else if (document.location.pathname === "/a/wa/help") {
-		presenceData.details = "Viewing Q&A";
-	} else if (document.location.pathname === "/a/wa/account") {
-		presenceData.details = "Viewing Account Settings";
-	} else if (document.location.pathname.startsWith("/a/wsa/")) {
-		presenceData.details = document.querySelector(
-			'[aria-label="title"]'
-		).textContent;
+	switch (document.location.pathname) {
+		case "/": {
+			presenceData.details = "Searching";
 
-		presenceData.state = document.querySelector(
-			'[aria-label="artist"]'
-		).textContent;
+			break;
+		}
+		case "/a/wa/favorites": {
+			presenceData.details = "Viewing Favorite Tabs";
+
+			break;
+		}
+		case "/a/wa/mytabs": {
+			presenceData.details = "Viewing Owned Tabs";
+
+			break;
+		}
+		case "/a/wa/submit": {
+			presenceData.details = "Submitting Tabs";
+
+			break;
+		}
+		case "/a/wa/plus": {
+			presenceData.details = "Viewing Plans";
+
+			break;
+		}
+		case "/a/wa/help": {
+			presenceData.details = "Viewing Q&A";
+
+			break;
+		}
+		case "/a/wa/account": {
+			presenceData.details = "Viewing Account Settings";
+
+			break;
+		}
+		default:
+			if (document.location.pathname.startsWith("/a/wsa/")) {
+				presenceData.details = document.querySelector(
+					'[aria-label="title"]'
+				).textContent;
+
+				presenceData.state = document.querySelector(
+					'[aria-label="artist"]'
+				).textContent;
+			}
 	}
 
 	presence.setActivity(presenceData);


### PR DESCRIPTION
## Description 
I added support for songsterr.com, a website for searching instruments' tabs. It's one of the most popular ones.

## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![Uwl0Pzt](https://github.com/PreMiD/Presences/assets/34231577/0b6097e8-2788-4348-8c26-89e7a8a7cc4f)

![omdI5Rr](https://github.com/PreMiD/Presences/assets/34231577/dd2a8273-c172-4b13-9866-a744bd4f40e5)

</details>

