### PR TITLE
fix(bilibilitv): thumbnail and null property access error

### DIFF
--- a/websites/B/bilibilitv/metadata.json
+++ b/websites/B/bilibilitv/metadata.json
@@ -8,10 +8,6 @@
 		{
 			"name": "Faelayis",
 			"id": "328731868096888833"
-		},
-		{
-			"name": "elaxan",
-			"id": "506212044152897546"
 		}
 	],
 	"service": "bilibilitv",

--- a/websites/B/bilibilitv/metadata.json
+++ b/websites/B/bilibilitv/metadata.json
@@ -23,7 +23,7 @@
 		"www.bilibili.tv",
 		"studio.bilibili.tv"
 	],
-	"version": "2.0.8",
+	"version": "2.0.9",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/B/bilibilitv/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/B/bilibilitv/assets/thumbnail.png",
 	"color": "#2e62ff",

--- a/websites/B/bilibilitv/metadata.json
+++ b/websites/B/bilibilitv/metadata.json
@@ -8,6 +8,10 @@
 		{
 			"name": "Faelayis",
 			"id": "328731868096888833"
+		},
+		{
+			"name": "elaxan",
+			"id": "506212044152897546"
 		}
 	],
 	"service": "bilibilitv",

--- a/websites/B/bilibilitv/presence.ts
+++ b/websites/B/bilibilitv/presence.ts
@@ -45,8 +45,8 @@ presence.on("UpdateData", async () => {
 				?.getAttribute("poster")
 				?.split("@")[0] ||
 			document
-				.querySelector<HTMLMetaElement>('meta[name="og:image"]')
-				?.content?.split("@")[0];
+				.querySelector<HTMLMetaElement>('meta[property="og:image"]')
+				.content.split("?")[0];
 	if (oldLang !== newLang || !strings) {
 		oldLang = newLang;
 		strings = await getStrings();
@@ -68,7 +68,7 @@ presence.on("UpdateData", async () => {
 			case "play": {
 				presenceData.details = title;
 				presenceData.state = `${strings.episode} ${document
-					.querySelector(".ep-item__reference--active")
+					.querySelector("a.ep-item.ep-item--active")
 					.textContent?.replace(/\D/g, "")}`;
 				presenceData.buttons = [
 					{

--- a/websites/B/bilibilitv/presence.ts
+++ b/websites/B/bilibilitv/presence.ts
@@ -41,12 +41,9 @@ presence.on("UpdateData", async () => {
 		),
 		thumbnail =
 			document
-				.querySelector(".player-mobile-video-wrap > video")
-				?.getAttribute("poster")
-				?.split("@")[0] ||
-			document
 				.querySelector<HTMLMetaElement>('meta[property="og:image"]')
-				.content.split("?")[0];
+				?.content?.split("?")?.[0] ??
+			"https://cdn.rcd.gg/PreMiD/websites/B/bilibilitv/assets/logo.png";
 	if (oldLang !== newLang || !strings) {
 		oldLang = newLang;
 		strings = await getStrings();


### PR DESCRIPTION
## Description

1. The thumbnail was not being displayed correctly due to an incorrect parsing of the `og:image` property.
2. Resolved the "Cannot read properties of null" error that occurred when trying to access the `textContent` property of certain elements.

## Acknowledgements

- [ ] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [ ] I linted the code by running `yarn format`
- [ ] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots

<details>
<summary>Proof showing the creation/modification is working as expected</summary>
  <img src="https://github.com/PreMiD/Presences/assets/107149635/15cc73b7-5efa-4933-bfbc-f4a44ab40938" alt="Proof image">
</details>

