### PR TITLE
feat(draw.io): add presence

### DIFF
--- a/websites/D/draw.io/metadata.json
+++ b/websites/D/draw.io/metadata.json
@@ -1,0 +1,43 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.9",
+	"author": {
+		"id": "348083986989449216",
+		"name": "hopperelec"
+	},
+	"service": "draw.io",
+	"description": {
+		"en": "draw.io or diagrams.net is a configurable diagramming/whiteboarding visualization application"
+	},
+	"url": "app.diagrams.net",
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/1hI3nKp.png",
+	"thumbnail": "https://i.imgur.com/B9pvFdj.png",
+	"color": "#d89000",
+	"category": "other",
+	"tags": [
+		"drawio",
+		"diagramsnet",
+		"draw-io",
+		"diagrams-net",
+		"draw",
+		"chart",
+		"diagrams",
+		"diagramming",
+		"whiteboard",
+		"whiteboarding",
+		"white-board",
+		"white-boarding",
+		"flowchart",
+		"flowcharts",
+		"flow-chart",
+		"flow-charts"
+	],
+	"settings": [
+		{
+			"id": "privacy",
+			"title": "Privacy Mode",
+			"icon": "fad fa-user-secret",
+			"value": false
+		}
+	]
+}

--- a/websites/D/draw.io/presence.ts
+++ b/websites/D/draw.io/presence.ts
@@ -12,7 +12,7 @@ presence.on("UpdateData", async () => {
 	else {
 		presenceData.details = "Editing a diagram";
 		if (!(await presence.getSetting<boolean>("privacy")))
-			presenceData.state = document.title.replace(" - draw.io$", "");
+			presenceData.state = document.title.replace(/ - draw.io$/, "");
 	}
 	presence.setActivity(presenceData);
 });

--- a/websites/D/draw.io/presence.ts
+++ b/websites/D/draw.io/presence.ts
@@ -1,0 +1,18 @@
+const presence = new Presence({
+	clientId: "1175537518746279956",
+});
+
+presence.on("UpdateData", async () => {
+	const presenceData: PresenceData = {
+		largeImageKey: "https://i.imgur.com/1hI3nKp.png",
+		startTimestamp: Date.now(),
+	};
+	if (document.title === "draw.io")
+		presenceData.details = "Creating a new diagram";
+	else {
+		presenceData.details = "Editing a diagram";
+		if (!(await presence.getSetting<boolean>("privacy")))
+			presenceData.state = document.title.replace(" - draw.io$", "");
+	}
+	presence.setActivity(presenceData);
+});


### PR DESCRIPTION
## Description 
Add presence for draw.io (AKA diagrams.net)

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://github.com/PreMiD/Presences/assets/52380674/a051c004-16a0-4689-8561-38019f393321)
![image](https://github.com/PreMiD/Presences/assets/52380674/bf105ec8-f20f-40cd-a960-be351f2c7fd6)
![image](https://github.com/PreMiD/Presences/assets/52380674/1f1cd5b5-a810-48e8-8b76-fbc0f3ec1eef)

</details>
