### PR TITLE
fix(VtuberWiki): fixed typo and missing images

### DIFF
--- a/websites/V/VtuberWiki/metadata.json
+++ b/websites/V/VtuberWiki/metadata.json
@@ -9,7 +9,7 @@
 		"en": "Search or browse in depth information about Vtubers or software related to Vtubers"
 	},
 	"url": "vtubers.wiki",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/V/VtuberWiki/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/V/VtuberWiki/assets/thumbnail.jpg",
 	"color": "#43B581",

--- a/websites/V/VtuberWiki/presence.ts
+++ b/websites/V/VtuberWiki/presence.ts
@@ -53,16 +53,16 @@ presence.on("UpdateData", async () => {
 			switch (pathSplit[1]) {
 				case "vtubers":
 					if (pathSplit[2]) {
-						presenceData.largeImageKey = `https://vtubers.wiki/${document.querySelector<HTMLImageElement>("#vtuber-image")?.getAttribute("src")}`;
+						presenceData.largeImageKey = `https://vtubers.wiki/${document
+							.querySelector<HTMLImageElement>("#vtuber-image")
+							?.getAttribute("src")}`;
 						presenceData.details = "Viewing a Vtuber";
 						presenceData.state = `${pageTitle} • ${
 							document.querySelector("#vtuber-desc")?.textContent
 						}`;
 						presenceData.smallImageKey = Assets.Logo;
 						presenceData.smallImageText = "Vtuber Wiki";
-						presenceData.buttons = [
-							{ label: `View ${pageTitle}`, url: href },
-						];
+						presenceData.buttons = [{ label: `View ${pageTitle}`, url: href }];
 					} else presenceData.details = "Viewing All The Vtubers";
 
 					break;

--- a/websites/V/VtuberWiki/presence.ts
+++ b/websites/V/VtuberWiki/presence.ts
@@ -53,13 +53,15 @@ presence.on("UpdateData", async () => {
 			switch (pathSplit[1]) {
 				case "vtubers":
 					if (pathSplit[2]) {
-						presenceData.largeImageKey = `https://www.vtubers.wiki/vtubers/${pathSplit[2]}/photo.jpg`;
-						presenceData.details = "Viewing a Vuber";
+						presenceData.largeImageKey = `https://vtubers.wiki/${document.querySelector<HTMLImageElement>("#vtuber-image")?.getAttribute("src")}`;
+						presenceData.details = "Viewing a Vtuber";
 						presenceData.state = `${pageTitle} • ${
 							document.querySelector("#vtuber-desc")?.textContent
 						}`;
+						presenceData.smallImageKey = Assets.Logo;
+						presenceData.smallImageText = "Vtuber Wiki";
 						presenceData.buttons = [
-							{ label: `View ${pathSplit[2]}`, url: href },
+							{ label: `View ${pageTitle}`, url: href },
 						];
 					} else presenceData.details = "Viewing All The Vtubers";
 
@@ -67,6 +69,8 @@ presence.on("UpdateData", async () => {
 				case "software":
 					if (pathSplit[2]) {
 						presenceData.largeImageKey = Assets.Cog;
+						presenceData.smallImageKey = Assets.Logo;
+						presenceData.smallImageText = "Vtuber Wiki";
 						presenceData.details = "Viewing Software";
 						presenceData.state = `${pageTitle}`;
 						presenceData.buttons = [{ label: `View ${pageTitle}`, url: href }];


### PR DESCRIPTION
## Description 

Fixed typo Vuber -> Vtuber and fixed images from being broken.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://github.com/PreMiD/Presences/assets/93791569/382a7637-3565-4bf0-974a-964d7fe2b910)


</details>
