### PR TITLE
fix(discord.js): url didnt support old docs

### DIFF
--- a/websites/D/Discord.js/metadata.json
+++ b/websites/D/Discord.js/metadata.json
@@ -11,6 +11,7 @@
 		"nl": "Discord.js is een krachtige node.js module die je toelaat om zeer eenvoudig te interageren met de Discord API."
 	},
 	"url": "discord.js.org",
+	"regExp": "([a-z0-9-]+[.])*(discord[.]js.org|old[.]discordjs.dev)[/]",
 	"version": "1.2.19",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/D/Discord.js/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/D/Discord.js/assets/thumbnail.png",

--- a/websites/D/Discord.js/metadata.json
+++ b/websites/D/Discord.js/metadata.json
@@ -12,7 +12,7 @@
 	},
 	"url": "discord.js.org",
 	"regExp": "([a-z0-9-]+[.])*(discord[.]js.org|old[.]discordjs.dev)[/]",
-	"version": "1.2.19",
+	"version": "1.2.20",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/D/Discord.js/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/D/Discord.js/assets/thumbnail.png",
 	"color": "#8dd6f1",

--- a/websites/D/Discord.js/presence.ts
+++ b/websites/D/Discord.js/presence.ts
@@ -1,82 +1,83 @@
 const presence = new Presence({
-    clientId: "639659455126044672"
-  }),
-  browsingStamp = Math.floor(Date.now() / 1000);
+		clientId: "639659455126044672",
+	}),
+	browsingStamp = Math.floor(Date.now() / 1000);
 
 presence.on("UpdateData", () => {
-  const data: PresenceData = {
-      largeImageKey: "https://cdn.rcd.gg/PreMiD/websites/D/Discord.js/assets/logo.png",
-      startTimestamp: browsingStamp
-  }
-  let route = document.location.pathname.split("/");
-  switch (document.location.hostname) {
-    case "discord.js.org": {
-      if (route[1] === "docs") {
-        data.smallImageKey = data.largeImageKey;
-        data.smallImageText = `${route[3].replace(/^[a-z]/i, (c) =>
-          c.toUpperCase()
-        )} - ${Number(route[4][0]) ? `v${route[4]}` : `${route[4]}`}`;
-        if (route.length === 5) {
-          data.details = `Viewing:`;
-          data.state = `${route[3].replace(/^[a-z]/i, (c) =>
-          c.toUpperCase()
-        )} About`;
-        } else {
-          data.details = `Looking for a ${route[5].split(':')[1]}:`;
-          data.state = `${route[5].split(':')[0]}`;
-        }
-      }
-    
-    break;
-  }
-    case "old.discordjs.dev": {
-    route = document.location.hash.split("/");
-    if (route.length === 1 || route[1] === "")
-        data.details = "Browsing the main page...";
-      else if (route[1] === "docs") {
-        [, , data.smallImageKey] = route;
-        data.smallImageText = `a${data.smallImageKey}a`
-      
-        if (route[4].startsWith("search?q=")) {
-          data.details = "Searching for:";
-          data.state = route[4].slice(9);
-        } else if (route[4] === "general") {
-          data.details = "Viewing:";
-          data.state =
-            route[5] === "faq"
-              ? route[5].toUpperCase()
-              : `${route[5].replace(/^[a-z]/i, (c) => c.toUpperCase())}`;
-        } else {
-          data.details = `Looking for a${
-            (route[5].split("?scrollTo=")[1] &&
-              route[5].split("?scrollTo=")[1].startsWith("e-")) ||
-            route[4] === "examples"
-              ? "n"
-              : ""
-          } ${
-            route[5].split("?scrollTo=")[1] &&
-            route[5].split("?scrollTo=")[1].startsWith("e-")
-              ? "event"
-              : `${
-                  route[4].endsWith("s") && route[4] !== "class"
-                    ? route[4].substring(0, route[4].length - 1)
-                    : route[4].replace(/^[a-z]/i, (c) => c.toUpperCase())
-                }`
-          }`;
-          data.state = `${route[5].split("?scrollTo=")[0]}${
-            route[5].split("?scrollTo=")[1]
-              ? `#${
-                  route[5].split("?scrollTo=")[1][1] === "-"
-                    ? route[5].split("?scrollTo=")[1].slice(2)
-                    : route[5].split("?scrollTo=")[1]
-                }`
-              : ""
-          }`;
-        }
-      }
-      break;
-    }
-  }
+	const data: PresenceData = {
+		largeImageKey:
+			"https://cdn.rcd.gg/PreMiD/websites/D/Discord.js/assets/logo.png",
+		startTimestamp: browsingStamp,
+	};
+	let route = document.location.pathname.split("/");
+	switch (document.location.hostname) {
+		case "discord.js.org": {
+			if (route[1] === "docs") {
+				data.smallImageKey = data.largeImageKey;
+				data.smallImageText = `${route[3].replace(/^[a-z]/i, c =>
+					c.toUpperCase()
+				)} - ${Number(route[4][0]) ? `v${route[4]}` : `${route[4]}`}`;
+				if (route.length === 5) {
+					data.details = `Viewing:`;
+					data.state = `${route[3].replace(/^[a-z]/i, c =>
+						c.toUpperCase()
+					)} About`;
+				} else {
+					data.details = `Looking for a ${route[5].split(":")[1]}:`;
+					data.state = `${route[5].split(":")[0]}`;
+				}
+			}
 
-  presence.setActivity(data);
+			break;
+		}
+		case "old.discordjs.dev": {
+			route = document.location.hash.split("/");
+			if (route.length === 1 || route[1] === "")
+				data.details = "Browsing the main page...";
+			else if (route[1] === "docs") {
+				[, , data.smallImageKey] = route;
+				data.smallImageText = `a${data.smallImageKey}a`;
+
+				if (route[4].startsWith("search?q=")) {
+					data.details = "Searching for:";
+					data.state = route[4].slice(9);
+				} else if (route[4] === "general") {
+					data.details = "Viewing:";
+					data.state =
+						route[5] === "faq"
+							? route[5].toUpperCase()
+							: `${route[5].replace(/^[a-z]/i, c => c.toUpperCase())}`;
+				} else {
+					data.details = `Looking for a${
+						(route[5].split("?scrollTo=")[1] &&
+							route[5].split("?scrollTo=")[1].startsWith("e-")) ||
+						route[4] === "examples"
+							? "n"
+							: ""
+					} ${
+						route[5].split("?scrollTo=")[1] &&
+						route[5].split("?scrollTo=")[1].startsWith("e-")
+							? "event"
+							: `${
+									route[4].endsWith("s") && route[4] !== "class"
+										? route[4].substring(0, route[4].length - 1)
+										: route[4].replace(/^[a-z]/i, c => c.toUpperCase())
+							  }`
+					}`;
+					data.state = `${route[5].split("?scrollTo=")[0]}${
+						route[5].split("?scrollTo=")[1]
+							? `#${
+									route[5].split("?scrollTo=")[1][1] === "-"
+										? route[5].split("?scrollTo=")[1].slice(2)
+										: route[5].split("?scrollTo=")[1]
+							  }`
+							: ""
+					}`;
+				}
+			}
+			break;
+		}
+	}
+
+	presence.setActivity(data);
 });

