### PR TITLE
fix(MyCanal): rechanged path for channel's img tag

### DIFF
--- a/websites/M/myCANAL/metadata.json
+++ b/websites/M/myCANAL/metadata.json
@@ -21,7 +21,7 @@
 		"nl": "Canal + is een Franse abonnementsaanbieder die is gekoppeld aan het kanaal met dezelfde naam. Het is eigendom van Vivendi met een aandeel van honderd procent."
 	},
 	"url": "www.canalplus.com",
-	"version": "2.0.8",
+	"version": "2.0.9",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/M/myCANAL/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/M/myCANAL/assets/thumbnail.png",
 	"color": "#000",

--- a/websites/M/myCANAL/presence.ts
+++ b/websites/M/myCANAL/presence.ts
@@ -53,15 +53,15 @@ presence.on("UpdateData", async () => {
 				).textContent;
 				presenceData.state = `sur ${
 					document.querySelector<HTMLImageElement>(
-						`#\\3${channelID}_toFocus > div[class*="cardLogoChannel"] > div > img`
-					).alt
+						`#\\3${channelID}_onclick > div > div.card__content_0dae1b.cardContent___DuNAN.ratio--169 > div[class*="cardLogoChannel"] > div > img`
+					)?.alt
 				}`;
 				[presenceData.startTimestamp, presenceData.endTimestamp] =
 					presence.getTimestamps(video.currentTime, video.duration);
 				presenceData.largeImageKey = showCover
 					? document.querySelector<HTMLImageElement>(
-							`#\\3${channelID}_toFocus > div[class*="cardLogoChannel"] > div > img`
-					  ).src
+							`#\\3${channelID}_onclick > div > div.card__content_0dae1b.cardContent___DuNAN.ratio--169 > div[class*="cardLogoChannel"] > div > img`
+					  )?.src
 					: Assets.Logo;
 				presenceData.smallImageKey = Assets.Live;
 				presenceData.smallImageText = "En direct";


### PR DESCRIPTION
## Description 
Changed the selector path for the img tag, as it was deprecated once again.

## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://github.com/PreMiD/Presences/assets/72155852/2ac3ea5a-14b1-4e6d-a383-d6087992cb45). 
![image](https://github.com/PreMiD/Presences/assets/72155852/9b2bf1e0-d73f-4a4f-8e23-55c0d9b59aa6)



</details>
