### PR TITLE
fix(Tidal): update songTitle selector to account for update

### DIFF
--- a/websites/T/Tidal/metadata.json
+++ b/websites/T/Tidal/metadata.json
@@ -22,7 +22,7 @@
 		"listen.tidal.com",
 		"tidal.com"
 	],
-	"version": "3.1.16",
+	"version": "3.1.17",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/T/Tidal/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/T/Tidal/assets/thumbnail.png",
 	"color": "#000000",

--- a/websites/T/Tidal/presence.ts
+++ b/websites/T/Tidal/presence.ts
@@ -34,7 +34,7 @@ presence.on("UpdateData", async () => {
 			largeImageKey: LOGO_URL,
 		},
 		songTitle = document.querySelector<HTMLAnchorElement>(
-			'div[data-test="footer-track-title"] > a'
+			".footerTrackTitleInformationContainer--w2bJS > a"
 		),
 		currentTime = document
 			.querySelector<HTMLElement>('time[data-test="current-time"]')


### PR DESCRIPTION
## Description 
Another update from Tidal that required changing the selectors.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
Before:

![grafik](https://github.com/PreMiD/Presences/assets/58221423/90b84b84-2b72-4230-ae20-4152d672e1e7)

After:

![grafik](https://github.com/PreMiD/Presences/assets/58221423/fb00475c-c61e-4518-af0a-58e3758be934)


</details>