### PR TITLE
feat(Stremio): add Stremio 5 & rewrite presence

### DIFF
--- a/websites/S/Stremio/metadata.json
+++ b/websites/S/Stremio/metadata.json
@@ -62,6 +62,15 @@
 			"title": "Show Buttons",
 			"icon": "fas fa-compress-arrows-alt",
 			"value": true
+		},
+		{
+			"id": "search",
+			"if": {
+				"privacy": false
+			},
+			"title": "Show Search",
+			"icon": "fas fa-search",
+			"value": false
 		}
 	]
 }

--- a/websites/S/Stremio/metadata.json
+++ b/websites/S/Stremio/metadata.json
@@ -1,13 +1,13 @@
 {
 	"$schema": "https://schemas.premid.app/metadata/1.9",
 	"author": {
-		"name": "Dark_Ville",
-		"id": "638080361179512853"
+		"name": "Sleeyax",
+		"id": "226037514954080257"
 	},
 	"contributors": [
 		{
-			"name": "Sleeyax",
-			"id": "226037514954080257"
+			"name": "Dark_Ville",
+			"id": "638080361179512853"
 		}
 	],
 	"service": "Stremio",

--- a/websites/S/Stremio/metadata.json
+++ b/websites/S/Stremio/metadata.json
@@ -4,6 +4,12 @@
 		"name": "Dark_Ville",
 		"id": "638080361179512853"
 	},
+	"contributors": [
+		{
+			"name": "Sleeyax",
+			"id": "226037514954080257"
+		}
+	],
 	"service": "Stremio",
 	"description": {
 		"en": "Freedom To Stream. Stremio is a modern media center that's a one-stop solution for your video entertainment. Discover, watch and organize video content from easy to install addons.",
@@ -11,16 +17,26 @@
 	},
 	"url": [
 		"www.stremio.com",
-		"app.strem.io"
+		"stremio.com",
+		"app.strem.io",
+		"web.strem.io",
+		"web.stremio.com"
 	],
