### PR TITLE
fix(Rádio Animu): add a fallback message

### DIFF
--- a/websites/R/Rádio Animu/metadata.json
+++ b/websites/R/Rádio Animu/metadata.json
@@ -21,7 +21,7 @@
 		"nl": "De meest moe radio in Brazilië"
 	},
 	"url": "www.animu.com.br",
-	"version": "1.2.26",
+	"version": "1.2.27",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/R/R%C3%A1dio%20Animu/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/R/R%C3%A1dio%20Animu/assets/thumbnail.png",
 	"color": "#2c004b",

--- a/websites/R/Rádio Animu/presence.ts
+++ b/websites/R/Rádio Animu/presence.ts
@@ -55,11 +55,14 @@ presence.on("UpdateData", async () => {
 	} else if (document.location.pathname.includes("/suafansingaqui/")) {
 		presenceData.details = "Sua Fansing Aqui";
 		presenceData.smallImageKey = Assets.Reading;
-	} else if (document.location.pathname === "/historia/") {
+	} else if (document.location.pathname.includes("/historia/")) {
 		presenceData.details = "História";
 		presenceData.smallImageKey = Assets.Reading;
 	} else if (document.location.pathname === "/") {
 		presenceData.details = "Página inicial";
+		presenceData.smallImageKey = Assets.Reading;
+	} else {
+		presenceData.details = "Algures por aqui...";
 		presenceData.smallImageKey = Assets.Reading;
 	}
 


### PR DESCRIPTION
## Description 
Added a fallback message for any part of the site that is unimplemented in the presence because of the existence of temporary event/easter egg(ish) pages that don't really need to be defined in the presence.
Before this commit, it would only show the default question block image with the name of the instance in these pages.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)
## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://github.com/PreMiD/Presences/assets/49950653/0d5e5572-13fe-4cef-880f-3aab24d73ebe)

![image](https://github.com/PreMiD/Presences/assets/49950653/4a8dfbb1-1e3d-4a67-a773-c71d8073dd2f)

</details>
