### PR TITLE
fix(FMovies): Fix Season and Episode Bug

### DIFF
--- a/websites/F/FMovies/metadata.json
+++ b/websites/F/FMovies/metadata.json
@@ -9,7 +9,7 @@
 		"en": "Watch online movies for free, watch movies free in high quality without registration.  Just a better place for watching online movies for free. Fmovies.to, FFmovies.is, FFmovies.to"
 	},
 	"url": "fmovies.to",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/F/FMovies/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/F/FMovies/assets/thumbnail.jpeg",
 	"color": "#1BB3C6",

--- a/websites/F/FMovies/presence.ts
+++ b/websites/F/FMovies/presence.ts
@@ -64,23 +64,13 @@ presence.on("UpdateData", async () => {
 		]);
 
 	if (pathname.includes("/series/") || pathname.includes("/tv/")) {
-		const season =
-				document
-					.querySelector(".watch[data-season]")
-					?.getAttribute("data-season") || null,
-			episode =
-				document.querySelector(".watch[data-ep]")?.getAttribute("data-ep") ||
-				null;
+		const matches = href.match(/\/(\d+-\d+)/);
 
-		if (season !== null || episode !== null) {
-			presenceData.state =
-				episode && season
-					? `S${season}:E${episode}`
-					: episode && !season
-					? `Episode ${episode}`
-					: !episode && season
-					? `Season ${season}`
-					: "";
+		if (matches) {
+			const [season, episode] = matches[1].split("-");
+			presenceData.state = `S${season}:E${episode}`;
+		} else {
+			presenceData.state = "";
 		}
 		setCommonData(presenceData, document, iFrameData, href);
 	} else if (pathname.startsWith("/movie/"))

--- a/websites/F/FMovies/presence.ts
+++ b/websites/F/FMovies/presence.ts
@@ -69,9 +69,9 @@ presence.on("UpdateData", async () => {
 		if (matches) {
 			const [season, episode] = matches[1].split("-");
 			presenceData.state = `S${season}:E${episode}`;
-		} else {
+		} else 
 			presenceData.state = "";
-		}
+		
 		setCommonData(presenceData, document, iFrameData, href);
 	} else if (pathname.startsWith("/movie/"))
 		setCommonData(presenceData, document, iFrameData, href);

--- a/websites/F/FMovies/presence.ts
+++ b/websites/F/FMovies/presence.ts
@@ -69,9 +69,8 @@ presence.on("UpdateData", async () => {
 		if (matches) {
 			const [season, episode] = matches[1].split("-");
 			presenceData.state = `S${season}:E${episode}`;
-		} else 
-			presenceData.state = "";
-		
+		} else presenceData.state = "";
+
 		setCommonData(presenceData, document, iFrameData, href);
 	} else if (pathname.startsWith("/movie/"))
 		setCommonData(presenceData, document, iFrameData, href);


### PR DESCRIPTION
## Description 
Previous code did not dynamically update the season and episode. It would require a manual reload for changes to take place. With the current code, it dynamically obtains the season and episode from the URL, so the season and episode will always be up to date on the Discord Rich Presence.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
![image](https://github.com/PreMiD/Presences/assets/42215640/4f6b5bb3-450c-4ec1-a257-bea86cb0be2d)

