### PR TITLE
feat(atomicradio): fix presence and added space names

### DIFF
--- a/websites/A/atomicradio/metadata.json
+++ b/websites/A/atomicradio/metadata.json
@@ -9,7 +9,7 @@
 		"en": "The future of radio is here. Experience 12 Spaces with non-stop music you'll love."
 	},
 	"url": "atomic.radio",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/atomicradio/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/atomicradio/assets/thumbnail.jpg",
 	"color": "#a9f923",

--- a/websites/A/atomicradio/presence.ts
+++ b/websites/A/atomicradio/presence.ts
@@ -14,7 +14,6 @@ presence.on("UpdateData", () => {
 		{ pathname } = document.location;
 
 	if (player) {
-		const spaceId = player.querySelector("#spaceId").textContent;
 		presenceData.largeImageKey = player.querySelector("#artwork").textContent;
 		presenceData.smallImageKey =
 			player.querySelector<HTMLButtonElement>('[id*="-button"]').id ===
@@ -28,9 +27,15 @@ presence.on("UpdateData", () => {
 		presenceData.endTimestamp = new Date(
 			player.querySelector("#endingAt").textContent
 		).getTime();
-		presenceData.smallImageText = spaceId.toUpperCase();
+		presenceData.smallImageText =
+			player.querySelector("div.track-space").textContent;
 		presenceData.buttons = [
-			{ label: "Listen", url: `https://atomic.radio/${spaceId}` },
+			{
+				label: "Listen",
+				url: `https://atomic.radio/${
+					player.querySelector("#spaceId").textContent
+				}`,
+			},
 		];
 	} else {
 		presenceData.details = "Browsing...";

--- a/websites/A/atomicradio/presence.ts
+++ b/websites/A/atomicradio/presence.ts
@@ -19,8 +19,8 @@ presence.on("UpdateData", () => {
 		presenceData.smallImageKey =
 			player.querySelector<HTMLButtonElement>('[id*="-button"]').id ===
 			"play-button"
-				? Assets.Pause
-				: Assets.Play;
+				? Assets.Play
+				: Assets.Pause;
 		presenceData.details =
 			player.querySelector<HTMLAnchorElement>("div.track-title").textContent;
 		presenceData.state =

--- a/websites/A/atomicradio/presence.ts
+++ b/websites/A/atomicradio/presence.ts
@@ -10,8 +10,7 @@ presence.on("UpdateData", () => {
 			smallImageKey: Assets.Search,
 			startTimestamp: browsingTimestamp,
 		},
-		player = document.querySelector<HTMLDivElement>("div.player"),
-		{ pathname } = document.location;
+		player = document.querySelector<HTMLDivElement>("div.player");
 
 	if (player) {
 		presenceData.largeImageKey = player.querySelector("#artwork").textContent;
@@ -37,27 +36,7 @@ presence.on("UpdateData", () => {
 				}`,
 			},
 		];
-	} else {
-		presenceData.details = "Browsing...";
-		if (pathname.includes("/statistics"))
-			presenceData.details = "Viewing statistics";
-		else if (pathname.includes("/streams"))
-			presenceData.details = "Viewing stream urls";
-		else if (pathname.includes("/about"))
-			presenceData.details = "Viewing about us";
-		else if (pathname.includes("/apply"))
-			presenceData.details = "Viewing apply";
-		else if (pathname.includes("/contributors"))
-			presenceData.details = "Viewing contributors";
-		else if (pathname.includes("/partners"))
-			presenceData.details = "Viewing partners";
-		else if (pathname.includes("/legal/imprint"))
-			presenceData.details = "Viewing imprint";
-		else if (pathname.includes("/legal/privacy"))
-			presenceData.details = "Viewing privacy";
-		else if (pathname.includes("/account"))
-			presenceData.details = "Viewing account";
-	}
+	} else presenceData.details = "Browsing...";
 
 	if (presenceData.details) presence.setActivity(presenceData);
 	else presence.setActivity();

--- a/websites/A/atomicradio/presence.ts
+++ b/websites/A/atomicradio/presence.ts
@@ -22,7 +22,7 @@ presence.on("UpdateData", () => {
 				? Assets.Pause
 				: Assets.Play;
 		presenceData.details =
-			player.querySelector<HTMLAnchorElement>("a.track-title").textContent;
+			player.querySelector<HTMLAnchorElement>("div.track-title").textContent;
 		presenceData.state =
 			player.querySelector<HTMLDivElement>("div.track-artist").textContent;
 		presenceData.endTimestamp = new Date(


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
A query selector for the title has been adapted as the presence no longer worked. The play / pause icons were set incorrectly so I have now corrected this. The user is no longer shown the Space Ids but the actual Space name.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img src="https://github.com/PreMiD/Presences/assets/20924469/533ec4dd-96a9-4394-b762-efce833ed8b4" />



</details>
