### PR TITLE
feat(AssetsUpdater): format files after changing assets

### DIFF
--- a/.github/workflows/AssetsUpdater.yml
+++ b/.github/workflows/AssetsUpdater.yml
@@ -30,9 +30,8 @@ jobs:
           git config --global core.quotePath false
           git config --global core.precomposeunicode true
           npm run assetsUpdater push
+          npm run format
           npm run bumpChanged uncommitted
-      - name: Format files
-        run: npm run format
       - name: Commit any changes
         uses: EndBug/add-and-commit@v9
         with:

--- a/.github/workflows/AssetsUpdater.yml
+++ b/.github/workflows/AssetsUpdater.yml
@@ -31,6 +31,8 @@ jobs:
           git config --global core.precomposeunicode true
           npm run assetsUpdater push
           npm run bumpChanged uncommitted
+      - name: Format files
+        run: npm run format
       - name: Commit any changes
         uses: EndBug/add-and-commit@v9
         with:


### PR DESCRIPTION
## Description 
Adds the format script to the asset updater, as changing the URL may affect how prettier would format the code.
This currently has the effect of potentially creating a commit that only formats the code, with the incorrect message of "update assets"

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

