### PR TITLE
chore: fix util.getDiff('removed')

### DIFF
--- a/tools/util.ts
+++ b/tools/util.ts
@@ -26,9 +26,14 @@ export function getDiff(
 		)
 			.toString()
 			.split("\n")
-			.filter(file =>
-				["presence.ts", "iframe.ts", "metadata.json"].includes(basename(file))
-			);
+			.filter(file => {
+				if (type === "removed") return "metadata.json" === basename(file);
+				else {
+					return ["presence.ts", "iframe.ts", "metadata.json"].includes(
+						basename(file)
+					);
+				}
+			});
 
 	if (!changedPresenceFolders.length) return [];
 


### PR DESCRIPTION
## Description 
When checking for `deleted` only check if they are metadata files. Not tested but should work 