-	"version": "1.0.6",
+	"version": "2.0.0",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/S/Stremio/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/S/Stremio/assets/thumbnail.jpg",
 	"color": "#8A5AAB",
 	"category": "videos",
 	"tags": [
+		"streaming",
+		"channels",
 		"cartoons",
-		"stream"
+		"movies",
+		"series",
+		"stream",
+		"shows",
+		"iptv",
+		"tv"
 	],
 	"settings": [
 		{

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -179,22 +179,27 @@ presence.on("UpdateData", async () => {
 					presenceData.details = "Search";
 					break;
 				case "player": {
-					let endTimestamp: number,
-					 isPaused = true;
+					 let isPaused = true;
 
 					if (!isNaN(video?.duration)) {
-						// eslint-disable-next-line no-one-time-vars/no-one-time-vars
-						const [, ts] = presence.getTimestampsfromMedia(video);
-						endTimestamp = ts;
+						[, presenceData.endTimestamp] = presence.getTimestampsfromMedia(video);
 						isPaused = video.paused;
+					} else if (video === null) {
+						isPaused = !!document.querySelector("div[class*='control-bar-button'] > svg[icon='ic_play']");
+						const seekBar = document.querySelector('[class*="seek-bar-container"]');
+						[, presenceData.endTimestamp] = presence.getTimestamps(
+							Number(
+								presence.timestampFromFormat(seekBar?.firstElementChild?.textContent)
+							),
+							Number(
+								presence.timestampFromFormat(seekBar?.lastElementChild?.textContent)
+							)
+						);
+						if (privacy) presenceData.state = "Watching";
 					}
 					
 					delete presenceData.startTimestamp;
-					if (endTimestamp) 
-						presenceData.endTimestamp = endTimestamp;
-					else
-						delete presenceData.endTimestamp;
-
+						
 					if (
 						(isPaused || (appVersion === AppVersion.V4 ? document.querySelector("#loading-logo").className.includes("flashing") : !!document.querySelector("div[class*='buffering-loader-container']")))
 					) 

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -205,6 +205,7 @@ presence.on("UpdateData", async () => {
 					if (appVersion === AppVersion.V4) {
 						title = document.querySelector("head > title")?.textContent?.replace("Stremio -", "")?.trim();
 						metaUrl = href.substring(0, href.lastIndexOf("/")).replace("player", "detail");
+						if (thumbnails) presenceData.largeImageKey = document.querySelector("#loading-logo")?.getAttribute("data-image") ?? "logo";
 					} else {
 						const playerState = await _eval("core.transport.getState('player')");
 						title = playerState.title as string;

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -313,7 +313,7 @@ presence.on("UpdateData", async () => {
 	}
 
 	if (!buttons) delete presenceData.buttons;
-	if (!thumbnails) delete presenceData.largeImageKey;
+	if (!thumbnails) presenceData.largeImageKey = Assets.Logo;
 	if (presenceData.details) presence.setActivity(presenceData);
 	else presence.setActivity();
 });

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -13,7 +13,7 @@ const enum Assets {
 	Logo = "https://cdn.rcd.gg/PreMiD/websites/S/Stremio/assets/logo.png",
 }
 
-function getApVersion(hostname: string) {
+function getAppVersion(hostname: string) {
 	switch (hostname) {
 		case "web.strem.io":
 		case "web.stremio.com":
@@ -108,7 +108,7 @@ presence.on("UpdateData", async () => {
 			presence.getSetting<boolean>("buttons"),
 			presence.getSetting<boolean>("search"),
 		]),
-		appVersion = getApVersion(hostname);
+		appVersion = getAppVersion(hostname);
 
 	if (!privacy && search) {
 		let searchInput: HTMLInputElement;

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -95,10 +95,9 @@ presence.on("UpdateData", async () => {
 									?.firstElementChild.getAttribute("src") ?? "logo";
 						}
 					} else {
-						const imgElement = document.querySelector<HTMLImageElement>("div[class|='meta-info-container'] > img[class|='logo']");
-						title = imgElement?.title;
-						presenceData.details = title;
-						if (thumbnails) presenceData.largeImageKey = imgElement?.src ?? "logo";
+						const imgElement = document.querySelector("div[class*='meta-info-container'] > img[class*='logo']") ?? document.querySelector("div[class*='poster-container'] img");
+						if (thumbnails) presenceData.largeImageKey = imgElement?.getAttribute("src") ?? "logo";
+						presenceData.details = imgElement?.getAttribute("title") ?? document.querySelector("div[class*='logo-placeholder']:last-child")?.textContent;
 					}
 
 					presenceData.state = "Viewing metadata";

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -332,13 +332,14 @@ presence.on("UpdateData", async () => {
 							"core.transport.getState('player')"
 						);
 						if (playerState.metaItem.type.toLowerCase() === "ready") {
-							// eslint-disable-next-line prefer-destructuring
-							const content = playerState.metaItem.content;
-							// eslint-disable-next-line prefer-destructuring
-							title = playerState.title;
+							const {
+								metaItem: { content },
+								seriesInfo: { season, episode },
+							} = playerState;
+							({ title } = playerState);
 							metaUrl = `${window.location.origin}/#/detail/${content.type}/${content.id}`;
 							if (content.type === "series")
-								metaUrl += `/${content.id}:${playerState.seriesInfo.season}:${playerState.seriesInfo.episode}`;
+								metaUrl += `/${content.id}:${season}:${episode}`;
 							presenceData.largeImageKey = content.logo ?? Assets.Logo;
 						}
 					}

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -103,7 +103,7 @@ presence.on("UpdateData", async () => {
 						presenceData.details = imgElement?.getAttribute("title") ?? document.querySelector("div[class*='logo-placeholder']:last-child")?.textContent;
 					}
 
-					presenceData.state = "Viewing metadata";
+					presenceData.state = `Viewing a ${hash.split("/")[2]}`;
 					presenceData.buttons = [
 						{
 							label: "View metadata",

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -3,10 +3,7 @@ const presence = new Presence({
 	}),
 	browsingTimestamp = Math.floor(Date.now() / 1000);
 
-let timestamp: [number, number],
-	pauseCheck: boolean,
-	search: HTMLInputElement,
-	title: string;
+let	title: string;
 
 presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
@@ -14,7 +11,7 @@ presence.on("UpdateData", async () => {
 				"https://cdn.rcd.gg/PreMiD/websites/S/Stremio/assets/logo.png",
 			startTimestamp: browsingTimestamp,
 		},
-		{ hash, hostname, href } = document.location,
+		{ hash, hostname, pathname, href } = document.location,
 		[privacy, thumbnails, buttons] = await Promise.all([
 			presence.getSetting<boolean>("privacy"),
 			presence.getSetting<boolean>("thumbnails"),
@@ -24,151 +21,186 @@ presence.on("UpdateData", async () => {
 			"[class='ng-binding ng-scope selected']"
 		)?.textContent;
 
-	if (hostname.includes("app.strem.io")) {
-		search = document.querySelector("#global-search-field");
-		const video = document.querySelector<HTMLMediaElement>("#videoPlayer");
-		if (privacy && !video) presenceData.details = "Browsing...";
-		else if (privacy && video) presenceData.details = "Watching...";
-		else if (search?.value) {
-			presenceData.details = "Searching For:";
-			presenceData.state = search.value;
-		} else if (hash.includes("/detail/")) {
-			title = document.querySelector(
-				"#detail > div:nth-child(3) > div > div.sidebar-info-container > div > div.logo > div"
-			).textContent;
-			presenceData.details = title;
-			presenceData.buttons = [
-				{
-					label: "Watch Video",
-					url: href,
-				},
-			];
-			if (thumbnails) {
-				presenceData.largeImageKey =
-					document
-						.querySelector(
-							"#detail > div.details-less-info > div.details-top > div:nth-child(1)"
-						)
-						?.firstElementChild.getAttribute("src") ?? "logo";
-			}
-		} else if (hash.includes("addons")) {
-			search = document.querySelector(
-				"#addons > div.filter > form > div.addon-search-input > input"
-			);
-			if (search?.value) {
-				presenceData.details = "Searching addons for:";
-				presenceData.state = search.value;
-			} else {
-				presenceData.state = active ?? "All";
-				title = document.querySelector(
-					"[class='ng-scope selected']"
-				)?.textContent;
+	switch (hostname) {
+		case "app.strem.io": {			
+			const video = document.querySelector<HTMLMediaElement>("#videoPlayer");
 
-				presenceData.buttons = [
-					{
-						label: "Browse Addons",
-						url: href,
-					},
-				];
-				presenceData.details = `Browsing ${title}`;
+			if (privacy) {
+				presenceData.details = !video ? "Browsing..." : "Watching...";
+				break;
 			}
-		} else if (hash.includes("settings")) {
-			presenceData.details = `${
-				document.querySelector("[class='ng-scope ng-binding active']")
-					?.textContent ?? "General"
-			} settings`;
-		} else if (hash.includes("/discover/")) {
-			if (active) {
-				presenceData.buttons = [
-					{
-						label: "Browse",
-						url: href,
-					},
-				];
-				presenceData.details = `Browsing: ${active}`;
-			} else presenceData.state = "Browsing Movies";
-		} else if (hash.includes("/library")) {
-			if (active) presenceData.details = `${active} Library`;
-			else presenceData.details = "Library";
 
-			presenceData.buttons = [
-				{
-					label: "View Library",
-					url: href,
-				},
-			];
-		} else if (hash.includes("/calendar")) {
-			presenceData.buttons = [
-				{
-					label: "View Calendar",
-					url: href,
-				},
-			];
-			presenceData.details = "Calendar";
-		} else if (hash.includes("player")) {
-			if (video?.duration) {
-				timestamp = presence.getTimestampsfromMedia(video);
-				pauseCheck = video?.paused ?? true;
-			} else if (!video.duration && document.querySelector("#controlbar-top")) {
-				let split = document
-					.querySelector("#play-progress-text")
-					?.textContent.split("/");
-				if (split?.[0]) {
-					split = split.map(s => s.trim());
-					timestamp = presence.getTimestamps(
-						presence.timestampFromFormat(split[0]),
-						presence.timestampFromFormat(split[1])
-					);
+			switch (hash.replace("#/", "").split("/").shift()) {
+				case "":
+					presenceData.details = "Board";
+					break;
+				case "detail":
+					title = document.querySelector(
+						"#detail > div:nth-child(3) > div > div.sidebar-info-container > div > div.logo > div"
+					)?.textContent;
+					presenceData.details = title;
+					presenceData.state = "Viewing Metadata";
+					presenceData.buttons = [
+						{
+							label: "View Metadata",
+							url: href,
+						},
+					];
+
+					if (thumbnails) {
+						presenceData.largeImageKey =
+							document
+								.querySelector(
+									"#detail > div.details-less-info > div.details-top > div:nth-child(1)"
+								)
+								?.firstElementChild.getAttribute("src") ?? "logo";
+					}
+
+					break;
+				case "addons":
+					title = document.querySelector(
+						"[class='ng-scope selected']"
+						)?.textContent;
+						
+					presenceData.state = active ?? "All";
+					presenceData.buttons = [
+						{
+							label: "Browse Addons",
+							url: href,
+						},
+					];
+					presenceData.details = `Browsing ${title}`;
+					break;
+				case "settings":
+					// eslint-disable-next-line no-case-declarations, no-one-time-vars/no-one-time-vars
+					const section = document.querySelector("[class='ng-scope ng-binding active']")?.textContent ?? "General";
+					presenceData.details = `${section} settings`;
+					break;
+				case "discover":
+					if (active) {
+						presenceData.buttons = [
+							{
+								label: "Browse",
+								url: href,
+							},
+						];
+					}
+					presenceData.details = `Browsing ${active ?? "Content"}`;
+					break;
+				case "library":
+					presenceData.details = "Library";
+					if (active) presenceData.details = `${active} ${presenceData.details}`;
+					presenceData.buttons = [
+						{
+							label: "View Library",
+							url: href,
+						},
+					];
+					break;
+				case "calendar":
+					presenceData.buttons = [
+						{
+							label: "View Calendar",
+							url: href,
+						},
+					];
+					presenceData.details = "Calendar";
+					break;
+				case "player": {
+					let timestamp: [number, number],
+					 pauseCheck: boolean;
+
+					if (video?.duration) {
+						timestamp = presence.getTimestampsfromMedia(video);
+						pauseCheck = video.paused ?? true;
+					} else if (document.querySelector("#controlbar-top")) {
+						let split = document
+							.querySelector("#play-progress-text")
+							?.textContent.split("/");
+						if (split?.[0]) {
+							split = split.map(s => s.trim());
+							timestamp = presence.getTimestamps(
+								presence.timestampFromFormat(split[0]),
+								presence.timestampFromFormat(split[1])
+							);
+						}
+	
+						pauseCheck = !document
+							.querySelector("#controlbar-top")
+							?.firstElementChild.className.includes("pause");
+					}
+
+					delete presenceData.startTimestamp;
+
+					if (
+						!pauseCheck &&
+						!document.querySelector("#loading-logo").className.includes("flashing")
+					) {
+						presenceData.endTimestamp = timestamp[1];
+						presenceData.smallImageKey = Assets.Play;
+					} else {
+						delete presenceData.endTimestamp;
+						presenceData.smallImageKey = Assets.Pause;
+					}
+
+					title = document
+						.querySelector("head > title")
+						?.textContent.replace("Stremio -", "");
+
+					presenceData.details = title;
+					presenceData.state = pauseCheck ? "Paused" : "Watching";
+					presenceData.buttons = [
+						{
+							label: "Watch",
+							url: href,
+						},
+					];
+					break;
 				}
-
-				pauseCheck = !document
-					.querySelector("#controlbar-top")
-					?.firstElementChild.className.includes("pause");
 			}
-			delete presenceData.startTimestamp;
-			if (
-				!pauseCheck &&
-				!document.querySelector("#loading-logo").className.includes("flashing")
-			) {
-				presenceData.endTimestamp = timestamp[1];
-				presenceData.smallImageKey = Assets.Play;
-			} else {
-				delete presenceData.endTimestamp;
-				presenceData.smallImageKey = Assets.Pause;
-			}
-			title = document
-				.querySelector("head > title")
-				?.textContent.replace("Stremio -", "");
-			presenceData.details = title;
-			presenceData.buttons = [
-				{
-					label: "Join View Party",
-					url: href,
-				},
-			];
-		} else if (hash === "#/") presenceData.details = "Viewing the homepage";
-	} else if (hostname === "stremio.com") {
-		if (hash.includes("addon-sdk")) presenceData.details = "Viewing Addon SDK";
-		else if (hash.includes("contribute"))
-			presenceData.details = "Contributing page";
-		else if (hash.includes("community"))
-			presenceData.details = "Viewing the Community";
-		else if (hash.includes("technology"))
-			presenceData.details = "Viewing the technology";
-		else if (document.querySelector("#tos-container > h1 > strong")) {
-			presenceData.details = `Reading ${
-				document.querySelector("#tos-container > h1 > strong").textContent
-			}`;
-		} else if (
-			document.querySelector("[class='active']")?.textContent !== "EN"
-		) {
-			presenceData.details =
-				document.querySelector("[class='active']")?.textContent ??
-				"Browsing...";
+			break;
 		}
+		case "www.stremio.com":
+		case "stremio.com":
+			presenceData.details = "Visiting stremio.com";
+
+			switch (pathname) {
+				case "/addon-sdk":
+					presenceData.state = "Addon SDK";
+					break;
+				
+				case "/contribute":
+					presenceData.state = "Contribute";
+					break;
+			
+				case "/community":
+					presenceData.state = " Community";
+					break;
+
+				case "/technology":
+					presenceData.state = "Technology";
+					break;
+			
+				case "/competition":
+					presenceData.state = "Competition";
+					break;
+
+				case "/careers":
+					presenceData.state = "Careers";
+					break;
+
+				default: 
+					// eslint-disable-next-line no-case-declarations
+					const activeTab = document.querySelector("[class='active']");
+					if (activeTab === null || activeTab.parentElement?.className === "langs") break;
+					presenceData.state = activeTab.textContent;
+			}
+			
+			break;
 	}
 
 	if (!buttons) delete presenceData.buttons;
+	
 	if (presenceData.details) presence.setActivity(presenceData);
 	else presence.setActivity();
 });

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -3,8 +3,6 @@ const presence = new Presence({
 	}),
 	browsingTimestamp = Math.floor(Date.now() / 1000);
 
-let	title: string;
-
 enum AppVersion {
 	Website = -1,
 	V4 = 4,
@@ -105,7 +103,7 @@ presence.on("UpdateData", async () => {
 					break;
 				case "detail": {
 					if (appVersion === AppVersion.V4) {
-						title = document.querySelector("#detail > div:nth-child(3) > div > div.sidebar-info-container > div > div.logo > div")?.textContent;
+						const title = document.querySelector("#detail > div:nth-child(3) > div > div.sidebar-info-container > div > div.logo > div")?.textContent;
 						presenceData.state = title;
 						if (thumbnails) {
 							presenceData.largeImageKey =
@@ -132,11 +130,10 @@ presence.on("UpdateData", async () => {
 					break;
 				}
 				case "addons": {
-					title = document.querySelector(
+					const title = document.querySelector(
 						appVersion === AppVersion.V4 ? "[class='ng-scope selected']" : "div[class*='addons-content'] > div[class*='selectable-inputs-container'] > div:nth-child(2) > div"
-					)?.textContent;
-
-					const type = document.querySelector(
+					)?.textContent,
+					 type = document.querySelector(
 						appVersion === AppVersion.V4 ? "[class='ng-binding ng-scope selected']" : "div[class*='addons-content'] > div[class*='selectable-inputs-container'] > div:nth-child(3) > div"
 					)?.textContent;
 						
@@ -231,7 +228,7 @@ presence.on("UpdateData", async () => {
 						presenceData.smallImageText = "Player is playing";
 					}
 
-					let metaUrl: string;
+					let metaUrl: string, title: string;
 
 					if (appVersion === AppVersion.V4) {
 						title = document.querySelector("head > title")?.textContent?.replace("Stremio -", "")?.trim();

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -176,6 +176,9 @@ presence.on("UpdateData", async () => {
 					];
 					presenceData.details = "Calendar";
 					break;
+				case "search":
+					presenceData.details = "Search";
+					break;
 				case "player": {
 					let endTimestamp: number,
 					 isPaused = true;

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -76,8 +76,7 @@ presence.on("UpdateData", async () => {
 			const video = document.querySelector<HTMLMediaElement>("video");
 
 			if (privacy) {
-				presenceData.details = "Privacy mode";
-				presenceData.state = !video ? "Browsing" : "Watching";
+				presenceData.details = !video ? "Browsing" : "Watching";
 				break;
 			}
 
@@ -88,7 +87,7 @@ presence.on("UpdateData", async () => {
 				case "detail": {
 					if (appVersion === AppVersion.V4) {
 						title = document.querySelector("#detail > div:nth-child(3) > div > div.sidebar-info-container > div > div.logo > div")?.textContent;
-						presenceData.details = title;
+						presenceData.state = title;
 						if (thumbnails) {
 							presenceData.largeImageKey =
 								document
@@ -100,10 +99,10 @@ presence.on("UpdateData", async () => {
 					} else {
 						const imgElement = document.querySelector("div[class*='meta-info-container'] > img[class*='logo']") ?? document.querySelector("div[class*='poster-container'] img");
 						if (thumbnails) presenceData.largeImageKey = imgElement?.getAttribute("src") ?? Assets.Logo;
-						presenceData.details = imgElement?.getAttribute("title") ?? document.querySelector("div[class*='logo-placeholder']:last-child")?.textContent;
+						presenceData.state = imgElement?.getAttribute("title") ?? document.querySelector("div[class*='logo-placeholder']:last-child")?.textContent;
 					}
 
-					presenceData.state = `Viewing a ${hash.split("/")[2]}`;
+					presenceData.details = `Viewing a ${hash.split("/")[2]}`;
 					presenceData.buttons = [
 						{
 							label: "View metadata",
@@ -122,6 +121,7 @@ presence.on("UpdateData", async () => {
 						appVersion === AppVersion.V4 ? "[class='ng-binding ng-scope selected']" : "div[class*='addons-content'] > div[class*='selectable-inputs-container'] > div:nth-child(3) > div"
 					)?.textContent;
 						
+					presenceData.details = `Browsing ${title?.toLowerCase()?.replace(" addons", "")} addons`;
 					presenceData.state = type ?? "All";
 					presenceData.buttons = [
 						{
@@ -129,7 +129,6 @@ presence.on("UpdateData", async () => {
 							url: href,
 						},
 					];
-					presenceData.details = `Browsing ${title?.toLowerCase()?.replace(" addons", "")} addons`;
 					break;
 				}
 				case "settings": {
@@ -198,7 +197,7 @@ presence.on("UpdateData", async () => {
 								presence.timestampFromFormat(seekBar?.lastElementChild?.textContent)
 							)
 						);
-						if (privacy) presenceData.state = "Watching";
+						if (privacy) presenceData.details = "Watching";
 					}
 					
 					delete presenceData.startTimestamp;
@@ -233,7 +232,7 @@ presence.on("UpdateData", async () => {
 						}
 					}
 					
-					presenceData.details = (title as string) ?? "Player";
+					presenceData.details = title ?? "Player";
 					presenceData.state = isPaused ? "Paused" : "Watching";
 					if (metaUrl) {
 						presenceData.buttons = [

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -227,14 +227,19 @@ presence.on("UpdateData", async () => {
 							.querySelector(
 								appVersion === AppVersion.V4
 									? "[class='ng-binding ng-scope selected']"
-									: "div[class*='selectable-inputs-container'] > div > div"
+									: "div[class*='selectable-inputs-container'] > div:nth-child(1) > div"
 							)
 							?.textContent?.toLowerCase(),
 						category = document.querySelector(
 							appVersion === AppVersion.V4
 								? "ul.sort > li.selected"
 								: "div[class*='selectable-inputs-container'] > div:nth-child(2) > div"
-						)?.textContent;
+						)?.textContent,
+						genre = document.querySelector(
+							appVersion === AppVersion.V4
+								? "ul.genre-select > li.selected"
+								: "div[class*='selectable-inputs-container'] > div:nth-child(3) > div"
+						)?.textContent?.replace("Select genre", "") || null;
 
 					presenceData.buttons = [
 						{
@@ -245,7 +250,7 @@ presence.on("UpdateData", async () => {
 					presenceData.details = `Discovering ${type ?? "content"}${
 						type === "series" ? "" : "s"
 					}`;
-					presenceData.state = category ?? "All";
+					presenceData.state = `${category}${genre ? ` | ${genre}` : ""}` ?? "All";
 
 					break;
 				}

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -347,7 +347,7 @@ presence.on("UpdateData", async () => {
 					break;
 
 				case "/community":
-					presenceData.state = " Community";
+					presenceData.state = "Community";
 					break;
 
 				case "/technology":

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -141,7 +141,7 @@ presence.on("UpdateData", async () => {
 								)
 								?.firstElementChild.getAttribute("src") ?? Assets.Logo;
 					} else {
-						const imgElement = document.querySelector("div[class*='meta-info-container'] > img[class*='logo']") ?? document.querySelector("div[class*='poster-container'] img");
+						const imgElement = document.querySelector("div[class*='meta-info-container'] > img[class*='logo']");
 						presenceData.largeImageKey = imgElement?.getAttribute("src") ?? Assets.Logo;
 						presenceData.state = imgElement?.getAttribute("title") ?? document.querySelector("div[class*='logo-placeholder']:last-child")?.textContent;
 					}

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -208,19 +208,26 @@ presence.on("UpdateData", async () => {
 						if (thumbnails) presenceData.largeImageKey = document.querySelector("#loading-logo")?.getAttribute("data-image") ?? "logo";
 					} else {
 						const playerState = await _eval("core.transport.getState('player')");
-						title = playerState.title as string;
-						metaUrl = `${window.location.origin}/#/detail/${playerState.metaItem.content.type}/${playerState.metaItem.content.id}/${playerState.libraryItem.state.video_id}`;
-						if (thumbnails) presenceData.largeImageKey = playerState.metaItem?.content?.logo ?? "logo";
+						if (playerState.metaItem.type.toLowerCase() === "ready") {
+							// eslint-disable-next-line prefer-destructuring
+							const content = playerState.metaItem.content;
+							// eslint-disable-next-line prefer-destructuring
+							title = playerState.title;
+							metaUrl = `${window.location.origin}/#/detail/${content.type}/${content.id}/${playerState.libraryItem.state.video_id}`;
+							if (thumbnails) presenceData.largeImageKey = content?.logo ?? "logo";
+						}
 					}
 					
-					presenceData.details = title ?? "Player";
+					presenceData.details = (title as string) ?? "Player";
 					presenceData.state = isPaused ? "Paused" : "Watching";
-					presenceData.buttons = [
-						{
-							label: "Watch",
-							url: metaUrl,
-						},
-					];
+					if (metaUrl) {
+						presenceData.buttons = [
+							{
+								label: "Watch",
+								url: metaUrl,
+							},
+						];
+					}
 					break;
 				}
 			}

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -73,7 +73,7 @@ presence.on("UpdateData", async () => {
 			const video = document.querySelector<HTMLMediaElement>("video");
 
 			if (privacy) {
-				presenceData.details = "Privacy Mode";
+				presenceData.details = "Privacy mode";
 				presenceData.state = !video ? "Browsing" : "Watching";
 				break;
 			}
@@ -101,10 +101,10 @@ presence.on("UpdateData", async () => {
 						if (thumbnails) presenceData.largeImageKey = imgElement?.src ?? "logo";
 					}
 
-					presenceData.state = "Viewing Metadata";
+					presenceData.state = "Viewing metadata";
 					presenceData.buttons = [
 						{
-							label: "View Metadata",
+							label: "View metadata",
 							url: href,
 						},
 					];
@@ -123,22 +123,22 @@ presence.on("UpdateData", async () => {
 					presenceData.state = type ?? "All";
 					presenceData.buttons = [
 						{
-							label: "Browse Addons",
+							label: "Browse addons",
 							url: href,
 						},
 					];
-					presenceData.details = `Browsing ${title}`;
+					presenceData.details = `Browsing ${title?.toLowerCase()?.replace(" addons", "")} addons`;
 					break;
 				}
 				case "settings": {
 					const section = document.querySelector(appVersion === AppVersion.V4 ? "[class='ng-scope ng-binding active']" : "div[class|='settings-content'] div[class*='selected']")?.textContent ?? "General";
-					presenceData.details = `${section} Settings`;
+					presenceData.details = `${section} settings`;
 					break;
 				}
 				case "discover": {
 					const type = document.querySelector(
 						appVersion === AppVersion.V4 ? "[class='ng-binding ng-scope selected']" : "div[class|='selectable-inputs-container'] > div > div"
-					)?.textContent,
+					)?.textContent?.toLowerCase(),
 					 category = document.querySelector(appVersion === AppVersion.V4 ? "ul.sort > li.selected" : "div[class|='selectable-inputs-container'] > div:nth-child(2) > div")?.textContent;
 
 					presenceData.buttons = [
@@ -147,7 +147,7 @@ presence.on("UpdateData", async () => {
 							url: href,
 						},
 					];
-					presenceData.details = `Discovering ${type ?? "Content"}`;
+					presenceData.details = `Discovering ${type ?? "content"}${type === "series" ? "" : "s"}`;
 					presenceData.state = category ?? "All";
 
 					break;
@@ -161,7 +161,7 @@ presence.on("UpdateData", async () => {
 					presenceData.state = type ?? "All";
 					presenceData.buttons = [
 						{
-							label: "View Library",
+							label: "View library",
 							url: href,
 						},
 					];
@@ -170,7 +170,7 @@ presence.on("UpdateData", async () => {
 				case "calendar":
 					presenceData.buttons = [
 						{
-							label: "View Calendar",
+							label: "View calendar",
 							url: href,
 						},
 					];

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -105,17 +105,15 @@ presence.on("UpdateData", async () => {
 					if (appVersion === AppVersion.V4) {
 						const title = document.querySelector("#detail > div:nth-child(3) > div > div.sidebar-info-container > div > div.logo > div")?.textContent;
 						presenceData.state = title;
-						if (thumbnails) {
-							presenceData.largeImageKey =
-								document
-									.querySelector(
-										"#detail > div.details-less-info > div.details-top > div:nth-child(1)"
-									)
-									?.firstElementChild.getAttribute("src") ?? Assets.Logo;
-						}
+						presenceData.largeImageKey =
+							document
+								.querySelector(
+									"#detail > div.details-less-info > div.details-top > div:nth-child(1)"
+								)
+								?.firstElementChild.getAttribute("src") ?? Assets.Logo;
 					} else {
 						const imgElement = document.querySelector("div[class*='meta-info-container'] > img[class*='logo']") ?? document.querySelector("div[class*='poster-container'] img");
-						if (thumbnails) presenceData.largeImageKey = imgElement?.getAttribute("src") ?? Assets.Logo;
+						presenceData.largeImageKey = imgElement?.getAttribute("src") ?? Assets.Logo;
 						presenceData.state = imgElement?.getAttribute("title") ?? document.querySelector("div[class*='logo-placeholder']:last-child")?.textContent;
 					}
 
@@ -233,7 +231,7 @@ presence.on("UpdateData", async () => {
 					if (appVersion === AppVersion.V4) {
 						title = document.querySelector("head > title")?.textContent?.replace("Stremio -", "")?.trim();
 						metaUrl = href.substring(0, href.lastIndexOf("/")).replace("player", "detail");
-						if (thumbnails) presenceData.largeImageKey = document.querySelector("#loading-logo")?.getAttribute("data-image") ?? Assets.Logo;
+						presenceData.largeImageKey = document.querySelector("#loading-logo")?.getAttribute("data-image") ?? Assets.Logo;
 					} else {
 						const playerState = await _eval("core.transport.getState('player')");
 						if (playerState.metaItem.type.toLowerCase() === "ready") {
@@ -244,7 +242,7 @@ presence.on("UpdateData", async () => {
 							metaUrl = `${window.location.origin}/#/detail/${content.type}/${content.id}`;
 							if (content.type === "series")
 								metaUrl += `/${content.id}:${playerState.seriesInfo.season}:${playerState.seriesInfo.episode}`;
-							if (thumbnails) presenceData.largeImageKey = content?.logo ?? Assets.Logo;
+							presenceData.largeImageKey = content?.logo ?? Assets.Logo;
 						}
 					}
 					
@@ -302,7 +300,7 @@ presence.on("UpdateData", async () => {
 	}
 
 	if (!buttons) delete presenceData.buttons;
-	
+	if (!thumbnails) delete presenceData.largeImageKey;
 	if (presenceData.details) presence.setActivity(presenceData);
 	else presence.setActivity();
 });

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -11,6 +11,10 @@ enum AppVersion {
 	V5 = 5,
 }
 
+const enum Assets {
+	Logo = "https://cdn.rcd.gg/PreMiD/websites/S/Stremio/assets/logo.png",
+}
+
 function getApVersion(hostname: string) {
 	switch (hostname) {
 		case "web.strem.io":
@@ -55,8 +59,7 @@ function _eval(js: string): Promise<any> {
 
 presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
-			largeImageKey:
-				"https://cdn.rcd.gg/PreMiD/websites/S/Stremio/assets/logo.png",
+			largeImageKey: Assets.Logo,
 			startTimestamp: browsingTimestamp,
 		},
 		{ hash, hostname, pathname, href } = document.location,
@@ -92,11 +95,11 @@ presence.on("UpdateData", async () => {
 									.querySelector(
 										"#detail > div.details-less-info > div.details-top > div:nth-child(1)"
 									)
-									?.firstElementChild.getAttribute("src") ?? "logo";
+									?.firstElementChild.getAttribute("src") ?? Assets.Logo;
 						}
 					} else {
 						const imgElement = document.querySelector("div[class*='meta-info-container'] > img[class*='logo']") ?? document.querySelector("div[class*='poster-container'] img");
-						if (thumbnails) presenceData.largeImageKey = imgElement?.getAttribute("src") ?? "logo";
+						if (thumbnails) presenceData.largeImageKey = imgElement?.getAttribute("src") ?? Assets.Logo;
 						presenceData.details = imgElement?.getAttribute("title") ?? document.querySelector("div[class*='logo-placeholder']:last-child")?.textContent;
 					}
 
@@ -212,7 +215,7 @@ presence.on("UpdateData", async () => {
 					if (appVersion === AppVersion.V4) {
 						title = document.querySelector("head > title")?.textContent?.replace("Stremio -", "")?.trim();
 						metaUrl = href.substring(0, href.lastIndexOf("/")).replace("player", "detail");
-						if (thumbnails) presenceData.largeImageKey = document.querySelector("#loading-logo")?.getAttribute("data-image") ?? "logo";
+						if (thumbnails) presenceData.largeImageKey = document.querySelector("#loading-logo")?.getAttribute("data-image") ?? Assets.Logo;
 					} else {
 						const playerState = await _eval("core.transport.getState('player')");
 						if (playerState.metaItem.type.toLowerCase() === "ready") {
@@ -223,7 +226,7 @@ presence.on("UpdateData", async () => {
 							metaUrl = `${window.location.origin}/#/detail/${content.type}/${content.id}`;
 							if (content.type === "series")
 								metaUrl += `/${content.id}:${playerState.seriesInfo.season}:${playerState.seriesInfo.episode}`;
-							if (thumbnails) presenceData.largeImageKey = content?.logo ?? "logo";
+							if (thumbnails) presenceData.largeImageKey = content?.logo ?? Assets.Logo;
 						}
 					}
 					

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -63,12 +63,31 @@ presence.on("UpdateData", async () => {
 			startTimestamp: browsingTimestamp,
 		},
 		{ hash, hostname, pathname, href } = document.location,
-		[privacy, thumbnails, buttons] = await Promise.all([
+		[privacy, thumbnails, buttons, search] = await Promise.all([
 			presence.getSetting<boolean>("privacy"),
 			presence.getSetting<boolean>("thumbnails"),
 			presence.getSetting<boolean>("buttons"),
+			presence.getSetting<boolean>("search"),
 		]),
 		appVersion = getApVersion(hostname);
+
+		if (!privacy && search) {
+			let searchInput: HTMLInputElement;
+
+			if (appVersion === AppVersion.V4)
+				searchInput = document.querySelector("#global-search-field");
+			else
+				searchInput = document.querySelector("input[class*='search-input']");
+		
+			const searchValue = searchInput?.value;
+
+			if (searchValue) {
+				presenceData.details = `Searching for ${searchValue}`;
+				presenceData.smallImageKey = Assets.Search;
+				presence.setActivity(presenceData);
+				return;
+			};
+		}
 
 	switch (appVersion) {
 		case AppVersion.V4:

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -69,10 +69,10 @@ function findVideo(presence: Presence): Video | null {
 	if (videoElement) {
 		const result: Video = { isEmbed: false, isPaused: videoElement.paused };
 
-		if (!isNaN(videoElement?.duration))
-			// eslint-disable-next-line curly
+		if (!isNaN(videoElement?.duration)) {
 			[result.startTimestamp, result.endTimestamp] =
 				presence.getTimestampsfromMedia(videoElement);
+		}
 
 		return result;
 	} else if (document.querySelector("div[class*='player-container']")) {
@@ -253,8 +253,9 @@ presence.on("UpdateData", async () => {
 					presenceData.details = `Discovering ${type ?? "content"}${
 						type === "series" ? "" : "s"
 					}`;
-					presenceData.state =
-						`${category}${genre ? ` | ${genre}` : ""}` ?? "All";
+					presenceData.state = `${category ?? "All"}${
+						genre ? ` | ${genre}` : ""
+					}`;
 
 					break;
 				}
@@ -338,7 +339,7 @@ presence.on("UpdateData", async () => {
 							metaUrl = `${window.location.origin}/#/detail/${content.type}/${content.id}`;
 							if (content.type === "series")
 								metaUrl += `/${content.id}:${playerState.seriesInfo.season}:${playerState.seriesInfo.episode}`;
-							presenceData.largeImageKey = content?.logo ?? Assets.Logo;
+							presenceData.largeImageKey = content.logo ?? Assets.Logo;
 						}
 					}
 
@@ -384,8 +385,7 @@ presence.on("UpdateData", async () => {
 					presenceData.state = "Careers";
 					break;
 
-				default:
-					// eslint-disable-next-line no-case-declarations
+				default: {
 					const activeTab = document.querySelector("[class='active']");
 					if (
 						activeTab === null ||
@@ -393,6 +393,7 @@ presence.on("UpdateData", async () => {
 					)
 						break;
 					presenceData.state = activeTab.textContent;
+				}
 			}
 
 			break;

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -112,11 +112,11 @@ presence.on("UpdateData", async () => {
 				}
 				case "addons": {
 					title = document.querySelector(
-						appVersion === AppVersion.V4 ? "[class='ng-scope selected']" : "div[class|='addons-content'] > div[class|='selectable-inputs-container'] > div:nth-child(2) > div"
+						appVersion === AppVersion.V4 ? "[class='ng-scope selected']" : "div[class*='addons-content'] > div[class*='selectable-inputs-container'] > div:nth-child(2) > div"
 					)?.textContent;
 
 					const type = document.querySelector(
-						appVersion === AppVersion.V4 ? "[class='ng-binding ng-scope selected']" : "div[class|='addons-content'] > div[class|='selectable-inputs-container'] > div:nth-child(3) > div"
+						appVersion === AppVersion.V4 ? "[class='ng-binding ng-scope selected']" : "div[class*='addons-content'] > div[class*='selectable-inputs-container'] > div:nth-child(3) > div"
 					)?.textContent;
 						
 					presenceData.state = type ?? "All";
@@ -130,15 +130,15 @@ presence.on("UpdateData", async () => {
 					break;
 				}
 				case "settings": {
-					const section = document.querySelector(appVersion === AppVersion.V4 ? "[class='ng-scope ng-binding active']" : "div[class|='settings-content'] div[class*='selected']")?.textContent ?? "General";
+					const section = document.querySelector(appVersion === AppVersion.V4 ? "[class='ng-scope ng-binding active']" : "div[class*='settings-content'] div[class*='selected']")?.textContent ?? "General";
 					presenceData.details = `${section} settings`;
 					break;
 				}
 				case "discover": {
 					const type = document.querySelector(
-						appVersion === AppVersion.V4 ? "[class='ng-binding ng-scope selected']" : "div[class|='selectable-inputs-container'] > div > div"
+						appVersion === AppVersion.V4 ? "[class='ng-binding ng-scope selected']" : "div[class*='selectable-inputs-container'] > div > div"
 					)?.textContent?.toLowerCase(),
-					 category = document.querySelector(appVersion === AppVersion.V4 ? "ul.sort > li.selected" : "div[class|='selectable-inputs-container'] > div:nth-child(2) > div")?.textContent;
+					 category = document.querySelector(appVersion === AppVersion.V4 ? "ul.sort > li.selected" : "div[class*='selectable-inputs-container'] > div:nth-child(2) > div")?.textContent;
 
 					presenceData.buttons = [
 						{
@@ -153,7 +153,7 @@ presence.on("UpdateData", async () => {
 				}
 				case "library": {
 					const type = document.querySelector(
-						appVersion === AppVersion.V4 ? "[class='ng-binding ng-scope selected']" : "div[class|='selectable-inputs-container'] > div > div"
+						appVersion === AppVersion.V4 ? "[class='ng-binding ng-scope selected']" : "div[class*='selectable-inputs-container'] > div > div"
 					)?.textContent;
 
 					presenceData.details = "Library";

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -140,6 +140,12 @@ presence.on("UpdateData", async () => {
 			switch (hash.replace("#/", "").split("/").shift().split("?").shift()) {
 				case "":
 					presenceData.details = "Board";
+					presenceData.buttons = [
+						{
+							label: "View board",
+							url: href,
+						},
+					];
 					break;
 				case "detail": {
 					if (appVersion === AppVersion.V4) {
@@ -208,6 +214,12 @@ presence.on("UpdateData", async () => {
 								: "div[class*='settings-content'] div[class*='selected']"
 						)?.textContent ?? "General";
 					presenceData.details = `${section} settings`;
+					presenceData.buttons = [
+						{
+							label: "View settings",
+							url: href,
+						},
+					];
 					break;
 				}
 				case "discover": {
@@ -255,13 +267,13 @@ presence.on("UpdateData", async () => {
 					break;
 				}
 				case "calendar":
+					presenceData.details = "Calendar";
 					presenceData.buttons = [
 						{
 							label: "View calendar",
 							url: href,
 						},
 					];
-					presenceData.details = "Calendar";
 					break;
 				case "search":
 					presenceData.details = "Search";

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -113,11 +113,11 @@ presence.on("UpdateData", async () => {
 				}
 				case "addons": {
 					title = document.querySelector(
-						appVersion === AppVersion.V4 ? "[class='ng-scope selected']" : "div[class|='selectable-inputs-container'] > div:nth-child(2) > div"
+						appVersion === AppVersion.V4 ? "[class='ng-scope selected']" : "div[class|='addons-content'] > div[class|='selectable-inputs-container'] > div:nth-child(2) > div"
 					)?.textContent;
 
 					const type = document.querySelector(
-						appVersion === AppVersion.V4 ? "[class='ng-binding ng-scope selected']" : "div[class|='selectable-inputs-container'] > div:nth-child(3) > div"
+						appVersion === AppVersion.V4 ? "[class='ng-binding ng-scope selected']" : "div[class|='addons-content'] > div[class|='selectable-inputs-container'] > div:nth-child(3) > div"
 					)?.textContent;
 						
 					presenceData.state = type ?? "All";

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -205,11 +205,14 @@ presence.on("UpdateData", async () => {
 						
 					if (
 						(isPaused || (appVersion === AppVersion.V4 ? document.querySelector("#loading-logo").className.includes("flashing") : !!document.querySelector("div[class*='buffering-loader-container']")))
-					) 
+					) {
 						presenceData.smallImageKey = Assets.Pause;
-					 else 
+						presenceData.smallImageText = "Player is paused";
+					} else { 
 						presenceData.smallImageKey = Assets.Play;
-					
+						presenceData.smallImageText = "Player is playing";
+					}
+
 					let metaUrl: string;
 
 					if (appVersion === AppVersion.V4) {

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -216,7 +216,9 @@ presence.on("UpdateData", async () => {
 							const content = playerState.metaItem.content;
 							// eslint-disable-next-line prefer-destructuring
 							title = playerState.title;
-							metaUrl = `${window.location.origin}/#/detail/${content.type}/${content.id}/${playerState.libraryItem.state.video_id}`;
+							metaUrl = `${window.location.origin}/#/detail/${content.type}/${content.id}`;
+							if (content.type === "series")
+								metaUrl += `/${content.id}:${playerState.seriesInfo.season}:${playerState.seriesInfo.episode}`;
 							if (thumbnails) presenceData.largeImageKey = content?.logo ?? "logo";
 						}
 					}

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -142,7 +142,7 @@ presence.on("UpdateData", async () => {
 					presenceData.details = "Board";
 					presenceData.buttons = [
 						{
-							label: "View board",
+							label: "View Board",
 							url: href,
 						},
 					];
@@ -175,7 +175,7 @@ presence.on("UpdateData", async () => {
 					presenceData.details = `Viewing a ${hash.split("/")[2]}`;
 					presenceData.buttons = [
 						{
-							label: "View metadata",
+							label: "View Metadata",
 							url: href,
 						},
 					];
@@ -200,7 +200,7 @@ presence.on("UpdateData", async () => {
 					presenceData.state = type ?? "All";
 					presenceData.buttons = [
 						{
-							label: "Browse addons",
+							label: "Browse Addons",
 							url: href,
 						},
 					];
@@ -216,7 +216,7 @@ presence.on("UpdateData", async () => {
 					presenceData.details = `${section} settings`;
 					presenceData.buttons = [
 						{
-							label: "View settings",
+							label: "View Settings",
 							url: href,
 						},
 					];
@@ -270,7 +270,7 @@ presence.on("UpdateData", async () => {
 					presenceData.state = type ?? "All";
 					presenceData.buttons = [
 						{
-							label: "View library",
+							label: "View Library",
 							url: href,
 						},
 					];
@@ -280,7 +280,7 @@ presence.on("UpdateData", async () => {
 					presenceData.details = "Calendar";
 					presenceData.buttons = [
 						{
-							label: "View calendar",
+							label: "View Calendar",
 							url: href,
 						},
 					];

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -285,20 +285,22 @@ presence.on("UpdateData", async () => {
 					delete presenceData.startTimestamp;
 
 					if (
-						video.isPaused ||
 						(appVersion === AppVersion.V4
 							? document
 									.querySelector("#loading-logo")
 									.className.includes("flashing")
 							: !!document.querySelector(
 									"div[class*='buffering-loader-container']"
-							  ))
+							  )) ||
+						video.isPaused
 					) {
 						presenceData.smallImageKey = Assets.Pause;
 						presenceData.smallImageText = "Player is paused";
+						presenceData.state = "Paused";
 					} else {
 						presenceData.smallImageKey = Assets.Play;
 						presenceData.smallImageText = "Player is playing";
+						presenceData.state = "Watching";
 					}
 
 					let metaUrl: string, title: string;
@@ -332,7 +334,6 @@ presence.on("UpdateData", async () => {
 					}
 
 					presenceData.details = title ?? "Player";
-					presenceData.state = video.isPaused ? "Paused" : "Watching";
 					if (metaUrl) {
 						presenceData.buttons = [
 							{

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -235,11 +235,14 @@ presence.on("UpdateData", async () => {
 								? "ul.sort > li.selected"
 								: "div[class*='selectable-inputs-container'] > div:nth-child(2) > div"
 						)?.textContent,
-						genre = document.querySelector(
-							appVersion === AppVersion.V4
-								? "ul.genre-select > li.selected"
-								: "div[class*='selectable-inputs-container'] > div:nth-child(3) > div"
-						)?.textContent?.replace("Select genre", "") || null;
+						genre =
+							document
+								.querySelector(
+									appVersion === AppVersion.V4
+										? "ul.genre-select > li.selected"
+										: "div[class*='selectable-inputs-container'] > div:nth-child(3) > div"
+								)
+								?.textContent?.replace("Select genre", "") || null;
 
 					presenceData.buttons = [
 						{
@@ -250,7 +253,8 @@ presence.on("UpdateData", async () => {
 					presenceData.details = `Discovering ${type ?? "content"}${
 						type === "series" ? "" : "s"
 					}`;
-					presenceData.state = `${category}${genre ? ` | ${genre}` : ""}` ?? "All";
+					presenceData.state =
+						`${category}${genre ? ` | ${genre}` : ""}` ?? "All";
 
 					break;
 				}


### PR DESCRIPTION
## Description 
Add support for the new Stremio web (a.k.a Stremio 5) domain and add improvements to the old domain (Stremio 4) and website.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Context

I work closely with the Stremio team and community. We find it necessary for the Stremio presence to support the following features at minimum:
- Support Stremio 5, 4 and the website
- Due to the nature of some addons (e.g. adult content), showing search queries in Discord activities should be a setting (turned **off** by default)
- In case of Stremio 5, favor usage of [stremio core](https://github.com/Stremio/stremio-core) to fetch information when possible.

There's another PR https://github.com/PreMiD/Presences/pull/7457 opened a few days ago by @DarkVillager, which lacks some of the features above and implements a few things differently. I'll leave the choice up to you to either:
- Merge DarkVillager's PR first, then mine
- Close DarkVillager's PR and only merge mine

I had a conversation with DarkVillager and at the time we agreed the first option would be the nicest because neither of our contributions would be lost but ultimately it's whatever suits your review procedure best.

## Coverage
This presence now covers the following domains:

Stremio web version 5:
- https://web.strem.io
- https://web.stremio.com

Stremio web version 4:
- https://app.strem.io

Website:
- [www.stremio.com](https://www.stremio.com)
- https://stremio.com

## Presence settings
The presence settings are pretty much the same as before. The only new setting is `Show Search`:

<img width="373" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/4256d825-73d9-402a-89f3-440818bde0ba">

When enabled, any content you search in Stremio is also shown in the activity. This setting is disabled by default.

## Screenshots
### Stremio Web
Activities for version 5 and 4 look the same. I've added some screenshots for each section but it's actually very similar to the current presence, just different wording.

#### Board
<details>
<summary>Click to expand</summary>

<img width="409" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/66e282ac-7554-4857-af24-66815c5a1c6b">

<img width="1294" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/3b4722ba-d6f1-48cb-a9c3-a33a8ad03a17">

</details>

#### Details
<details>
<summary>Click to expand</summary>

`thumbnail: false`

<img width="405" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/5449b60b-e974-4b1e-bc86-ca7b42e47057">

`thumbnail: true`

<img width="409" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/16442483-aa4a-4324-8d54-4d631b805086">

<img width="1294" alt="2023_07_08_17_03_58" src="https://github.com/PreMiD/Presences/assets/30344294/6e707580-bea0-4d07-8eaf-e2d44669eef7">

</details>

#### Player
Clicking the 'watch' button redirects the user to the metadata page of the content that is currently playing. Opening the link directly is not possible because URLs easily go over discord's 512 characters limit. Besides that, redirecting to video streams is also prohibited according to the [PreMiD developer guildelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md#presencets).

<details>
<summary>Click to expand</summary>

**Movie/series:**

`thumbnail: false`

<img width="409" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/3d2adb5b-4e0c-4606-be99-3dc67431a6c2">

`thumbnail: true`

<img width="409" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/e011803d-ef7d-4fce-b02e-3ddb322cc91b">

**Channel:**

<img width="417" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/fa228e66-c380-45a8-a4a5-3cba667bc513">

<img width="1302" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/a0209294-8162-4c19-8a7f-9dee34c86030">

</details>

#### Addons
<details>
<summary>Click to expand</summary>

<img width="409" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/ead8768f-6c1b-4e47-8f9a-15be4d975667">

<img width="409" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/ec069612-2ee5-4e67-a8f4-73777c73a352">

<img width="1294" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/4cc4afa3-fbf2-4f37-99de-12d58aabc689">

</details>

#### Settings
<details>
<summary>Click to expand</summary>

<img width="409" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/3548d859-1195-483b-b78e-ba321129a5ac">

<img width="409" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/cc263915-5996-4074-983d-fa3f4fa1bd6c">

<img width="1294" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/3273a67c-00e6-4b6f-871f-2edb1310131a">

</details>

#### Discover
<details>
<summary>Click to expand</summary>

<img width="412" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/75e9b1f4-0f1c-4c1d-b6a5-317321a82af2">

<img width="412" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/c1ce1418-b021-4bda-a470-ae8313d41d46">

<img width="1294" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/7be1e06c-e140-4964-8b06-8c3a922cd471">

</details>

#### Library
<details>
<summary>Click to expand</summary>

<img width="409" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/ed0f3ea3-ac94-4ef8-9ca8-fec06613db96">

<img width="409" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/623a50cf-1258-4830-8eab-fcfbe226db66">

</details>

#### Calendar
<details>
<summary>Click to expand</summary>

<img width="409" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/0cfcb2cf-46b4-43e5-9c4e-fe04bc033e57">

</details>

#### Search
As mentioned above, search has become a setting and is turned **off** by default.

<details>
<summary>Click to expand</summary>

`search: false` 

(screenshot applies to v5 only, v4 doesn't have a dedicates search page)

<img width="409" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/eda6d0a2-b435-4d65-a8ec-7f4bae4499cc">

`search: true`:

<img width="409" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/199cbd0d-dceb-4481-8877-7ad70734a616">

<img width="1294" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/bff13cb2-a27a-490f-a2e0-32135ce61ca6">

</details>

### Website
Presence settings don't have an effect here, this activity is always visible in Discord when visiting the stremio website and optionally includes a `state` when visiting particular pages. 

<details>
<summary>Click to expand</summary>

<img width="405" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/7ba836c4-9d8f-4838-9cc8-e88fddc6eefa">

<img width="405" alt="image" src="https://github.com/PreMiD/Presences/assets/30344294/1780815e-c929-409e-b8a9-02800d351d51">

</details>

## Notes
A few more things I like to mention:

- There's plenty of commits and I'm not sure what counts as a breaking change. Maybe, when merging this PR, squash committing everything as a single feature so it becomes one entry in the changelog would be best?
- The Stremio presence could benefit from translations, but considering we haven't reached the [1000+ users requirement](https://docs.premid.app/en/dev/presence/metadata#adding-new-strings) yet it's only in English for now.
- This is my first presence contribution. I did my best to follow all guidelines but kindly let me know in case I missed something.  