### PR TITLE
fix(YouTube Music): no href temp fix

### DIFF
--- a/websites/Y/YouTube Music/metadata.json
+++ b/websites/Y/YouTube Music/metadata.json
@@ -19,7 +19,7 @@
 		"vi_VN": "Một dịch vụ phát nhạc với các album, đĩa đơn, video, bản remix, và các tiết mục trực tiếp chính thức và hơn nữa cho Android, iOS và máy tính. Tất cả đều tại đây."
 	},
 	"url": "music.youtube.com",
-	"version": "3.0.9",
+	"version": "3.0.10",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/thumbnail.png",
 	"color": "#E40813",

--- a/websites/Y/YouTube Music/presence.ts
+++ b/websites/Y/YouTube Music/presence.ts
@@ -29,7 +29,7 @@ presence.on("UpdateData", async () => {
 		{ mediaSession } = navigator,
 		watchID = document
 			.querySelector<HTMLAnchorElement>("a.ytp-title-link.yt-uix-sessionlink")
-			.href.match(/v=([^&#]{5,})/)?.[1],
+			?.href.match(/v=([^&#]{5,})/)?.[1],
 		repeatMode = document
 			.querySelector('ytmusic-player-bar[slot="player-bar"]')
 			.getAttribute("repeat-Mode_"),

--- a/websites/Y/YouTube Music/presence.ts
+++ b/websites/Y/YouTube Music/presence.ts
@@ -27,8 +27,7 @@ presence.on("UpdateData", async () => {
 			presence.getSetting<boolean>("privacy"),
 		]),
 		{ mediaSession } = navigator,
-		watchID =
-			window.location.href.match(/v=([^&#]{5,})/)?.[1] ??
+		watchID = href.match(/v=([^&#]{5,})/)?.[1] ??
 			document
 				.querySelector<HTMLAnchorElement>("a.ytp-title-link.yt-uix-sessionlink")
 				?.href.match(/v=([^&#]{5,})/)?.[1],

--- a/websites/Y/YouTube Music/presence.ts
+++ b/websites/Y/YouTube Music/presence.ts
@@ -27,7 +27,8 @@ presence.on("UpdateData", async () => {
 			presence.getSetting<boolean>("privacy"),
 		]),
 		{ mediaSession } = navigator,
-		watchID = href.match(/v=([^&#]{5,})/)?.[1] ??
+		watchID =
+			href.match(/v=([^&#]{5,})/)?.[1] ??
 			document
 				.querySelector<HTMLAnchorElement>("a.ytp-title-link.yt-uix-sessionlink")
 				?.href.match(/v=([^&#]{5,})/)?.[1],

--- a/websites/Y/YouTube Music/presence.ts
+++ b/websites/Y/YouTube Music/presence.ts
@@ -27,9 +27,11 @@ presence.on("UpdateData", async () => {
 			presence.getSetting<boolean>("privacy"),
 		]),
 		{ mediaSession } = navigator,
-		watchID = document
-			.querySelector<HTMLAnchorElement>("a.ytp-title-link.yt-uix-sessionlink")
-			?.href.match(/v=([^&#]{5,})/)?.[1],
+		watchID =
+			window.location.href.match(/v=([^&#]{5,})/)?.[1] ??
+			document
+				.querySelector<HTMLAnchorElement>("a.ytp-title-link.yt-uix-sessionlink")
+				?.href.match(/v=([^&#]{5,})/)?.[1],
 		repeatMode = document
 			.querySelector('ytmusic-player-bar[slot="player-bar"]')
 			.getAttribute("repeat-Mode_"),


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

https://discord.com/channels/493130730549805057/1181769179070734398
![image](https://github.com/PreMiD/Presences/assets/73395916/7a2c907f-7b05-4b0b-98b8-40257bc0df06)

The issue is still there and will have to be looked into.
Only added null check, to prevent error / presence freezing

Currently, the listen along button won't lead to the actual song
![image](https://github.com/PreMiD/Presences/assets/73395916/e8c1baf7-772b-4a0c-96bb-2875c026245c) ![image](https://github.com/PreMiD/Presences/assets/73395916/843b4a96-68d7-48fc-9ac1-636c41d8e4b9)

If possible, it now takes the `watchID` from the url
