### PR TITLE
chore: rearrage lint commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
 	"author": "Timeraa",
 	"license": "MPL-2.0",
 	"scripts": {
-		"lint": "prettier --write . && eslint --fix .",
-		"lint:ci": "prettier --check . && eslint .",
+		"lint": "eslint --fix . && prettier --write .",
+		"lint:ci": "eslint . && prettier --check .",
 		"format": "npm run metadataSorter && npm run lint",
 		"schemaEnforcer": "npm run format && npm run bumpChanged",
 		"compileTools": "tsc -p tools/tsconfig.json",


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
This should prevent issues where the format/lint command needs to be run twice to resolve all issues.
Eslint can change files to a state that prettier does not like, so eslint should run first

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)
