### PR TITLE
feat(Tetra Legends): add presence

### DIFF
--- a/websites/T/Tetra Legends/metadata.json
+++ b/websites/T/Tetra Legends/metadata.json
@@ -1,0 +1,22 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.7",
+	"author": {
+		"id": "300707889717444608",
+		"name": "dxl44"
+	},
+	"service": "Tetra Legends",
+	"description": {
+		"en": "A browser-based clone of Tetris with both new and classic gamemodes."
+	},
+	"url": "tetralegends.app",
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/9c3lJCA.png",
+	"thumbnail": "https://i.imgur.com/Su9t23q.png",
+	"color": "#000000",
+	"category": "games",
+	"tags": [
+		"game",
+		"gaming",
+		"puzzle"
+	]
+}

--- a/websites/T/Tetra Legends/metadata.json
+++ b/websites/T/Tetra Legends/metadata.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.premid.app/metadata/1.7",
+	"$schema": "https://schemas.premid.app/metadata/1.9",
 	"author": {
 		"id": "300707889717444608",
 		"name": "dxl44"

--- a/websites/T/Tetra Legends/presence.ts
+++ b/websites/T/Tetra Legends/presence.ts
@@ -12,10 +12,11 @@ presence.on("UpdateData", async () => {
 
 	if (document.querySelector("#game-container").classList[0] === "hidden")
 		presenceData.details = "In Menus";
-	else {
+	else if (document.querySelector("header.header")) {
 		presenceData.details = `Mode: ${
 			document.querySelector("header.header").innerHTML
 		}`;
-	}
+	} else presenceData.details = "Mode: Marathon";
+
 	presence.setActivity(presenceData);
 });

--- a/websites/T/Tetra Legends/presence.ts
+++ b/websites/T/Tetra Legends/presence.ts
@@ -1,0 +1,21 @@
+const presence = new Presence({
+		clientId: "1145899076760637460",
+	}),
+	gameTime = Math.floor(Date.now() / 1000);
+
+
+presence.on("UpdateData", async () => {
+	const presenceData: PresenceData = {
+		largeImageKey:
+				"https://i.imgur.com/UV7X7U4.jpg",
+		details: "In Menus",
+		startTimestamp: gameTime,
+	};
+
+	if (document.querySelector("#game-container").classList[0] === "hidden") { // 
+		presenceData.details = "In Menus";
+	} else 
+		presenceData.details = `Mode: ${document.querySelector("header.header").innerHTML}`;
+
+	presence.setActivity(presenceData);
+});

--- a/websites/T/Tetra Legends/presence.ts
+++ b/websites/T/Tetra Legends/presence.ts
@@ -3,19 +3,19 @@ const presence = new Presence({
 	}),
 	gameTime = Math.floor(Date.now() / 1000);
 
-
 presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
-		largeImageKey:
-				"https://i.imgur.com/UV7X7U4.jpg",
+		largeImageKey: "https://i.imgur.com/UV7X7U4.jpg",
 		details: "In Menus",
 		startTimestamp: gameTime,
 	};
 
-	if (document.querySelector("#game-container").classList[0] === "hidden") { // 
+	if (document.querySelector("#game-container").classList[0] === "hidden")
 		presenceData.details = "In Menus";
-	} else 
-		presenceData.details = `Mode: ${document.querySelector("header.header").innerHTML}`;
-
+	else {
+		presenceData.details = `Mode: ${
+			document.querySelector("header.header").innerHTML
+		}`;
+	}
 	presence.setActivity(presenceData);
 });


### PR DESCRIPTION
## Description 
Adds presence for [Tetra Legends](https://tetralegends.app/), a single player browser-based Tetris clone. Displays the current mode you're playing or if you're in the menus, as well as your total play time.
## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<a href="https://imgur.com/9GCk8Wt"><img src="https://i.imgur.com/9GCk8Wtl.png" title="source: imgur.com" /></a>
<a href="https://imgur.com/1Fjb6LJ"><img src="https://i.imgur.com/1Fjb6LJl.png" title="source: imgur.com" /></a>
<a href="https://imgur.com/Up4P738"><img src="https://i.imgur.com/Up4P738l.png" title="source: imgur.com" /></a>
</details>
