### PR TITLE
feat(Mastodon): add social.vivaldi.net as a supported url

### DIFF
--- a/websites/M/Mastodon/metadata.json
+++ b/websites/M/Mastodon/metadata.json
@@ -20,9 +20,10 @@
 		"infosec.exchange",
 		"aus.social",
 		"social.network.europa.eu",
-		"masto.ai"
+		"masto.ai",
+		"social.vivaldi.net"
 	],
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/M/Mastodon/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/M/Mastodon/assets/thumbnail.png",
 	"color": "#6364ff",


### PR DESCRIPTION
## Description 
I added social.vivaldi.net as a supported url

Resolves #7558

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)





</details>
