### PR TITLE
feat(wumpus.store): add presence

### DIFF
--- a/websites/W/wumpus.store/metadata.json
+++ b/websites/W/wumpus.store/metadata.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.9",
+	"author": {
+		"id": "347077478726238228",
+		"name": "Dominik"
+	},
+	"service": "wumpus.store",
+	"description": {
+		"en": "Rich Presence for wumpus.store - The #1 Discord Bot Store",
+		"de": "Rich Presence für wumpus.store - Der #1 Discord Bot Store"
+	},
+	"url": "wumpus.store",
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/QCtoeEM.png",
+	"thumbnail": "https://i.imgur.com/UUnO5tH.png",
+	"color": "#bcabeb",
+	"category": "other",
+	"tags": [
+		"discord",
+		"bot",
+		"wumpus"
+	]
+}

--- a/websites/W/wumpus.store/metadata.json
+++ b/websites/W/wumpus.store/metadata.json
@@ -11,7 +11,7 @@
 	},
 	"url": "wumpus.store",
 	"version": "1.0.0",
-	"logo": "https://i.imgur.com/QCtoeEM.png",
+	"logo": "https://i.imgur.com/KaW8pr2.png",
 	"thumbnail": "https://i.imgur.com/UUnO5tH.png",
 	"color": "#bcabeb",
 	"category": "other",

