### PR TITLE
fix(dアニメストア): discord rich-presence

### DIFF
--- a/websites/D/dアニメストア/metadata.json
+++ b/websites/D/dアニメストア/metadata.json
@@ -13,7 +13,7 @@
 		"nl": "De beste anime streaming website in Japan! Eerste maand gratis! Onbeperkt bekijken van meer dan 2900 animes voor 400 yen per maand (exclusief belasting)! U kunt andere dan DoCoMo mobiele apparaten ook gebruiken. Nog betere kwaliteit op tablets, pc's, Chromecasts en Fire TV!"
 	},
 	"url": "animestore.docomo.ne.jp",
-	"version": "2.0.8",
+	"version": "2.0.9",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/D/d%E3%82%A2%E3%83%8B%E3%83%A1%E3%82%B9%E3%83%88%E3%82%A2/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/D/d%E3%82%A2%E3%83%8B%E3%83%A1%E3%82%B9%E3%83%88%E3%82%A2/assets/thumbnail.jpg",
 	"color": "#ea552a",

--- a/websites/D/dアニメストア/presence.ts
+++ b/websites/D/dアニメストア/presence.ts
@@ -1,11 +1,7 @@
 {
 	const presence = new Presence({
-			clientId: "611012705306017792",
-		}),
-		strings = presence.getStrings({
-			play: "general.playing",
-			pause: "general.paused",
-		});
+		clientId: "611012705306017792",
+	});
 
 	presence.on("UpdateData", async () => {
 		if (
@@ -22,9 +18,7 @@
 					largeImageKey:
 						"https://cdn.rcd.gg/PreMiD/websites/D/d%E3%82%A2%E3%83%8B%E3%83%A1%E3%82%B9%E3%83%88%E3%82%A2/assets/logo.png",
 					smallImageKey: isPlaying ? "play" : "pause",
-					smallImageText: isPlaying
-						? (await strings).play
-						: (await strings).pause,
+					smallImageText: isPlaying ? "playing" : "paused",
 					startTimestamp:
 						Math.floor(Date.now() / 1000) - Math.floor(video.currentTime),
 				};


### PR DESCRIPTION
## Description 
The problem of opening the corresponding web page not being reflected as a Discord Rich Presence is resolved.
Resolves #6633
Resolves #7183 

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

<img src="https://github.com/PreMiD/Presences/assets/61118664/9d37672a-0dbe-4439-bffb-9615c5299b5d">

<img src="https://github.com/PreMiD/Presences/assets/61118664/1ebb8af0-1921-41df-b32c-c74cefcf08d2">


</details>
