### PR TITLE
fix(GitHub): fix images & show org repo's tab

### DIFF
--- a/websites/G/GitHub/metadata.json
+++ b/websites/G/GitHub/metadata.json
@@ -8,6 +8,10 @@
 		{
 			"name": "Encrypted",
 			"id": "564434085708038144"
+		},
+		{
+			"name": "veryCrunchy",
+			"id": "576097150359044106"
 		}
 	],
 	"service": "GitHub",
@@ -29,10 +33,10 @@
 		"github.com",
 		"gist.github.com"
 	],
-	"version": "2.11.9",
+	"version": "2.11.10",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/G/GitHub/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/G/GitHub/assets/thumbnail.png",
-	"color": "#000000",
+	"color": "#171515",
 	"category": "other",
 	"tags": [
 		"programming",

--- a/websites/G/GitHub/presence.ts
+++ b/websites/G/GitHub/presence.ts
@@ -73,11 +73,12 @@ presence.on("UpdateData", async () => {
 				const searchParam = new URLSearchParams(search).get("tab"),
 					profileName = document
 						.querySelector("span.p-nickname")
-						?.textContent.trim();
+						?.textContent.split("·")[0]
+						.trim();
 				presenceData.buttons = [{ label: "View Profile", url: href }];
 				if (cover) {
 					presenceData.largeImageKey = `${
-						document.querySelector<HTMLImageElement>("img.avatar").src
+						document.querySelector<HTMLImageElement>("img.avatar-user").src
 					}.png`;
 				}
 				if (searchParam)
@@ -99,7 +100,7 @@ presence.on("UpdateData", async () => {
 					presenceData.largeImageKey = `https://avatars.githubusercontent.com/u/${
 						document.querySelector<HTMLMetaElement>(
 							'meta[name~="octolytics-dimension-user_id"]'
-						).content
+						)?.content
 					}`;
 				}
 
@@ -258,30 +259,6 @@ presence.on("UpdateData", async () => {
 					presenceData.state = `${repository.owner}/${repository.name}`;
 				}
 				break;
-			case !!document.querySelector<HTMLMetaElement>(
-				'meta[name="hovercard-subject-tag"]'
-			):
-				presenceData.details = "Viewing an organization";
-
-				if (privacy) {
-					delete presenceData.state;
-					delete presenceData.buttons;
-					break;
-				}
-				presenceData.state = document.title;
-				if (cover) {
-					presenceData.largeImageKey = `${(presenceData.largeImageKey =
-						document.querySelector<HTMLMetaElement>(
-							'meta[property~="og:image"]'
-						).content)}`;
-				}
-				break;
-			case pathname.includes("/features"):
-				presenceData.details = "Browsing features";
-				if (pathname.includes("copilot"))
-					presenceData.state = "Looking at Github Copilot";
-
-				break;
 			case pathname.includes("/orgs/"):
 				if (privacy) {
 					presenceData.details = "Viewing the people in an organization";
@@ -292,12 +269,39 @@ presence.on("UpdateData", async () => {
 				presenceData.details = `Viewing ${pathname.split("/")[2]}'s ${
 					pathname.split("/")[3]
 				}`;
+
+				break;
+			case !!document.querySelector<HTMLMetaElement>(
+				'meta[name="hovercard-subject-tag"]'
+			):
+				presenceData.details = "Viewing an organization";
+
+				if (privacy) {
+					delete presenceData.state;
+					delete presenceData.buttons;
+					break;
+				}
+
+				presenceData.state = document.title;
 				if (cover) {
 					presenceData.largeImageKey = `${
-						document.querySelector<HTMLImageElement>("h1 > a > img").src
+						document.querySelector<HTMLMetaElement>(
+							'meta[property~="og:image"]'
+						)?.content ??
+						document.querySelector<HTMLImageElement>(
+							"img[itemprop='image'].avatar"
+						)?.src ??
+						presenceData.largeImageKey
 					}`;
 				}
 				break;
+			case pathname.includes("/features"):
+				presenceData.details = "Browsing features";
+				if (pathname.includes("copilot"))
+					presenceData.state = "Looking at Github Copilot";
+
+				break;
+
 			case pathname === "/" || !pathname:
 				presenceData.details = "Viewing the home page";
 				break;


### PR DESCRIPTION
- fixes showing wrong image
- adds better null checks for images
- fixes organization repositories tab not showing
- fixes users pronouns showing in name

<details><summary>screenshots</summary>
<p>


![image](https://github.com/PreMiD/Presences/assets/73395916/8ab4cc16-7ae1-4d17-82f1-aa8faa6dce8c)
![image](https://github.com/PreMiD/Presences/assets/73395916/5209df93-3f41-4ccb-ad28-0ca157e25f8e)
![image](https://github.com/PreMiD/Presences/assets/73395916/a455623b-af1f-4979-9c64-945dbc48de08)
![image](https://github.com/PreMiD/Presences/assets/73395916/d8072e23-7603-45bc-97d1-a6d92d542e39)
</details> 
</p>