--- a/websites/W/wumpus.store/presence.ts
+++ b/websites/W/wumpus.store/presence.ts
@@ -20,6 +20,7 @@ presence.on("UpdateData", async () => {
 		}
 		case "/search": {
 			presenceData.details = "Searching for a new bot";
+			presenceData.smallImageKey = Assets.Search
 			break;
 		}
 		case "/": {

--- a/websites/W/wumpus.store/presence.ts
+++ b/websites/W/wumpus.store/presence.ts
@@ -10,7 +10,6 @@ presence.on("UpdateData", async () => {
 			startTimestamp: browsingUnix,
 		},
 		{ pathname, origin } = document.location;
-	
 
 	let title: HTMLElement, logo: HTMLElement;
 
@@ -34,7 +33,11 @@ presence.on("UpdateData", async () => {
 		document.querySelector('b[class*="chakra-text"]')
 	) {
 		title = document.querySelector('b[class*="chakra-text"]');
-		logo = document.querySelectorAll('[class*="chakra-container"]')?.[1]?.querySelector('[class*="chakra-avatar__img"]') ?? document.querySelector('[class*="chakra-avatar__img"]');
+		logo =
+			document
+				.querySelectorAll('[class*="chakra-container"]')?.[1]
+				?.querySelector('[class*="chakra-avatar__img"]') ??
+			document.querySelector('[class*="chakra-avatar__img"]');
 		presenceData.details = "Viewing Bot:";
 		presenceData.state = title.textContent;
 		presenceData.smallImageKey = logo.getAttribute("src");

--- a/websites/W/wumpus.store/presence.ts
+++ b/websites/W/wumpus.store/presence.ts
@@ -8,11 +8,30 @@ presence.on("UpdateData", async () => {
 			largeImageKey: "https://imgur.com/QCtoeEM.png",
 		},
 		{ pathname } = document.location;
-	presenceData.details = "Viewing Page:";
+	presenceData.details = "Viewing Home Page";
 
 	let title: HTMLElement, logo: HTMLElement;
 	presenceData.startTimestamp = browsingUnix;
-	if (document.querySelector(".css-1igwmid > b")) {
+
+	switch (pathname) {
+		case "/bot/add": {
+			presenceData.details = "Adding a new bot";
+			break;
+		}
+		case "/search": {
+			presenceData.details = "Searching for a new bot";
+			break;
+		}
+		case "/": {
+			presenceData.details = "Viewing Home Page";
+			break;
+		}
+	}
+
+	if (
+		pathname.startsWith("/bot/") &&
+		document.querySelector(".css-1igwmid > b")
+	) {
 		title = document.querySelector(".css-1igwmid > b");
 		logo = document.querySelector(
 			".chakra-stack > .chakra-stack > .chakra-stack > .chakra-avatar > img"
@@ -33,16 +52,6 @@ presence.on("UpdateData", async () => {
 		];
 	}
 
-	switch (pathname) {
-		case "/bot/add": {
-			presenceData.details = "Adding a new bot";
-			break;
-		}
-		case "/search": {
-			presenceData.details = "Searching for a new bot";
-			break;
-		}
-	}
 	if (presenceData.details) presence.setActivity(presenceData);
 	else presence.setActivity();
 });

--- a/websites/W/wumpus.store/presence.ts
+++ b/websites/W/wumpus.store/presence.ts
@@ -5,13 +5,14 @@ const presence = new Presence({
 
 presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
-			largeImageKey: "https://imgur.com/QCtoeEM.png",
+			largeImageKey: "https://i.imgur.com/KaW8pr2.png",
+			details: "Viewing Home Page",
+			startTimestamp: browsingUnix,
 		},
-		{ pathname } = document.location;
-	presenceData.details = "Viewing Home Page";
+		{ pathname, origin } = document.location;
+	
 
 	let title: HTMLElement, logo: HTMLElement;
-	presenceData.startTimestamp = browsingUnix;
 
 	switch (pathname) {
 		case "/bot/add": {
@@ -30,10 +31,10 @@ presence.on("UpdateData", async () => {
 
 	if (
 		pathname.startsWith("/bot/") &&
-		document.querySelector(".css-1igwmid > b")
+		document.querySelector('b[class*="chakra-text"]')
 	) {
-		title = document.querySelector('b[class*="chakra-text"]')
-		logo = document.querySelectorAll('[class*="chakra-container"]')?.[1]?.querySelector('[class*="chakra-avatar__img"]') ?? document.querySelector('[class*="chakra-avatar__img"]')
+		title = document.querySelector('b[class*="chakra-text"]');
+		logo = document.querySelectorAll('[class*="chakra-container"]')?.[1]?.querySelector('[class*="chakra-avatar__img"]') ?? document.querySelector('[class*="chakra-avatar__img"]');
 		presenceData.details = "Viewing Bot:";
 		presenceData.state = title.textContent;
 		presenceData.smallImageKey = logo.getAttribute("src");
@@ -41,11 +42,11 @@ presence.on("UpdateData", async () => {
 		presenceData.buttons = [
 			{
 				label: "Visit Bot Page",
-				url: `${document.location.origin}/bot/${pathname.split("/")[2]}/`,
+				url: `${origin}/bot/${pathname.split("/")[2]}/`,
 			},
 			{
 				label: `Vote for ${title.textContent}`,
-				url: `${document.location.origin}/bot/${pathname.split("/")[2]}/vote`,
+				url: `${origin}/bot/${pathname.split("/")[2]}/vote`,
 			},
 		];
 	}

--- a/websites/W/wumpus.store/presence.ts
+++ b/websites/W/wumpus.store/presence.ts
@@ -45,7 +45,7 @@ presence.on("UpdateData", async () => {
 		presenceData.buttons = [
 			{
 				label: "Visit Bot Page",
-				url: `${origin}/bot/${pathname.split("/")[2]}/`,
+				url: href,
 			},
 			{
 				label: `Vote for ${title.textContent}`,

--- a/websites/W/wumpus.store/presence.ts
+++ b/websites/W/wumpus.store/presence.ts
@@ -49,7 +49,7 @@ presence.on("UpdateData", async () => {
 			},
 			{
 				label: `Vote for ${title.textContent}`,
-				url: `${origin}/bot/${pathname.split("/")[2]}/vote`,
+				url: `${href}/vote`
 			},
 		];
 	}

--- a/websites/W/wumpus.store/presence.ts
+++ b/websites/W/wumpus.store/presence.ts
@@ -1,0 +1,48 @@
+const presence = new Presence({
+		clientId: "998532462755979275",
+	}),
+	browsingUnix = Math.floor(Date.now() / 1000);
+
+presence.on("UpdateData", async () => {
+	const presenceData: PresenceData = {
+			largeImageKey: "https://imgur.com/QCtoeEM.png",
+		},
+		{ pathname } = document.location;
+	presenceData.details = "Viewing Page:";
+
+	let title: HTMLElement, logo: HTMLElement;
+	presenceData.startTimestamp = browsingUnix;
+	if (document.querySelector(".css-1igwmid > b")) {
+		title = document.querySelector(".css-1igwmid > b");
+		logo = document.querySelector(
+			".chakra-stack > .chakra-stack > .chakra-stack > .chakra-avatar > img"
+		);
+		presenceData.details = "Viewing Bot:";
+		presenceData.state = title.textContent;
+		presenceData.smallImageKey = logo.getAttribute("src");
+
+		presenceData.buttons = [
+			{
+				label: "Visit Bot Page",
+				url: `${document.location.origin}/bot/${pathname.split("/")[2]}/`,
+			},
+			{
+				label: `Vote for ${title.textContent}`,
+				url: `${document.location.origin}/bot/${pathname.split("/")[2]}/vote`,
+			},
+		];
+	}
+
+	switch (pathname) {
+		case "/bot/add": {
+			presenceData.details = "Adding a new bot";
+			break;
+		}
+		case "/search": {
+			presenceData.details = "Searching for a new bot";
+			break;
+		}
+	}
+	if (presenceData.details) presence.setActivity(presenceData);
+	else presence.setActivity();
+});

--- a/websites/W/wumpus.store/presence.ts
+++ b/websites/W/wumpus.store/presence.ts
@@ -33,9 +33,7 @@ presence.on("UpdateData", async () => {
 		document.querySelector(".css-1igwmid > b")
 	) {
 		title = document.querySelector(".css-1igwmid > b");
-		logo = document.querySelector(
-			".chakra-stack > .chakra-stack > .chakra-stack > .chakra-avatar > img"
-		);
+		logo = document.querySelectorAll('[class*="chakra-container"]')?.[1]?.querySelector('[class*="chakra-avatar__img"]') ?? document.querySelector('[class*="chakra-avatar__img"]')
 		presenceData.details = "Viewing Bot:";
 		presenceData.state = title.textContent;
 		presenceData.smallImageKey = logo.getAttribute("src");

--- a/websites/W/wumpus.store/presence.ts
+++ b/websites/W/wumpus.store/presence.ts
@@ -9,7 +9,7 @@ presence.on("UpdateData", async () => {
 			details: "Viewing Home Page",
 			startTimestamp: browsingUnix,
 		},
-		{ pathname, origin } = document.location;
+		{ pathname, href} = document.location;
 
 	let title: HTMLElement, logo: HTMLElement;
 

--- a/websites/W/wumpus.store/presence.ts
+++ b/websites/W/wumpus.store/presence.ts
@@ -9,7 +9,7 @@ presence.on("UpdateData", async () => {
 			details: "Viewing Home Page",
 			startTimestamp: browsingUnix,
 		},
-		{ pathname, href} = document.location;
+		{ pathname, href } = document.location;
 
 	let title: HTMLElement, logo: HTMLElement;
 
@@ -20,7 +20,7 @@ presence.on("UpdateData", async () => {
 		}
 		case "/search": {
 			presenceData.details = "Searching for a new bot";
-			presenceData.smallImageKey = Assets.Search
+			presenceData.smallImageKey = Assets.Search;
 			break;
 		}
 		case "/": {
@@ -50,7 +50,7 @@ presence.on("UpdateData", async () => {
 			},
 			{
 				label: `Vote for ${title.textContent}`,
-				url: `${href}/vote`
+				url: `${href}/vote`,
 			},
 		];
 	}

--- a/websites/W/wumpus.store/presence.ts
+++ b/websites/W/wumpus.store/presence.ts
@@ -32,7 +32,7 @@ presence.on("UpdateData", async () => {
 		pathname.startsWith("/bot/") &&
 		document.querySelector(".css-1igwmid > b")
 	) {
-		title = document.querySelector(".css-1igwmid > b");
+		title = document.querySelector('b[class*="chakra-text"]')
 		logo = document.querySelectorAll('[class*="chakra-container"]')?.[1]?.querySelector('[class*="chakra-avatar__img"]') ?? document.querySelector('[class*="chakra-avatar__img"]')
 		presenceData.details = "Viewing Bot:";
 		presenceData.state = title.textContent;


### PR DESCRIPTION
## Description 
Presence for Wumpus.store. Displays what bot you are viewing along with buttons to vote for the bot on the site. Also displays when you are adding a bit, searching for one or viewing the homepage.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://github.com/PreMiD/Presences/assets/68947960/c21e7589-dcb6-429b-983c-a02b4fae4c98)

![image](https://github.com/PreMiD/Presences/assets/68947960/118af549-8dee-4182-a62d-ac8c1803ad32)

![image](https://github.com/PreMiD/Presences/assets/68947960/43d99630-1a39-4a9a-b5c6-b9c1e260372a)




</details>
