### PR TITLE
feat(YouTube): refactor and update selectors

### DIFF
--- a/websites/Y/YouTube/metadata.json
+++ b/websites/Y/YouTube/metadata.json
@@ -12,6 +12,10 @@
 		{
 			"name": "DooMLorD",
 			"id": "465105167751315471"
+		},
+		{
+			"name": "theusaf",
+			"id": "193714715631812608"
 		}
 	],
 	"service": "YouTube",
@@ -67,7 +71,7 @@
 		"www.youtube.com",
 		"studio.youtube.com"
 	],
-	"version": "5.5.0",
+	"version": "5.6.0",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/thumbnail.jpg",
 	"color": "#E40813",

--- a/websites/Y/YouTube/presence.ts
+++ b/websites/Y/YouTube/presence.ts
@@ -87,7 +87,7 @@ const nullResolver: Resolver = {
 	isActive: () => true,
 	getTitle: () => document.title,
 	getUploader: () => "",
-}
+};
 
 let strings: Awaited<ReturnType<typeof getStrings>>,
 	oldLang: string = null;

--- a/websites/Y/YouTube/presence.ts
+++ b/websites/Y/YouTube/presence.ts
@@ -7,7 +7,7 @@ import youtubeEmbedResolver from "./video_sources/embed";
 import youtubeMoviesResolver from "./video_sources/movies";
 import youtubeTVResolver from "./video_sources/tv";
 import youtubeResolver from "./video_sources/default";
