### PR TITLE
fix(Otakudesu): changing to new url domain (.cam)

### DIFF
--- a/websites/O/Otakudesu/metadata.json
+++ b/websites/O/Otakudesu/metadata.json
@@ -10,7 +10,7 @@
 		"nl": "Download, bekijk en stream anime met Indonesische ondertiteling en met 240p, 360p, 480p en 720p resolutie met MP4-formaat en MKV samen met de batch.",
 		"id": "Download, nonton dan streaming anime subtitle Indonesia dengan resolusi 240p, 360p, 480p, & 720p dengan format MP4 & MKV bersama dengan batchnya"
 	},
-	"url": "otakudesu.bid",
+	"url": "otakudesu.cam",
 	"version": "2.0.16",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/O/Otakudesu/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/O/Otakudesu/assets/thumbnail.png",


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
changing from **otakudesu.bid** to **otakudesu.cam**

## Acknowledgements
- [ ] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [ ] I linted the code by running `yarn format`
- [ ] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>



</details>
![Screenshot (466)](https://github.com/PreMiD/Presences/assets/117517427/d571d93a-be8a-4a03-aae6-93b6636a4116)
![Screenshot (467)](https://github.com/PreMiD/Presences/assets/117517427/c1c950d6-93ff-40b5-a191-2f1fc78204e2)
![Screenshot (463)](https://github.com/PreMiD/Presences/assets/117517427/21b46c1f-fa12-4b62-84d1-fa621c37bb70)
![Screenshot (464)](https://github.com/PreMiD/Presences/assets/117517427/b31ae505-9bf9-488f-8fbf-165eeab8a33b)
