### PR TITLE
perf(X.com): remove unnecessary creation of presence objects

### DIFF
--- a/websites/X/X.com/metadata.json
+++ b/websites/X/X.com/metadata.json
@@ -19,7 +19,7 @@
 		"twitter.com",
 		"x.com"
 	],
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/X/X.com/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/X/X.com/assets/thumbnail.png",
 	"color": "#000000",

--- a/websites/X/X.com/presence.ts
+++ b/websites/X/X.com/presence.ts
@@ -88,10 +88,12 @@ let strings: Awaited<ReturnType<typeof getStrings>>,
 
 presence.on("UpdateData", async () => {
 	//* Update strings if user selected another language.
-	const newLang = await presence.getSetting<string>("lang").catch(() => "en"),
-		privacy = await presence.getSetting<boolean>("privacy"),
-		time = await presence.getSetting<boolean>("time"),
-		twitter = await presence.getSetting<boolean>("twitter");
+	const [newLang, privacy, time, twitter] = await Promise.all([
+		presence.getSetting<string>("lang").catch(() => "en"),
+		presence.getSetting<boolean>("privacy"),
+		presence.getSetting<boolean>("time"),
+		presence.getSetting<boolean>("twitter"),
+	]);
 
 	if (!twitterCheck || twitterCheck !== twitter) {
 		twitterCheck = twitter;

--- a/websites/X/X.com/presence.ts
+++ b/websites/X/X.com/presence.ts
@@ -27,9 +27,7 @@ function setClient(clientId: PresenceClients) {
 		presence = presences[clientId];
 		presence.setActivity();
 	} else {
-		presence = new Presence({
-			clientId: clientId,
-		});
+		presence = new Presence({ clientId });
 		presences[clientId] = presence;
 	}
 	presence.info("Switched presence client!");

--- a/websites/X/X.com/presence.ts
+++ b/websites/X/X.com/presence.ts
@@ -22,11 +22,6 @@ const presences: Record<string, Presence> = {
 	};
 
 function setClient(clientId: PresenceClients) {
-	if (Number(presence.getExtensionVersion()) < 224) {
-		//Extensions below this version, don't support this feature.
-		presence.hideSetting("twitter");
-		return;
-	}
 	presence.clearActivity();
 	if (presences[clientId]) {
 		presence = presences[clientId];
@@ -37,6 +32,7 @@ function setClient(clientId: PresenceClients) {
 		});
 		presences[clientId] = presence;
 	}
+	presence.info("Switched presence client!");
 }
 
 function stripText(element: HTMLElement, id = "None", log = true): string {
@@ -95,10 +91,13 @@ presence.on("UpdateData", async () => {
 		presence.getSetting<boolean>("twitter"),
 	]);
 
-	if (!twitterCheck || twitterCheck !== twitter) {
+	if (!twitter && twitterCheck !== twitter) {
 		twitterCheck = twitter;
 		setClient(PresenceClients.X);
-	} else setClient(PresenceClients.Twitter);
+	} else if (twitterCheck !== twitter) {
+		twitterCheck = twitter;
+		setClient(PresenceClients.Twitter);
+	}
 
 	if (oldLang !== newLang || !strings) {
 		oldLang = newLang;

--- a/websites/X/X.com/presence.ts
+++ b/websites/X/X.com/presence.ts
@@ -8,7 +8,7 @@ let presence = new Presence({
 	}),
 	twitterCheck: boolean;
 
-const presences: Record<string, Presence> = {
+const presences: { [key in PresenceClients]?: Presence } = {
 		[PresenceClients.X]: presence,
 	},
 	capitalize = (text: string): string => {

--- a/websites/X/X.com/presence.ts
+++ b/websites/X/X.com/presence.ts
@@ -107,32 +107,32 @@ presence.on("UpdateData", async () => {
 
 	let title: string, info: string;
 
-	const path = window.location.pathname;
+	const { pathname, href } = document.location;
 
-	if (oldUrl !== window.location.href) {
-		oldUrl = window.location.href;
+	if (oldUrl !== href) {
+		oldUrl = href;
 		elapsed = Math.floor(Date.now() / 1000);
 	}
 
 	title = strings.browsing;
-	info = capitalize(path.split("/")[1]);
+	info = capitalize(pathname.split("/")[1]);
 
-	if (path.match("/i/")) {
-		info = capitalize(path.split("/")[2]);
+	if (pathname.match("/i/")) {
+		info = capitalize(pathname.split("/")[2]);
 		if (info === "Bookmarks") info = strings.bookmarks;
 	}
 
-	if (path.match("/notifications")) info = strings.notifs;
+	if (pathname.match("/notifications")) info = strings.notifs;
 
-	if (path.match("/explore")) info = strings.explore;
+	if (pathname.match("/explore")) info = strings.explore;
 
-	if (path.match("/tos")) info = strings.terms;
+	if (pathname.match("/tos")) info = strings.terms;
 
-	if (path.match("/privacy")) info = strings.privacy;
+	if (pathname.match("/privacy")) info = strings.privacy;
 
-	if (path.match("/settings/")) info = strings.settings;
+	if (pathname.match("/settings/")) info = strings.settings;
 
-	if (path.match("/search")) {
+	if (pathname.match("/search")) {
 		if (privacy) {
 			title = strings.searchSomething;
 			info = null;
@@ -143,33 +143,33 @@ presence.on("UpdateData", async () => {
 	}
 
 	const objHeader = document.querySelector(
-		`a[href='/${document.location.pathname.split("/")[1]}/header_photo']`
+		`a[href='/${pathname.split("/")[1]}/header_photo']`
 	)?.parentElement.children[1]?.children[1] as HTMLElement;
 
 	if (objHeader) {
 		title = strings.viewPosts;
 		info = `${
 			stripText(objHeader, "Object Header").split("@")[0]
-		} // ${capitalize(path.split("/")[1])}`;
+		} // ${capitalize(pathname.split("/")[1])}`;
 
-		if (path.match("/with_replies")) title = strings.viewPostsWithReplies;
+		if (pathname.match("/with_replies")) title = strings.viewPostsWithReplies;
 
-		if (path.match("/media")) title = strings.viewMedia;
+		if (pathname.match("/media")) title = strings.viewMedia;
 
-		if (path.match("/likes")) title = strings.viewLiked;
+		if (pathname.match("/likes")) title = strings.viewLiked;
 	}
 
-	if (!objHeader && path.match("/status/")) {
+	if (!objHeader && pathname.match("/status/")) {
 		title = strings.readPost;
 		[info] = stripText(
-			document.querySelectorAll(
-				`a[href='/${path.split("/")[1]}']`
-			)[1] as HTMLElement,
+			document.querySelectorAll<HTMLAnchorElement>(
+				`a[href='/${pathname.split("/")[1]}']`
+			)[1],
 			"Post"
 		).split("@");
 	}
 
-	if (path.match("/messages") && objHeader) {
+	if (pathname.match("/messages") && objHeader) {
 		title = strings.viewDms;
 		info = stripText(objHeader, "Object Header");
 		if (privacy) info = null;
@@ -179,14 +179,14 @@ presence.on("UpdateData", async () => {
 		document.querySelectorAll("h2")
 	).find(c => c.parentElement.children[1]?.textContent.includes("@"));
 
-	if (path.match("/moments") && etcHeader) {
+	if (pathname.match("/moments") && etcHeader) {
 		title = "Browsing Moments...";
-		info = capitalize(path.split("/")[1]);
+		info = capitalize(pathname.split("/")[1]);
 	}
 
-	if (path.match("/lists") && etcHeader) {
+	if (pathname.match("/lists") && etcHeader) {
 		title = strings.viewList;
-		info = capitalize(path.split("/")[1]);
+		info = capitalize(pathname.split("/")[1]);
 	}
 
 	const presenceData: PresenceData = {

--- a/websites/X/X.com/presence.ts
+++ b/websites/X/X.com/presence.ts
@@ -199,5 +199,5 @@ presence.on("UpdateData", async () => {
 
 	if (time) presenceData.startTimestamp = elapsed;
 
-	presence.setActivity(presenceData, true);
+	presence.setActivity(presenceData);
 });


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
* Removes creation of `Presence` objects every `UpdateData`
* Only changes presence when setting is changed
* Loads settings in parallel
* Doesn't hide twitter setting
  * Not sure where that arbitrary 224 value came from, especially since it was added to a presence when the latest stable version is 223. It should still work.
* Refactors code with latest guidelines

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/PreMiD/Presences/assets/32113157/1cb1a5d1-cf6b-4df5-9f49-89150bb66cc4)

![image](https://github.com/PreMiD/Presences/assets/32113157/85d4ea15-eb1a-45fa-a445-a1b00ca41f36)



</details>
