### PR TITLE
fix(ITVX): fix videos presence due to data structure change

### DIFF
--- a/websites/I/ITVX/metadata.json
+++ b/websites/I/ITVX/metadata.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.premid.app/metadata/1.7",
+	"$schema": "https://schemas.premid.app/metadata/1.9",
 	"author": {
 		"name": "dAn",
 		"id": "169516316124905473"
@@ -13,9 +13,9 @@
 		"www.itv.com",
 		"itv.com"
 	],
-	"version": "1.0.5",
-	"logo": "https://i.imgur.com/xUkE69G.png",
-	"thumbnail": "https://i.imgur.com/jqV7iTp.jpg",
+	"version": "1.0.9",
+	"logo": "https://cdn.rcd.gg/PreMiD/websites/I/ITVX/assets/logo.png",
+	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/I/ITVX/assets/thumbnail.jpg",
 	"color": "#102C3D",
 	"category": "videos",
 	"tags": [

--- a/websites/I/ITVX/metadata.json
+++ b/websites/I/ITVX/metadata.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.premid.app/metadata/1.9",
+	"$schema": "https://schemas.premid.app/metadata/1.7",
 	"author": {
 		"name": "dAn",
 		"id": "169516316124905473"
@@ -13,9 +13,9 @@
 		"www.itv.com",
 		"itv.com"
 	],
-	"version": "1.0.8",
-	"logo": "https://cdn.rcd.gg/PreMiD/websites/I/ITVX/assets/logo.png",
-	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/I/ITVX/assets/thumbnail.jpg",
+	"version": "1.0.5",
+	"logo": "https://i.imgur.com/xUkE69G.png",
+	"thumbnail": "https://i.imgur.com/jqV7iTp.jpg",
 	"color": "#102C3D",
 	"category": "videos",
 	"tags": [

--- a/websites/I/ITVX/presence.ts
+++ b/websites/I/ITVX/presence.ts
@@ -39,19 +39,21 @@ interface CategoriesNextData {
 interface ProgrammeNextData {
 	props: {
 		pageProps: {
-			title: {
-				CTAText?: string;
-				episodeNumber?: number;
-				programmeTitle: string;
-				seriesNumber?: number;
-				titleType: string;
+			programme: {
+				heroCtaLabel?: string;
+				title: string;
+			},
+			episode: {
+				productionType: string,
+				episode: number,
+				series: number
 			};
 		};
 	};
 }
 
 const enum Assets {
-	Logo = "https://cdn.rcd.gg/PreMiD/websites/I/ITVX/assets/logo.png",
+	Logo = "https://i.imgur.com/xUkE69G.png",
 }
 
 const presence = new Presence({
@@ -144,13 +146,13 @@ presence.on("UpdateData", async () => {
 					delete presenceData.startTimestamp;
 
 					const nextData = fetchNextData<ProgrammeNextData>();
-					presenceData.details = `Watching ${nextData.props.pageProps.title.programmeTitle}`;
+					presenceData.details = `Watching ${nextData.props.pageProps.programme.title}`;
 
 					if (
-						nextData.props.pageProps.title.CTAText &&
-						nextData.props.pageProps.title.titleType !== "FILM"
+						nextData.props.pageProps.programme.heroCtaLabel &&
+						nextData.props.pageProps.episode.productionType !== "FILM"
 					)
-						presenceData.state = nextData.props.pageProps.title.CTAText;
+						presenceData.state = nextData.props.pageProps.programme.heroCtaLabel;
 
 					const [video] = document.querySelectorAll("video");
 

--- a/websites/I/ITVX/presence.ts
+++ b/websites/I/ITVX/presence.ts
@@ -42,11 +42,11 @@ interface ProgrammeNextData {
 			programme: {
 				heroCtaLabel?: string;
 				title: string;
-			},
+			};
 			episode: {
-				productionType: string,
-				episode: number,
-				series: number
+				productionType: string;
+				episode: number;
+				series: number;
 			};
 		};
 	};
@@ -151,8 +151,10 @@ presence.on("UpdateData", async () => {
 					if (
 						nextData.props.pageProps.programme.heroCtaLabel &&
 						nextData.props.pageProps.episode.productionType !== "FILM"
-					)
-						presenceData.state = nextData.props.pageProps.programme.heroCtaLabel;
+					) {
+						presenceData.state =
+							nextData.props.pageProps.programme.heroCtaLabel;
+					}
 
 					const [video] = document.querySelectorAll("video");
 

--- a/websites/I/ITVX/presence.ts
+++ b/websites/I/ITVX/presence.ts
@@ -53,7 +53,7 @@ interface ProgrammeNextData {
 }
 
 const enum Assets {
-	Logo = "https://i.imgur.com/xUkE69G.png",
+	Logo = "https://cdn.rcd.gg/PreMiD/websites/I/ITVX/assets/logo.png",
 }
 
 const presence = new Presence({


### PR DESCRIPTION
## Description 
ITVX has slightly changed the structure of the NEXT_DATA page props, and as a result broke the ability to correctly display the presence when watching videos.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
![image](https://github.com/PreMiD/Presences/assets/30360284/4223f5fd-c0bd-4d7e-838d-6a6beeaff6b9)
