### PR TITLE
fix(Tidal): update selector

### DIFF
--- a/websites/T/Tidal/metadata.json
+++ b/websites/T/Tidal/metadata.json
@@ -22,7 +22,7 @@
 		"listen.tidal.com",
 		"tidal.com"
 	],
-	"version": "3.1.17",
+	"version": "3.1.18",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/T/Tidal/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/T/Tidal/assets/thumbnail.png",
 	"color": "#000000",

--- a/websites/T/Tidal/presence.ts
+++ b/websites/T/Tidal/presence.ts
@@ -34,7 +34,7 @@ presence.on("UpdateData", async () => {
 			largeImageKey: LOGO_URL,
 		},
 		songTitle = document.querySelector<HTMLAnchorElement>(
-			".footerTrackTitleInformationContainer--w2bJS > a"
+			"[data-test='footer-track-title'] > div > a"
 		),
 		currentTime = document
 			.querySelector<HTMLElement>('time[data-test="current-time"]')


### PR DESCRIPTION
## Description 
Another update from Tidal that changed specificallly the song title selector, we're now using the attribute instead of a random class which should lead to more persitent functionality.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![grafik](https://github.com/PreMiD/Presences/assets/58221423/82b7c8da-5535-4deb-bc6a-e924cdd5362f)

</details>
