### PR TITLE
fix(Otakudesu): changing to new url domain (.cam)

### DIFF
--- a/websites/O/Otakudesu/metadata.json
+++ b/websites/O/Otakudesu/metadata.json
@@ -11,7 +11,7 @@
 		"id": "Download, nonton dan streaming anime subtitle Indonesia dengan resolusi 240p, 360p, 480p, & 720p dengan format MP4 & MKV bersama dengan batchnya"
 	},
 	"url": "otakudesu.cam",
-	"version": "2.0.16",
+	"version": "2.0.17",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/O/Otakudesu/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/O/Otakudesu/assets/thumbnail.png",
 	"color": "#ffffff",

--- a/websites/O/Otakudesu/metadata.json
+++ b/websites/O/Otakudesu/metadata.json
@@ -10,7 +10,7 @@
 		"nl": "Download, bekijk en stream anime met Indonesische ondertiteling en met 240p, 360p, 480p en 720p resolutie met MP4-formaat en MKV samen met de batch.",
 		"id": "Download, nonton dan streaming anime subtitle Indonesia dengan resolusi 240p, 360p, 480p, & 720p dengan format MP4 & MKV bersama dengan batchnya"
 	},
-	"url": "otakudesu.bid",
+	"url": "otakudesu.cam",
 	"version": "2.0.16",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/O/Otakudesu/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/O/Otakudesu/assets/thumbnail.png",


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
changing from **otakudesu.bid** to **otakudesu.cam**

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![Screenshot (466)](https://github.com/PreMiD/Presences/assets/117517427/649f1324-2702-4176-9bef-96d3a20881fa)

![Screenshot (463)](https://github.com/PreMiD/Presences/assets/117517427/0bae5c40-5385-499c-ba14-b52c17b9f1f2)

![Screenshot (464)](https://github.com/PreMiD/Presences/assets/117517427/315ff43f-d271-4563-836b-251029579b50)

![Screenshot (467)](https://github.com/PreMiD/Presences/assets/117517427/a3d1fa78-17cc-4661-ac10-6957f247f791)



</details>
