### PR TITLE
perf(YouTube): add fallback to settings retrieval

### DIFF
--- a/websites/Y/YouTube/metadata.json
+++ b/websites/Y/YouTube/metadata.json
@@ -71,7 +71,7 @@
 		"www.youtube.com",
 		"studio.youtube.com"
 	],
-	"version": "5.6.0",
+	"version": "5.7.0",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/thumbnail.jpg",
 	"color": "#E40813",

--- a/websites/Y/YouTube/presence.ts
+++ b/websites/Y/YouTube/presence.ts
@@ -7,12 +7,16 @@ import youtubeEmbedResolver from "./video_sources/embed";
 import youtubeMoviesResolver from "./video_sources/movies";
 import youtubeTVResolver from "./video_sources/tv";
 import youtubeResolver from "./video_sources/default";
-import { Resolver, adjustTimeError } from "./util";
+import {
+	Resolver,
+	adjustTimeError,
+	presence,
+	strings,
+	getSetting,
+	checkStringLanguage,
+} from "./util";
 
-const presence = new Presence({
-		clientId: "463097721130188830",
-	}),
-	browsingTimestamp = Math.floor(Date.now() / 1000);
+const browsingTimestamp = Math.floor(Date.now() / 1000);
 
 enum YouTubeAssets {
 	Logo = "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/logo.png",
@@ -26,71 +30,11 @@ enum LogoMode {
 	Channel = 2,
 }
 
-async function getStrings() {
-	return presence.getStrings(
-		{
-			play: "general.playing",
-			pause: "general.paused",
-			live: "general.live",
-			ad: "youtube.ad",
-			search: "general.searchFor",
-			browsingTypeVideos: "youtube.browsingTypeVideos",
-			browseShorts: "youtube.browsingShorts",
-			browsingVid: "youtube.browsingVideos",
-			browsingPlayl: "youtube.browsingPlaylists",
-			viewCPost: "youtube.viewingCommunityPost",
-			ofChannel: "youtube.ofChannel",
-			readChannel: "youtube.readingChannel",
-			searchChannel: "youtube.searchChannel",
-			trending: "youtube.trending",
-			browsingThrough: "youtube.browsingThrough",
-			subscriptions: "youtube.subscriptions",
-			library: "youtube.library",
-			history: "youtube.history",
-			purchases: "youtube.purchases",
-			reports: "youtube.reportHistory",
-			upload: "youtube.upload",
-			viewChannel: "general.viewChannel",
-			viewAllPlayL: "youtube.viewAllPlaylist",
-			viewEvent: "youtube.viewLiveEvents",
-			viewLiveDash: "youtube.viewLiveDashboard",
-			viewAudio: "youtube.viewAudioLibrary",
-			studioVid: "youtube.studio.viewContent",
-			studioEdit: "youtube.studio.editVideo",
-			studioAnaly: "youtube.studio.videoAnalytics",
-			studioComments: "youtube.studio.videoComments",
-			studioTranslate: "youtube.studio.videoTranslations",
-			studioTheir: "youtube.studio.viewTheir",
-			studioCAnaly: "youtube.studio.channelAnalytics",
-			studioCComments: "youtube.studio.channelComments",
-			studioCTranslate: "youtube.studio.channelTranslations",
-			studioArtist: "youtube.studio.artistPage",
-			studioDash: "youtube.studio.dashboard",
-			viewPlaylist: "general.viewPlaylist",
-			readAbout: "general.readingAbout",
-			viewAccount: "general.viewAccount",
-			viewHome: "general.viewHome",
-			watchVid: "general.watchingVid",
-			watchLive: "general.watchingLive",
-			browsing: "general.browsing",
-			searchSomething: "general.searchSomething",
-			watchStreamButton: "general.buttonWatchStream",
-			watchVideoButton: "general.buttonWatchVideo",
-			viewChannelButton: "general.buttonViewChannel",
-			videos: "youtube.videos",
-		},
-		await presence.getSetting<string>("lang").catch(() => "en")
-	);
-}
-
 const nullResolver: Resolver = {
 	isActive: () => true,
 	getTitle: () => document.title,
 	getUploader: () => "",
 };
-
-let strings: Awaited<ReturnType<typeof getStrings>>,
-	oldLang: string = null;
 
 presence.on("UpdateData", async () => {
 	const [
@@ -102,23 +46,20 @@ presence.on("UpdateData", async () => {
 			channelPic,
 			logo,
 			buttons,
-		] = await Promise.all([
-			presence.getSetting<string>("lang").catch(() => "en"),
-			presence.getSetting<boolean>("privacy"),
-			presence.getSetting<boolean>("time"),
-			presence.getSetting<string>("vidDetail"),
-			presence.getSetting<string>("vidState"),
-			presence.getSetting<boolean>("channelPic"),
-			presence.getSetting<number>("logo"),
-			presence.getSetting<boolean>("buttons"),
-		]),
+		] = [
+			getSetting<string>("lang", "en"),
+			getSetting<boolean>("privacy", true),
+			getSetting<boolean>("time", true),
+			getSetting<string>("vidDetail", "%title%"),
+			getSetting<string>("vidState", "%uploader%"),
+			getSetting<boolean>("channelPic", false),
+			getSetting<number>("logo", 0),
+			getSetting<boolean>("buttons", true),
+		],
 		{ pathname, hostname, search, href } = document.location;
 
 	// Update strings if user selected another language.
-	if (oldLang !== newLang || !strings) {
-		oldLang = newLang;
-		strings = await getStrings();
-	}
+	if (!checkStringLanguage(newLang)) return;
 
 	// If there is a vid playing
 	const video = Array.from(

--- a/websites/Y/YouTube/util.ts
+++ b/websites/Y/YouTube/util.ts
@@ -108,7 +108,7 @@ fetchStrings();
 /**
  * Sets the current language to fetch strings for and returns whether any strings are loaded.
  */
-export function checkStringLanguage(lang: string) {
+export function checkStringLanguage(lang: string): boolean {
 	currentTargetLang = lang;
 	return !!strings;
 }

--- a/websites/Y/YouTube/util.ts
+++ b/websites/Y/YouTube/util.ts
@@ -1,3 +1,7 @@
+export const presence = new Presence({
+	clientId: "463097721130188830",
+});
+
 let cachedTime = 0;
 export function adjustTimeError(time: number, acceptableError: number): number {
 	if (Math.abs(time - cachedTime) > acceptableError) cachedTime = time;
@@ -12,4 +16,128 @@ export interface Resolver {
 	isActive(): boolean;
 	getTitle(): string;
 	getUploader(): string;
+}
+
+const stringMap = {
+	play: "general.playing",
+	pause: "general.paused",
+	live: "general.live",
+	ad: "youtube.ad",
+	search: "general.searchFor",
+	browsingTypeVideos: "youtube.browsingTypeVideos",
+	browseShorts: "youtube.browsingShorts",
+	browsingVid: "youtube.browsingVideos",
+	browsingPlayl: "youtube.browsingPlaylists",
+	viewCPost: "youtube.viewingCommunityPost",
+	ofChannel: "youtube.ofChannel",
+	readChannel: "youtube.readingChannel",
+	searchChannel: "youtube.searchChannel",
+	trending: "youtube.trending",
+	browsingThrough: "youtube.browsingThrough",
+	subscriptions: "youtube.subscriptions",
+	library: "youtube.library",
+	history: "youtube.history",
+	purchases: "youtube.purchases",
+	reports: "youtube.reportHistory",
+	upload: "youtube.upload",
+	viewChannel: "general.viewChannel",
+	viewAllPlayL: "youtube.viewAllPlaylist",
+	viewEvent: "youtube.viewLiveEvents",
+	viewLiveDash: "youtube.viewLiveDashboard",
+	viewAudio: "youtube.viewAudioLibrary",
+	studioVid: "youtube.studio.viewContent",
+	studioEdit: "youtube.studio.editVideo",
+	studioAnaly: "youtube.studio.videoAnalytics",
+	studioComments: "youtube.studio.videoComments",
+	studioTranslate: "youtube.studio.videoTranslations",
+	studioTheir: "youtube.studio.viewTheir",
+	studioCAnaly: "youtube.studio.channelAnalytics",
+	studioCComments: "youtube.studio.channelComments",
+	studioCTranslate: "youtube.studio.channelTranslations",
+	studioArtist: "youtube.studio.artistPage",
+	studioDash: "youtube.studio.dashboard",
+	viewPlaylist: "general.viewPlaylist",
+	readAbout: "general.readingAbout",
+	viewAccount: "general.viewAccount",
+	viewHome: "general.viewHome",
+	watchVid: "general.watchingVid",
+	watchLive: "general.watchingLive",
+	browsing: "general.browsing",
+	searchSomething: "general.searchSomething",
+	watchStreamButton: "general.buttonWatchStream",
+	watchVideoButton: "general.buttonWatchVideo",
+	viewChannelButton: "general.buttonViewChannel",
+	videos: "youtube.videos",
+};
+
+export let strings: Awaited<
+	ReturnType<typeof presence.getStrings<typeof stringMap>>
+> = null;
+
+let oldLang: string = null,
+	currentTargetLang: string = null,
+	fetchingStrings = false,
+	stringFetchTimeout: number = null;
+
+function fetchStrings() {
+	if (oldLang === currentTargetLang && strings) return;
+	if (fetchingStrings) return;
+	const targetLang = currentTargetLang;
+	fetchingStrings = true;
+	stringFetchTimeout = setTimeout(() => {
+		presence.error(`Failed to fetch strings for ${targetLang}.`);
+		fetchingStrings = false;
+	}, 5e3);
+	presence.info(`Fetching strings for ${targetLang}.`);
+	presence
+		.getStrings(stringMap, targetLang)
+		.then(result => {
+			if (targetLang !== currentTargetLang) return;
+			clearTimeout(stringFetchTimeout);
+			strings = result;
+			fetchingStrings = false;
+			oldLang = targetLang;
+			presence.info(`Fetched strings for ${targetLang}.`);
+		})
+		.catch(() => null);
+}
+
+setInterval(fetchStrings, 3000);
+fetchStrings();
+
+/**
+ * Sets the current language to fetch strings for and returns whether any strings are loaded.
+ */
+export function checkStringLanguage(lang: string) {
+	currentTargetLang = lang;
+	return !!strings;
+}
+
+const settingsFetchStatus: Record<string, number> = {},
+	cachedSettings: Record<string, unknown> = {};
+
+function startSettingGetter(setting: string) {
+	if (!settingsFetchStatus[setting]) {
+		let success = false;
+		settingsFetchStatus[setting] = setTimeout(() => {
+			if (!success)
+				presence.error(`Failed to fetch setting '${setting}' in time.`);
+			delete settingsFetchStatus[setting];
+		}, 2000);
+		presence
+			.getSetting(setting)
+			.then(result => {
+				cachedSettings[setting] = result;
+				success = true;
+			})
+			.catch(() => null);
+	}
+}
+
+export function getSetting<E extends string | boolean | number>(
+	setting: string,
+	fallback: E = null
+): E {
+	startSettingGetter(setting);
+	return (cachedSettings[setting] as E) ?? fallback;
 }


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
The likely cause of "YouTube not working" was that the `lang` setting never loaded or timed out.

Changes:
- prevents presence from failing to show when `lang` setting doesn't load
  - defaults to `en` language
- fetches strings and settings in background intervals
- Resolves #7709
 
## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/PreMiD/Presences/assets/32113157/010eeb47-c978-4d76-8291-7a702b0ee6f1)


</details>