--- a/websites/D/Discord.js/presence.ts
+++ b/websites/D/Discord.js/presence.ts
@@ -35,9 +35,6 @@ presence.on("UpdateData", () => {
         data.details = "Browsing the main page...";
       else if (route[1] === "docs") {
         [, , data.smallImageKey] = route;
-        // data.smallImageText = `${route[2].replace(/^[a-z]/i, (c) =>
-        //   c.toUpperCase()
-        // )} - ${Number(route[3][0]) ? `v${route[3]}` : `${route[3]}`}`;
         data.smallImageText = `a${data.smallImageKey}a`
       
         if (route[4].startsWith("search?q=")) {

--- a/websites/D/Discord.js/presence.ts
+++ b/websites/D/Discord.js/presence.ts
@@ -8,7 +8,7 @@ presence.on("UpdateData", () => {
       largeImageKey: "https://cdn.rcd.gg/PreMiD/websites/D/Discord.js/assets/logo.png",
       startTimestamp: browsingStamp
   }
-  var route = document.location.pathname.split("/");
+  let route = document.location.pathname.split("/");
   switch (document.location.hostname) {
     case "discord.js.org": {
       if (route[1] === "docs") {

--- a/websites/D/Discord.js/presence.ts
+++ b/websites/D/Discord.js/presence.ts
@@ -7,51 +7,77 @@ presence.on("UpdateData", () => {
   const data: PresenceData = {
       largeImageKey: "https://cdn.rcd.gg/PreMiD/websites/D/Discord.js/assets/logo.png",
       startTimestamp: browsingStamp
-    },
+  }
+  var route = document.location.pathname.split("/");
+  switch (document.location.hostname) {
+    case "discord.js.org": {
+      if (route[1] === "docs") {
+        data.smallImageKey = data.largeImageKey;
+        data.smallImageText = `${route[3].replace(/^[a-z]/i, (c) =>
+          c.toUpperCase()
+        )} - ${Number(route[4][0]) ? `v${route[4]}` : `${route[4]}`}`;
+        if (route.length === 5) {
+          data.details = `Viewing:`;
+          data.state = `${route[3].replace(/^[a-z]/i, (c) =>
+          c.toUpperCase()
+        )} About`;
+        } else {
+          data.details = `Looking for a ${route[5].split(':')[1]}:`;
+          data.state = `${route[5].split(':')[0]}`;
+        }
+      }
+    
+    break;
+  }
+    case "old.discordjs.dev": {
     route = document.location.hash.split("/");
-  if (route.length === 1 || route[1] === "")
-    data.details = "Browsing the main page...";
-  else if (route[1] === "docs") {
-    [, , data.smallImageKey] = route;
-    data.smallImageText = `${route[2].replace(/^[a-z]/i, (c) =>
-      c.toUpperCase()
-    )} - ${Number(route[3][0]) ? `v${route[3]}` : `${route[3]}`}`;
-
-    if (route[4].startsWith("search?q=")) {
-      data.details = "Searching for:";
-      data.state = route[4].slice(9);
-    } else if (route[4] === "general") {
-      data.details = "Viewing:";
-      data.state =
-        route[5] === "faq"
-          ? route[5].toUpperCase()
-          : `${route[5].replace(/^[a-z]/i, (c) => c.toUpperCase())}`;
-    } else {
-      data.details = `Looking for a${
-        (route[5].split("?scrollTo=")[1] &&
-          route[5].split("?scrollTo=")[1].startsWith("e-")) ||
-        route[4] === "examples"
-          ? "n"
-          : ""
-      } ${
-        route[5].split("?scrollTo=")[1] &&
-        route[5].split("?scrollTo=")[1].startsWith("e-")
-          ? "event"
-          : `${
-              route[4].endsWith("s") && route[4] !== "class"
-                ? route[4].substring(0, route[4].length - 1)
-                : route[4].replace(/^[a-z]/i, (c) => c.toUpperCase())
-            }`
-      }`;
-      data.state = `${route[5].split("?scrollTo=")[0]}${
-        route[5].split("?scrollTo=")[1]
-          ? `#${
-              route[5].split("?scrollTo=")[1][1] === "-"
-                ? route[5].split("?scrollTo=")[1].slice(2)
-                : route[5].split("?scrollTo=")[1]
-            }`
-          : ""
-      }`;
+    if (route.length === 1 || route[1] === "")
+        data.details = "Browsing the main page...";
+      else if (route[1] === "docs") {
+        [, , data.smallImageKey] = route;
+        // data.smallImageText = `${route[2].replace(/^[a-z]/i, (c) =>
+        //   c.toUpperCase()
+        // )} - ${Number(route[3][0]) ? `v${route[3]}` : `${route[3]}`}`;
+        data.smallImageText = `a${data.smallImageKey}a`
+      
+        if (route[4].startsWith("search?q=")) {
+          data.details = "Searching for:";
+          data.state = route[4].slice(9);
+        } else if (route[4] === "general") {
+          data.details = "Viewing:";
+          data.state =
+            route[5] === "faq"
+              ? route[5].toUpperCase()
+              : `${route[5].replace(/^[a-z]/i, (c) => c.toUpperCase())}`;
+        } else {
+          data.details = `Looking for a${
+            (route[5].split("?scrollTo=")[1] &&
+              route[5].split("?scrollTo=")[1].startsWith("e-")) ||
+            route[4] === "examples"
+              ? "n"
+              : ""
+          } ${
+            route[5].split("?scrollTo=")[1] &&
+            route[5].split("?scrollTo=")[1].startsWith("e-")
+              ? "event"
+              : `${
+                  route[4].endsWith("s") && route[4] !== "class"
+                    ? route[4].substring(0, route[4].length - 1)
+                    : route[4].replace(/^[a-z]/i, (c) => c.toUpperCase())
+                }`
+          }`;
+          data.state = `${route[5].split("?scrollTo=")[0]}${
+            route[5].split("?scrollTo=")[1]
+              ? `#${
+                  route[5].split("?scrollTo=")[1][1] === "-"
+                    ? route[5].split("?scrollTo=")[1].slice(2)
+                    : route[5].split("?scrollTo=")[1]
+                }`
+              : ""
+          }`;
+        }
+      }
+      break;
     }
   }
 

--- a/websites/D/Discord.js/presence.ts
+++ b/websites/D/Discord.js/presence.ts
@@ -18,7 +18,7 @@ presence.on("UpdateData", () => {
 					c.toUpperCase()
 				)} - ${Number(route[4][0]) ? `v${route[4]}` : `${route[4]}`}`;
 				if (route.length === 5) {
-					data.details = `Viewing:`;
+					data.details = "Viewing:";
 					data.state = `${route[3].replace(/^[a-z]/i, c =>
 						c.toUpperCase()
 					)} About`;


### PR DESCRIPTION
## Description 
Discord.js docs have moved to old.discordjs.dev while then remake the docs. I have added regex that supports the old docs url and the current docs url
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