-import { adjustTimeError } from "./util";
+import { Resolver, adjustTimeError } from "./util";
 
 const presence = new Presence({
 		clientId: "463097721130188830",
@@ -83,6 +83,12 @@ async function getStrings() {
 	);
 }
 
+const nullResolver: Resolver = {
+	isActive: () => true,
+	getTitle: () => document.title,
+	getUploader: () => "",
+}
+
 let strings: Awaited<ReturnType<typeof getStrings>>,
 	oldLang: string = null;
 
@@ -127,6 +133,7 @@ presence.on("UpdateData", async () => {
 			youtubeTVResolver,
 			youtubeResolver,
 			youtubeMoviesResolver,
+			nullResolver,
 		].find(resolver => resolver.isActive());
 
 		if (resolver === youtubeShortsResolver)

--- a/websites/Y/YouTube/util.ts
+++ b/websites/Y/YouTube/util.ts
@@ -1,0 +1,9 @@
+export function truncateAfter(str: string, pattern: string): string {
+	return str.slice(0, str.indexOf(pattern));
+}
+
+export interface Resolver {
+  isActive(): boolean;
+  getTitle(): string;
+  getUploader(): string;
+}

--- a/websites/Y/YouTube/util.ts
+++ b/websites/Y/YouTube/util.ts
@@ -1,9 +1,6 @@
 let cachedTime = 0;
 export function adjustTimeError(time: number, acceptableError: number): number {
-	const diff = Math.abs(time - cachedTime);
-	if (diff > acceptableError) {
-		cachedTime = time;
-	}
+	if (Math.abs(time - cachedTime) > acceptableError) cachedTime = time;
 	return cachedTime;
 }
 

--- a/websites/Y/YouTube/util.ts
+++ b/websites/Y/YouTube/util.ts
@@ -1,9 +1,18 @@
+let cachedTime = 0;
+export function adjustTimeError(time: number, acceptableError: number): number {
+	const diff = Math.abs(time - cachedTime);
+	if (diff > acceptableError) {
+		cachedTime = time;
+	}
+	return cachedTime;
+}
+
 export function truncateAfter(str: string, pattern: string): string {
 	return str.slice(0, str.indexOf(pattern));
 }
 
 export interface Resolver {
-  isActive(): boolean;
-  getTitle(): string;
-  getUploader(): string;
+	isActive(): boolean;
+	getTitle(): string;
+	getUploader(): string;
 }

--- a/websites/Y/YouTube/video_sources/default.ts
+++ b/websites/Y/YouTube/video_sources/default.ts
@@ -4,7 +4,7 @@ function isActive(): boolean {
 	return !!getTitle() && !!getUploader();
 }
 
-function getTitle() {
+function getTitle(): string {
 	if (document.location.pathname.includes("/watch")) {
 		return document
 			.querySelector("h1 yt-formatted-string.ytd-video-primary-info-renderer")
@@ -13,7 +13,7 @@ function getTitle() {
 		return document.querySelector(".ytd-miniplayer .title")?.textContent.trim();
 }
 
-function getUploader() {
+function getUploader(): string {
 	return (
 		document
 			.querySelector("ytd-video-owner-renderer .ytd-channel-name a")

--- a/websites/Y/YouTube/video_sources/default.ts
+++ b/websites/Y/YouTube/video_sources/default.ts
@@ -18,7 +18,7 @@ function getUploader() {
 	return (
 		document
 			.querySelector("ytd-video-owner-renderer .ytd-channel-name a")
-			.textContent.trim() ||
+			?.textContent.trim() ||
 		document.querySelector("yt-formatted-string#owner-name")?.textContent.trim()
 	);
 }

--- a/websites/Y/YouTube/video_sources/default.ts
+++ b/websites/Y/YouTube/video_sources/default.ts
@@ -9,9 +9,8 @@ function getTitle() {
 		return document
 			.querySelector("h1 yt-formatted-string.ytd-video-primary-info-renderer")
 			?.textContent.trim();
-	} else {
+	} else
 		return document.querySelector(".ytd-miniplayer .title")?.textContent.trim();
-	}
 }
 
 function getUploader() {

--- a/websites/Y/YouTube/video_sources/default.ts
+++ b/websites/Y/YouTube/video_sources/default.ts
@@ -1,7 +1,7 @@
 import { Resolver } from "../util";
 
 function isActive(): boolean {
-	return !!getTitle();
+	return !!getTitle() && !!getUploader();
 }
 
 function getTitle() {

--- a/websites/Y/YouTube/video_sources/default.ts
+++ b/websites/Y/YouTube/video_sources/default.ts
@@ -1,0 +1,32 @@
+import { Resolver } from "../util";
+
+function isActive(): boolean {
+	return !!getTitle();
+}
+
+function getTitle() {
+	if (document.location.pathname.includes("/watch")) {
+		return document
+			.querySelector("h1 yt-formatted-string.ytd-video-primary-info-renderer")
+			?.textContent.trim();
+	} else {
+		return document.querySelector(".ytd-miniplayer .title")?.textContent.trim();
+	}
+}
+
+function getUploader() {
+	return (
+		document
+			.querySelector("ytd-video-owner-renderer .ytd-channel-name a")
+			.textContent.trim() ||
+		document.querySelector("yt-formatted-string#owner-name")?.textContent.trim()
+	);
+}
+
+const resolver: Resolver = {
+	isActive,
+	getTitle,
+	getUploader,
+};
+
+export default resolver;

--- a/websites/Y/YouTube/video_sources/embed.ts
+++ b/websites/Y/YouTube/video_sources/embed.ts
@@ -1,10 +1,10 @@
 import { Resolver } from "../util";
 
-function isActive() {
+function isActive(): boolean {
 	return document.location.pathname.includes("/embed");
 }
 
-function getTitle() {
+function getTitle(): string {
 	return document
 		.querySelector('[class="reel-video-in-sequence style-scope ytd-shorts"]')
 		?.querySelector(
@@ -13,7 +13,7 @@ function getTitle() {
 		?.textContent.trim();
 }
 
-function getUploader() {
+function getUploader(): string {
 	return document
 		.querySelector("div.ytp-title-expanded-heading > h2 > a")
 		?.textContent.trim();

--- a/websites/Y/YouTube/video_sources/embed.ts
+++ b/websites/Y/YouTube/video_sources/embed.ts
@@ -1,0 +1,28 @@
+import { Resolver } from "../util";
+
+function isActive() {
+	return document.location.pathname.includes("/embed");
+}
+
+function getTitle() {
+	return document
+		.querySelector('[class="reel-video-in-sequence style-scope ytd-shorts"]')
+		?.querySelector(
+			'[class="title style-scope ytd-reel-player-header-renderer"]'
+		)
+		?.textContent.trim();
+}
+
+function getUploader() {
+	return document
+		.querySelector("div.ytp-title-expanded-heading > h2 > a")
+		?.textContent.trim();
+}
+
+const resolver: Resolver = {
+	isActive,
+	getTitle,
+	getUploader,
+};
+
+export default resolver;

--- a/websites/Y/YouTube/video_sources/movies.ts
+++ b/websites/Y/YouTube/video_sources/movies.ts
@@ -4,7 +4,7 @@ function isActive(): boolean {
 	return true;
 }
 
-function getTitle() {
+function getTitle(): string {
 	return (
 		document
 			.querySelector(".title.style-scope.ytd-video-primary-info-renderer")
@@ -13,7 +13,7 @@ function getTitle() {
 	);
 }
 
-function getUploader() {
+function getUploader(): string {
 	return document
 		.querySelector(".style-scope.ytd-channel-name > a")
 		?.textContent.trim();

--- a/websites/Y/YouTube/video_sources/movies.ts
+++ b/websites/Y/YouTube/video_sources/movies.ts
@@ -1,0 +1,31 @@
+import { Resolver } from "../util";
+
+function isActive(): boolean {
+	return true;
+}
+
+function getTitle() {
+	return document
+		.querySelector(".title.style-scope.ytd-video-primary-info-renderer")
+		?.textContent.trim();
+}
+
+function getUploader() {
+	return (
+		document
+			.querySelector(".style-scope.ytd-channel-name > a")
+			?.textContent.trim() ||
+		document
+			.querySelector(".style-scope.ytd-channel-name > a")
+			?.textContent.trim() ||
+		document.querySelector("div.ytp-title-text > a")?.textContent
+	);
+}
+
+const resolver: Resolver = {
+	isActive,
+	getTitle,
+	getUploader,
+};
+
+export default resolver;

--- a/websites/Y/YouTube/video_sources/movies.ts
+++ b/websites/Y/YouTube/video_sources/movies.ts
@@ -5,21 +5,18 @@ function isActive(): boolean {
 }
 
 function getTitle() {
-	return document
-		.querySelector(".title.style-scope.ytd-video-primary-info-renderer")
-		?.textContent.trim();
+	return (
+		document
+			.querySelector(".title.style-scope.ytd-video-primary-info-renderer")
+			?.textContent.trim() ||
+		document.querySelector("div.ytp-title-text > a")?.textContent.trim()
+	);
 }
 
 function getUploader() {
-	return (
-		document
-			.querySelector(".style-scope.ytd-channel-name > a")
-			?.textContent.trim() ||
-		document
-			.querySelector(".style-scope.ytd-channel-name > a")
-			?.textContent.trim() ||
-		document.querySelector("div.ytp-title-text > a")?.textContent
-	);
+	return document
+		.querySelector(".style-scope.ytd-channel-name > a")
+		?.textContent.trim();
 }
 
 const resolver: Resolver = {

--- a/websites/Y/YouTube/video_sources/movies.ts
+++ b/websites/Y/YouTube/video_sources/movies.ts
@@ -1,7 +1,7 @@
 import { Resolver } from "../util";
 
 function isActive(): boolean {
-	return true;
+	return !!getTitle() && !!getUploader();
 }
 
 function getTitle(): string {

--- a/websites/Y/YouTube/video_sources/old.ts
+++ b/websites/Y/YouTube/video_sources/old.ts
@@ -7,11 +7,11 @@ function isActive(): boolean {
 	);
 }
 
-function getTitle() {
+function getTitle(): string {
 	return document.querySelector(".watch-title")?.textContent.trim();
 }
 
-function getUploader() {
+function getUploader(): string {
 	return document.querySelector("#owner-name a")?.textContent.trim();
 }
 

--- a/websites/Y/YouTube/video_sources/old.ts
+++ b/websites/Y/YouTube/video_sources/old.ts
@@ -1,0 +1,24 @@
+import { Resolver } from "../util";
+
+function isActive(): boolean {
+	return (
+		!!document.querySelector(".watch-title") &&
+		document.location.pathname.includes("/watch")
+	);
+}
+
+function getTitle() {
+	return document.querySelector(".watch-title")?.textContent.trim();
+}
+
+function getUploader() {
+	return document.querySelector("#owner-name a")?.textContent.trim();
+}
+
+const resolver: Resolver = {
+	isActive,
+	getTitle,
+	getUploader,
+};
+
+export default resolver;

--- a/websites/Y/YouTube/video_sources/shorts.ts
+++ b/websites/Y/YouTube/video_sources/shorts.ts
@@ -1,7 +1,7 @@
 import { Resolver } from "../util";
 
 function isActive(): boolean {
-	return !!document.location.pathname.includes("/shorts/");
+	return document.location.pathname.includes("/shorts/");
 }
 
 function getTitle(): string {
@@ -48,7 +48,7 @@ export async function cacheShortData(hostname: string, shortsPath: string) {
 	} else return cached;
 }
 export function getCache() {
-  return cached;
+	return cached;
 }
 
 const resolver: Resolver = {

--- a/websites/Y/YouTube/video_sources/shorts.ts
+++ b/websites/Y/YouTube/video_sources/shorts.ts
@@ -1,0 +1,60 @@
+import { Resolver } from "../util";
+
+function isActive(): boolean {
+	return !!document.location.pathname.includes("/shorts/");
+}
+
+function getTitle(): string {
+	return document
+		.querySelector('[class="ytp-title-link yt-uix-sessionlink"]')
+		?.textContent.trim();
+}
+
+function getUploader() {
+	return cached?.uploader;
+}
+
+function delay(ms: number) {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+let cached: { id: string; uploader: string; channelURL: string };
+export async function cacheShortData(hostname: string, shortsPath: string) {
+	if (!cached?.id || cached.id !== shortsPath) {
+		await delay(300);
+		const closest =
+			document
+				.querySelector("video")
+				?.closest("ytd-reel-video-renderer")
+				?.querySelector(
+					"yt-formatted-string#text.style-scope.ytd-channel-name"
+				) ??
+			document
+				.querySelectorAll("video")[1]
+				?.closest("ytd-reel-video-renderer")
+				?.querySelector(
+					"yt-formatted-string#text.style-scope.ytd-channel-name"
+				);
+		cached = {
+			id: shortsPath,
+			uploader: `${closest
+				.querySelector("a")
+				?.getAttribute("href")
+				?.replace("/", "")
+				?.replace("@", "")} (${closest?.textContent})`,
+			channelURL: `https://${hostname}/${closest?.textContent}`,
+		};
+		return cached;
+	} else return cached;
+}
+export function getCache() {
+  return cached;
+}
+
+const resolver: Resolver = {
+	isActive,
+	getTitle,
+	getUploader,
+};
+
+export default resolver;

--- a/websites/Y/YouTube/video_sources/shorts.ts
+++ b/websites/Y/YouTube/video_sources/shorts.ts
@@ -10,11 +10,11 @@ function getTitle(): string {
 		?.textContent.trim();
 }
 
-function getUploader() {
+function getUploader(): string {
 	return cached?.uploader;
 }
 
-function delay(ms: number) {
+function delay(ms: number): Promise<void> {
 	return new Promise(resolve => setTimeout(resolve, ms));
 }
 

--- a/websites/Y/YouTube/video_sources/shorts.ts
+++ b/websites/Y/YouTube/video_sources/shorts.ts
@@ -18,8 +18,17 @@ function delay(ms: number): Promise<void> {
 	return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-let cached: { id: string; uploader: string; channelURL: string };
-export async function cacheShortData(hostname: string, shortsPath: string) {
+interface Cache {
+	id: string;
+	uploader: string;
+	channelURL: string;
+}
+
+let cached: Cache;
+export async function cacheShortData(
+	hostname: string,
+	shortsPath: string
+): Promise<Cache> {
 	if (!cached?.id || cached.id !== shortsPath) {
 		await delay(300);
 		const closest =
@@ -47,7 +56,7 @@ export async function cacheShortData(hostname: string, shortsPath: string) {
 		return cached;
 	} else return cached;
 }
-export function getCache() {
+export function getCache(): Cache {
 	return cached;
 }
 

--- a/websites/Y/YouTube/video_sources/shorts.ts
+++ b/websites/Y/YouTube/video_sources/shorts.ts
@@ -38,7 +38,7 @@ export async function cacheShortData(hostname: string, shortsPath: string) {
 		cached = {
 			id: shortsPath,
 			uploader: `${closest
-				.querySelector("a")
+				?.querySelector("a")
 				?.getAttribute("href")
 				?.replace("/", "")
 				?.replace("@", "")} (${closest?.textContent})`,

--- a/websites/Y/YouTube/video_sources/tv.ts
+++ b/websites/Y/YouTube/video_sources/tv.ts
@@ -4,18 +4,15 @@ function isActive(): boolean {
 	return !!document.querySelector(".player-video-title");
 }
 
-function getTitle() {
+function getTitle(): string {
 	return document.querySelector(".player-video-title")?.textContent.trim();
 }
 
-const YOUTUBE_TV_SEPERATOR = "•";
-function getUploader() {
+function getUploader(): string {
 	let title = document
 		.querySelector(".player-video-details")
 		?.textContent.trim();
-	if (title) {
-		title = truncateAfter(title, YOUTUBE_TV_SEPERATOR);
-	}
+	if (title) title = truncateAfter(title, "•");
 	return title;
 }
 

--- a/websites/Y/YouTube/video_sources/tv.ts
+++ b/websites/Y/YouTube/video_sources/tv.ts
@@ -1,0 +1,28 @@
+import { Resolver, truncateAfter } from "../util";
+
+function isActive(): boolean {
+	return !!document.querySelector(".player-video-title");
+}
+
+function getTitle() {
+	return document.querySelector(".player-video-title")?.textContent.trim();
+}
+
+const YOUTUBE_TV_SEPERATOR = "•";
+function getUploader() {
+	let title = document
+		.querySelector(".player-video-details")
+		?.textContent.trim();
+	if (title) {
+		title = truncateAfter(title, YOUTUBE_TV_SEPERATOR);
+	}
+	return title;
+}
+
+const resolver: Resolver = {
+	isActive,
+	getTitle,
+	getUploader,
+};
+
+export default resolver;


### PR DESCRIPTION
## Description 
* Refactors the code
  * Removes lots of duplication of code
  * Uses `switch(true)` to replace long if-else chains
  * Moves various title/uploader queries into separate files/methods
  * Removes unneeded typing and other inconsistencies
* Fixes
  * Viewing a playlist now works
  * Potentially resolves viewing a video again?
* Notes/Observations
  * The old YouTube code may not be needed (new YouTube layout seems to be forced now?), but keeping it just in case.
  * Unsure if there is a difference between YouTube movies and videos in terms of query selectors

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![2023-10-25 22_37_58](https://github.com/PreMiD/Presences/assets/32113157/a284a460-49fc-4d6b-b005-42fd078727c1)

![2023-10-25 22_36_41](https://github.com/PreMiD/Presences/assets/32113157/5750142d-ef6f-4f5e-9cc3-5da5feb70c5c)

</details>
