### PR TITLE
refactor(Taiyō): add button, new page and refactor code

### DIFF
--- a/websites/T/Taiyō/metadata.json
+++ b/websites/T/Taiyō/metadata.json
@@ -6,7 +6,9 @@
 	},
 	"service": "Taiyō",
 	"altnames": [
-		"Taiyō.moe"
+		"Taiyō.moe",
+		"Taiyo.moe",
+		"Taiyo"
 	],
 	"description": {
 		"en": "Read manga online for free at Taiyō, without ads, with high-quality images, and reader support.",

--- a/websites/T/Taiyō/metadata.json
+++ b/websites/T/Taiyō/metadata.json
@@ -16,7 +16,7 @@
 		"taiyo.moe",
 		"www.taiyo.moe"
 	],
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/T/Taiy%C5%8D/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/T/Taiy%C5%8D/assets/thumbnail.png",
 	"color": "#FF4F4F",

--- a/websites/T/Taiyō/presence.ts
+++ b/websites/T/Taiyō/presence.ts
@@ -19,7 +19,10 @@ presence.on("UpdateData", async () => {
 			presenceData.details = "Importando mangá";
 		else if (pathname.includes("/medias/edit"))
 			presenceData.details = "Editando mangá";
-		else if (pathname.includes("/chapters/upload")) {
+		else if (
+			pathname.includes("/chapters/upload") ||
+			pathname.includes("/chapters/bulk-upload")
+		) {
 			const chapterNumber = document.querySelector<HTMLInputElement>(
 					'.chapter-number input[type="number"]'
 				)?.value,

--- a/websites/T/Taiyō/presence.ts
+++ b/websites/T/Taiyō/presence.ts
@@ -46,6 +46,11 @@ presence.on("UpdateData", async () => {
 		}
 
 		case "chapter": {
+			const mediaLink =
+					document.querySelector<HTMLAnchorElement>(".media-title").href,
+				links = getCover(mediaLink.split("/")[4]);
+			if (links.length > 0)
+				presenceData.largeImageKey = `https://www.taiyo.moe${links[1]}`;
 			presenceData.details =
 				document.querySelector(".media-title")?.textContent;
 			presenceData.state = `${
@@ -53,7 +58,10 @@ presence.on("UpdateData", async () => {
 			} - Página ${
 				document.querySelector(".chapter-currentPage")?.textContent
 			}`;
-			presenceData.buttons = [{ label: "Ler capítulo", url: href }];
+			presenceData.buttons = [
+				{ label: "Ler capítulo", url: href.replace(/\/[^/]*$/, "") },
+				{ label: "Ler mangá", url: mediaLink },
+			];
 			break;
 		}
 
@@ -69,6 +77,18 @@ presence.on("UpdateData", async () => {
 		default:
 			presenceData.details = "Na página inicial...";
 			break;
+	}
+
+	function getCover(uuid: string) {
+		const elements = document.querySelectorAll(
+				'link[rel="preload"][as="image"]'
+			),
+			links: string[] = [];
+		for (const element of elements) {
+			const imageSrcSet = element.getAttribute("imagesrcset");
+			if (imageSrcSet) links.push(imageSrcSet.split(", ")[0].split(" ")[0]);
+		}
+		return links.filter(link => link.includes(uuid));
 	}
 
 	if (presenceData.details) presence.setActivity(presenceData);

--- a/websites/T/Taiyō/presence.ts
+++ b/websites/T/Taiyō/presence.ts
@@ -11,60 +11,64 @@ presence.on("UpdateData", async () => {
 		},
 		{ href, pathname } = document.location;
 
-	if (pathname === "/") presenceData.details = "Na página inicial...";
-	else if (pathname.endsWith("/sign-in"))
-		presenceData.details = "Fazendo login";
-	else if (pathname.startsWith("/dashboard")) {
-		if (pathname.includes("/medias/import"))
-			presenceData.details = "Importando mangá";
-		else if (pathname.includes("/medias/edit"))
-			presenceData.details = "Editando mangá";
-		else if (
-			pathname.includes("/chapters/upload") ||
-			pathname.includes("/chapters/bulk-upload")
-		) {
-			const chapterNumber = document.querySelector<HTMLInputElement>(
-					'.chapter-number input[type="number"]'
-				)?.value,
-				chapterVolume = document.querySelector<HTMLInputElement>(
-					'.chapter-volume input[type="number"]'
-				)?.value,
-				chapterTitle = document.querySelectorAll<HTMLInputElement>(
-					'input[data-slot="input"]'
-				)[1]?.value;
-			if (chapterTitle) {
-				presenceData.details = `Upando: ${chapterTitle}`;
-				if (chapterNumber && chapterVolume)
-					presenceData.state = `Cap. ${chapterNumber} - Vol. ${chapterVolume}`;
-			} else presenceData.details = "Upando mangá...";
-		} else if (pathname.includes("/scans/add"))
-			presenceData.details = "Adicionando scan";
-		else presenceData.details = "No dashboard...";
-	} else if (pathname.startsWith("/chapter/")) {
-		presenceData.details = `${
-			document.querySelector(".media-title")?.textContent
-		}`;
-		presenceData.state = `${
-			document.querySelector(".chapter-number")?.textContent
-		} - Página ${document.querySelector(".chapter-currentPage")?.textContent}`;
-		presenceData.buttons = [
-			{
-				label: "Ler capítulo",
-				url: href,
-			},
-		];
-	} else if (pathname.startsWith("/media/")) {
-		presenceData.largeImageKey =
-			document.querySelector<HTMLImageElement>(".cover-url").src;
-		presenceData.details = `${
-			document.querySelector(".media-title")?.textContent
-		}`;
-		presenceData.buttons = [
-			{
-				label: "Ler mangá",
-				url: href,
-			},
-		];
+	switch (pathname.split("/")[1]) {
+		case "auth":
+			presenceData.details = "Fazendo login";
+			break;
+
+		case "dashboard": {
+			if (pathname.includes("/medias/import"))
+				presenceData.details = "Importando mangá";
+			else if (pathname.includes("/medias/edit"))
+				presenceData.details = "Editando mangá";
+			else if (
+				pathname.includes("/chapters/upload") ||
+				pathname.includes("/chapters/bulk-upload")
+			) {
+				const chapterNumber = document.querySelector<HTMLInputElement>(
+						'.chapter-number input[type="number"]'
+					)?.value,
+					chapterVolume = document.querySelector<HTMLInputElement>(
+						'.chapter-volume input[type="number"]'
+					)?.value,
+					chapterTitle = document.querySelectorAll<HTMLInputElement>(
+						'input[data-slot="input"]'
+					)[1]?.value;
+				if (chapterTitle) {
+					presenceData.details = `Upando: ${chapterTitle}`;
+					if (chapterNumber && chapterVolume)
+						presenceData.state = `Cap. ${chapterNumber} - Vol. ${chapterVolume}`;
+				} else presenceData.details = "Upando mangá...";
+			} else if (pathname.includes("/scans/add"))
+				presenceData.details = "Adicionando scan";
+			else presenceData.details = "No dashboard...";
+			break;
+		}
+
+		case "chapter": {
+			presenceData.details =
+				document.querySelector(".media-title")?.textContent;
+			presenceData.state = `${
+				document.querySelector(".chapter-number")?.textContent
+			} - Página ${
+				document.querySelector(".chapter-currentPage")?.textContent
+			}`;
+			presenceData.buttons = [{ label: "Ler capítulo", url: href }];
+			break;
+		}
+
+		case "media": {
+			presenceData.largeImageKey =
+				document.querySelector<HTMLImageElement>(".cover-url")?.src;
+			presenceData.details =
+				document.querySelector(".media-title")?.textContent;
+			presenceData.buttons = [{ label: "Ler mangá", url: href }];
+			break;
+		}
+
+		default:
+			presenceData.details = "Na página inicial...";
+			break;
 	}
 
 	if (presenceData.details) presence.setActivity(presenceData);


### PR DESCRIPTION
## Description 

- New route on the dashboard
- New button in the reader
- Refactored code to "switch case"
- Manga cover in the reader
- News Altnames

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
New button and cover in the reader
![image](https://github.com/PreMiD/Presences/assets/71954875/d68be66b-0d2f-4eb3-a54a-39341265db83)

