### PR TITLE
fix: Obtain streamer name from path rather than HTML Element

### DIFF
--- a/websites/T/Twitch/presence.ts
+++ b/websites/T/Twitch/presence.ts
@@ -420,7 +420,7 @@ presence.on("UpdateData", async () => {
 
 			if (path.includes("/moderator/")) {
 				presenceData.details = strings.modStreamer;
-				presenceData.state = getElement(".stream-info-card p > a");
+				presenceData.state = path.match(/moderator\/([a-z\d][\w]{2,24})$/i)?.[1] ?? 'Not selected';
 
 				if (getElement(".modview-dock-widget p") !== "Offline") {
 					presenceData.smallImageKey = "live";


### PR DESCRIPTION
## Description 
Currently the getElement selector for obtaining the streamers name does not work reliable on my end. Thus, obtaining it from the path is a cleaner and more reliable solution, as this does not depend on any DOM Content to load.

There is no open issue for this behaviour.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)