### PR TITLE
Update presence.ts

### DIFF
--- a/websites/F/FMovies/metadata.json
+++ b/websites/F/FMovies/metadata.json
@@ -9,7 +9,7 @@
 		"en": "Watch online movies for free, watch movies free in high quality without registration.  Just a better place for watching online movies for free. Fmovies.to, FFmovies.is, FFmovies.to"
 	},
 	"url": "fmovies.to",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/F/FMovies/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/F/FMovies/assets/thumbnail.jpeg",
 	"color": "#1BB3C6",

--- a/websites/F/FMovies/presence.ts
+++ b/websites/F/FMovies/presence.ts
@@ -63,7 +63,7 @@ presence.on("UpdateData", async () => {
 			presence.getSetting<boolean>("image"),
 		]);
 
-		if (pathname.includes("/series/") || pathname.includes("/tv/")) {
+	if (pathname.includes("/series/") || pathname.includes("/tv/")) {
 			const matches = href.match(/\/(\d+-\d+)/);
 			if (matches) {
 				const [season, episode] = matches[1].split('-');

--- a/websites/F/FMovies/presence.ts
+++ b/websites/F/FMovies/presence.ts
@@ -63,24 +63,14 @@ presence.on("UpdateData", async () => {
 			presence.getSetting<boolean>("image"),
 		]);
 
-	if (pathname.includes("/series/") || pathname.includes("/tv/")) {
-		const season =
-				document
-					.querySelector(".watch[data-season]")
-					?.getAttribute("data-season") || null,
-			episode =
-				document.querySelector(".watch[data-ep]")?.getAttribute("data-ep") ||
-				null;
-
-		if (season !== null || episode !== null) {
-			presenceData.state =
-				episode && season
-					? `S${season}:E${episode}`
-					: episode && !season
-					? `Episode ${episode}`
-					: !episode && season
-					? `Season ${season}`
-					: "";
+		if (pathname.includes("/series/") || pathname.includes("/tv/")) {
+			const matches = href.match(/\/(\d+-\d+)/);
+			if (matches) {
+				const [season, episode] = matches[1].split('-');
+				presenceData.state = `S${season}:E${episode}`;
+			} else {
+				presenceData.state = "";
+			}
 		}
 		setCommonData(presenceData, document, iFrameData, href);
 	} else if (pathname.startsWith("/movie/"))


### PR DESCRIPTION
Rather than get the season and episode from the attributes, it is simpler to obtain it from the href. The season and episode are provided in this format: 1-1. Which makes it fail-proof every time as well as consistent when the episode is over and the next one begins.

## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
