### PR TITLE
feat(Mastodon): add timestamps, privacy mode and a new pathname

### DIFF
--- a/websites/M/Mastodon/metadata.json
+++ b/websites/M/Mastodon/metadata.json
@@ -19,9 +19,10 @@
 		"indieweb.social",
 		"infosec.exchange",
 		"aus.social",
-		"social.network.europa.eu"
+		"social.network.europa.eu",
+		"masto.ai"
 	],
-	"version": "1.0.3",
+	"version": "1.1.0",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/M/Mastodon/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/M/Mastodon/assets/thumbnail.png",
 	"color": "#6364ff",
@@ -29,5 +30,19 @@
 	"tags": [
 		"mastodon",
 		"social"
+	],
+	"settings": [
+		{
+			"id": "time",
+			"title": "Show timestamps",
+			"icon": "fad fa-stopwatch",
+			"value": true
+		},
+		{
+			"id": "privacy",
+			"title": "Privacy Mode",
+			"icon": "fad fa-user-secret",
+			"value": false
+		}
 	]
 }

--- a/websites/M/Mastodon/presence.ts
+++ b/websites/M/Mastodon/presence.ts
@@ -29,36 +29,29 @@ presence.on("UpdateData", async () => {
 
 	switch (pathname) {
 		case "/home": {
-			presenceData.smallImageText = "Home";
 			presenceData.details = "On the homepage";
 			break;
 		}
 		case "/notifications": {
-			presenceData.smallImageText = "Notifications";
 			presenceData.details = "Checking notifications";
 			break;
 		}
 		case "/public/local": {
-			presenceData.smallImageText = "Local timeline";
 			presenceData.details = "Looking in local timeline";
 			break;
 		}
 		case "/public": {
 			presenceData.largeImageKey = Assets.FediverseLogo;
-			presenceData.smallImageText = "Fediverse";
 			presenceData.details = "Looking in fediverse";
 			break;
 		}
 		case "/bookmarks":
 		case "/favourites":
 		case "/lists": {
-			const pathName = pathname.split("/")[1];
-			presenceData.smallImageText = pathName;
-			presenceData.details = `Looking at their ${pathName}`;
+			presenceData.details = `Looking at their ${pathname.split("/")[1]}`;
 			break;
 		}
 		case "/search": {
-			presenceData.smallImageText = "Search";
 			presenceData.details = !privacy
 				? `Searching ${document
 						.querySelector(".search__input")
@@ -67,7 +60,6 @@ presence.on("UpdateData", async () => {
 			break;
 		}
 		case "/relationships": {
-			presenceData.smallImageText = "Relationships";
 			presenceData.details = "Viewing their followers";
 			break;
 		}
@@ -84,17 +76,14 @@ presence.on("UpdateData", async () => {
 			break;
 		}
 		case "/directory": {
-			presenceData.smallImageText = "Directory";
 			presenceData.details = "On the directory";
 			break;
 		}
 		case "/privacy-policy": {
-			presenceData.smallImageText = "Privacy and Policy";
 			presenceData.details = "Reading Privacy and Policy";
 			break;
 		}
 		case "/follow_requests": {
-			presenceData.smallImageText = "follow_requests";
 			presenceData.details = "Looking at their follow requests";
 			break;
 		}
@@ -116,11 +105,9 @@ presence.on("UpdateData", async () => {
 		presenceData.details = `Viewing ${
 			!privacy ? `${pathname.split(/[@,/]+/)[1]}'s` : "a"
 		} profile`;
-	} else if (pathname.startsWith("/settings")) {
-		presenceData.smallImageText = "Settings";
+	} else if (pathname.startsWith("/settings"))
 		presenceData.details = "Viewing their settings";
-	} else if (pathname.startsWith("/tags")) {
-		presenceData.smallImageText = "tags";
+	else if (pathname.startsWith("/tags")) {
 		presenceData.details = !privacy
 			? `Searching ${pathname.split("/")[2]} tag`
 			: "Searching for: tags";


### PR DESCRIPTION
## Description 
I added timestamps, privacy mode and a new pathname. The masto.ai instance is supported now

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/PreMiD/Presences/assets/133604163/be7988e2-a26f-4363-8ffd-a580d52fab80)

![image](https://github.com/PreMiD/Presences/assets/133604163/87a32a86-b63c-41be-bcc3-081f76e52260)

![image](https://github.com/PreMiD/Presences/assets/133604163/80cf817b-714b-4d37-8a79-2e6901c81a88)


</details>
