### PR TITLE
fix(PresenceValidator): Correcting spelling mistake

### DIFF
--- a/tools/auto/presenceValidator.ts
+++ b/tools/auto/presenceValidator.ts
@@ -160,7 +160,7 @@ for (const presence of changedPresences) {
 		warnings.push({
 			presence,
 			message:
-				"Presence has metadata.iFrameRegExp set to '.*', pleaase change this if possible",
+				"Presence has metadata.iFrameRegExp set to '.*', please change this if possible",
 			properties: {
 				file: resolve(presencePath, "metadata.json"),
 				startLine: getLine("iFrameRegExp"),


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
This PR fixes a spelling mistake in the Presence Validator. It was introduced in [this commit](https://github.com/PreMiD/Presences/commit/28708c179bad7116d31d94fd8ebda8c38a1550e3) back in April.
![image](https://github.com/PreMiD/Presences/assets/88365935/59efe9b8-a16c-49c1-a6a5-a04606c09363)


## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
N/A



</details>
