### PR TITLE
perf: cache eslint and prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ lerna-debug.log*
 !.yarn/sdks
 !.yarn/versions
 
+# Cache files
+.eslintcache
+
 # local VSCode files
 **/.vscode/*
 **/.history

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
 	"author": "Timeraa",
 	"license": "MPL-2.0",
 	"scripts": {
-		"lint": "eslint --fix . && prettier --write .",
-		"lint:ci": "eslint . && prettier --check .",
+		"lint": "eslint --cache --fix . && prettier --cache --write .",
+		"lint:ci": "eslint --cache . && prettier --cache --check .",
 		"format": "npm run metadataSorter && npm run lint",
 		"schemaEnforcer": "npm run format && npm run bumpChanged",
 		"compileTools": "tsc -p tools/tsconfig.json",


### PR DESCRIPTION
## Description 
Due to the size of the project, this *significantly* decreases the runtime of repeat invocations of `npm run lint` in my case.

(Prettier's cache doesn't need to be added to `.gitignore` as it's stored in `node_modules`.)

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)