### PR TITLE
fix(GitHub): organization page

### DIFF
--- a/websites/G/GitHub/metadata.json
+++ b/websites/G/GitHub/metadata.json
@@ -29,7 +29,7 @@
 		"github.com",
 		"gist.github.com"
 	],
-	"version": "2.11.7",
+	"version": "2.11.8",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/G/GitHub/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/G/GitHub/assets/thumbnail.png",
 	"color": "#000000",

--- a/websites/G/GitHub/presence.ts
+++ b/websites/G/GitHub/presence.ts
@@ -250,22 +250,22 @@ presence.on("UpdateData", async () => {
 					presenceData.state = `${repository.owner}/${repository.name}`;
 				}
 				break;
-			case !!document.querySelector<HTMLHeadingElement>(
-				"#js-pjax-container > div > header > div.container-xl.pt-4.pt-lg-0.p-responsive.clearfix > div > div.flex-1 > h1"
+			case !!document.querySelector<HTMLMetaElement>(
+				'meta[name="hovercard-subject-tag"]'
 			):
+				presenceData.details = "Viewing an organization";
+
 				if (privacy) {
-					presenceData.details = "Viewing an organization";
 					delete presenceData.state;
 					delete presenceData.buttons;
 					break;
 				}
-				presenceData.details = "Viewing an organization";
-				presenceData.state =
-					document.querySelector<HTMLHeadingElement>("h1")?.textContent;
+				presenceData.state = document.title;
 				if (cover) {
-					presenceData.largeImageKey = `${
-						document.querySelector<HTMLImageElement>("div > img").src
-					}`;
+					presenceData.largeImageKey = `${(presenceData.largeImageKey =
+						document.querySelector<HTMLMetaElement>(
+							'meta[property~="og:image"]'
+						).content)}`;
 				}
 				break;
 			case pathname.includes("/features"):


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

This PR fixes the `org` page

<samp>see screenshots.</samp>

## Acknowledgements
- [ ] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

### Before

- shows nothing.
- displaying the user profile instead of organization profile.
- wrong title. (it displays `Global Navigation`)

</br>

**privacy mode on**
<img width="552" alt="image" src="https://github.com/PreMiD/Presences/assets/57343545/81b4d028-fc6b-4ce8-908f-097cc46a2f4a">

**privacy mode off**
<img width="553" alt="image" src="https://github.com/PreMiD/Presences/assets/57343545/0ab5916c-4fba-46a1-a93a-4324f8fddb38">




### After

**privacy mode on**
<img width="548" alt="image" src="https://github.com/PreMiD/Presences/assets/57343545/1fb9c8ce-715d-4a4d-aaac-eb153bd708a0">

**privacy mode off**
<img width="550" alt="image" src="https://github.com/PreMiD/Presences/assets/57343545/54ea5213-f218-4766-ad78-61f0be14d34a">


</details>
