### PR TITLE
fix(Reaper Scans): update query selector for reading percentage

### DIFF
--- a/websites/R/Reaper Scans/metadata.json
+++ b/websites/R/Reaper Scans/metadata.json
@@ -15,7 +15,7 @@
 		"en": "Read Comics and Novels on Reaper Scans."
 	},
 	"url": "reaperscans.com",
-	"version": "1.1.6",
+	"version": "1.2.0",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/R/Reaper%20Scans/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/R/Reaper%20Scans/assets/thumbnail.jpg",
 	"color": "#6E3CAA",

--- a/websites/R/Reaper Scans/presence.ts
+++ b/websites/R/Reaper Scans/presence.ts
@@ -41,7 +41,7 @@ presence.on("UpdateData", () => {
 						(document.documentElement.scrollTop /
 							(document.querySelector(
 								pathSplit[0] === "comics"
-									? "main > div:nth-of-type(2)"
+									? "main"
 									: "article"
 							).scrollHeight -
 								window.innerHeight)) *

--- a/websites/R/Reaper Scans/presence.ts
+++ b/websites/R/Reaper Scans/presence.ts
@@ -40,9 +40,7 @@ presence.on("UpdateData", () => {
 					let progress =
 						(document.documentElement.scrollTop /
 							(document.querySelector(
-								pathSplit[0] === "comics"
-									? "main"
-									: "article"
+								pathSplit[0] === "comics" ? "main" : "article"
 							).scrollHeight -
 								window.innerHeight)) *
 						100;


### PR DESCRIPTION
## Description 
Updates the query selectors for the percentage. This fixes the errors in the console when reading a comic.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/PreMiD/Presences/assets/32113157/40f53b24-f5e8-4aa2-983f-9ccaa9132c9d)


</details>
