### PR TITLE
feat(KEXP): add presence

### DIFF
--- a/websites/K/KEXP/metadata.json
+++ b/websites/K/KEXP/metadata.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.9",
+	"author": {
+		"id": "408039555296395264",
+		"name": "indium."
+	},
+	"service": "KEXP",
+	"description": {
+		"en": "KEXP operates one of the world's most influential listener-supported music radio stations. Broadcasting on 90.3 KEXP-FM in Seattle, it also reaches audiences through its website and mobile apps.",
+		"es": "KEXP opera una de las estaciones de radio de música más influyentes en el mundo. Respaldada por los oyentes, transmite en 90.3 KEXP-FM en Seattle, además de a través de su sitio web y aplicaciones móviles."
+	},
+	"url": "kexp.org",
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/RBf6mDU.png",
+	"thumbnail": "https://i.imgur.com/GJT7mBf.png",
+	"color": "#fbab2c",
+	"category": "music",
+	"tags": [
+		"radio",
+		"music",
+		"kexp",
+		"seattle"
+	]
+}

--- a/websites/K/KEXP/presence.ts
+++ b/websites/K/KEXP/presence.ts
@@ -1,0 +1,48 @@
+const presence = new Presence({
+		clientId: "1138970637440917504",
+	}),
+	timeElapsed = Math.floor(Date.now() / 1000);
+
+presence.on("UpdateData", async () => {
+	const strings = await presence.getStrings({
+			play: "presence.playback.playing",
+			pause: "presence.playback.paused",
+		}),
+		playBackStatus = document.querySelector("button.Player-ctaButton"),
+		coverImage = document
+			.querySelector(".Player-coverImage")
+			?.getAttribute("src"),
+		presenceData: PresenceData = {
+			startTimestamp: timeElapsed,
+			largeImageKey: /^https:\/\//.test(coverImage)
+				? coverImage
+				: "https://i.imgur.com/RBf6mDU.png",
+			buttons: [
+				{
+					label: "Listen along!",
+					url: "https://kexp.org/listen/",
+				},
+			],
+			details: document.querySelector("a.Player-show")?.textContent,
+			state: document.querySelector("div.Player-title")?.textContent,
+		};
+
+	if (playBackStatus) {
+		switch (playBackStatus.ariaLabel) {
+			case "Play Stream": {
+				presenceData.smallImageKey = Assets.Pause;
+				presenceData.smallImageText = strings.pause;
+				break;
+			}
+			case "Pause Stream": {
+				presenceData.smallImageKey = Assets.Play;
+				presenceData.smallImageText = strings.play;
+				break;
+			}
+			default:
+				break;
+		}
+	}
+
+	presence.setActivity(presenceData);
+});


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

- Add presence for [KEXP](https://kexp.org/)
- The presence updates based on whether the radio is being listened to or not
- The presence image is taken from the cover of the currently playing song; if not available, it uses the station logo
- It includes a button to listen along simultaneously
- The presence description was taken from the [About KEXP](https://www.kexp.org/about/) page and translated to Spanish as it's my native language
- If there's no song playing, only the show name is showed

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes, thus speeding up the process of the pull request being merged
-->


![image](https://github.com/PreMiD/Presences/assets/86681635/50f9d28a-c7e2-4daa-a367-85a343000717)
![image](https://github.com/PreMiD/Presences/assets/86681635/b6090b05-637e-46a4-8e98-94ee1133f12f)
![image](https://github.com/PreMiD/Presences/assets/86681635/9696caf5-d010-443a-a750-58ea6e150453)
![image](https://github.com/PreMiD/Presences/assets/86681635/734d917f-34b2-4d04-8d41-0d9f4b79fa8b)
![image](https://github.com/PreMiD/Presences/assets/86681635/8958c630-08b9-4783-b0c9-d500a990e2bd)

</details>
