### PR TITLE
feat(Doodstreams): add presence

### DIFF
--- a/websites/D/Doodstreams/metadata.json
+++ b/websites/D/Doodstreams/metadata.json
@@ -1,0 +1,25 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.9",
+	"author": {
+		"id": "638080361179512853",
+		"name": "dark_ville"
+	},
+	"service": "Doodstreams",
+	"description": {
+		"en": "Doodstream redefines video sharing with a commitment to unrivaled HLS streaming, unlimited bandwidth and seamless user experience."
+	},
+	"url": "doods.pro",
+	"regExp": "(ww(w)?([0-9])?[.])?dood(s)?[.][a-z]*",
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/e7SBEQM.png",
+	"thumbnail": "https://i.imgur.com/Ny5sYjY.png",
+	"color": "#FF9900",
+	"category": "videos",
+	"tags": [
+		"anime",
+		"video",
+		"stream",
+		"streaming",
+		"sharing"
+	]
+}

--- a/websites/D/Doodstreams/metadata.json
+++ b/websites/D/Doodstreams/metadata.json
@@ -9,7 +9,7 @@
 		"en": "Doodstream redefines video sharing with a commitment to unrivaled HLS streaming, unlimited bandwidth and seamless user experience."
 	},
 	"url": "doods.pro",
-	"regExp": "(ww(w)?([0-9])?[.])?dood(s)?[.][a-z]*",
+	"regExp": "((ww(w)?([0-9])?[.])?dood(s)?[.][a-z]*)|((ww(w)?([0-9])?[.])?doodstream[.][a-z]*([.][a-z]*)?)",
 	"version": "1.0.0",
 	"logo": "https://i.imgur.com/e7SBEQM.png",
 	"thumbnail": "https://i.imgur.com/Ny5sYjY.png",

--- a/websites/D/Doodstreams/metadata.json
+++ b/websites/D/Doodstreams/metadata.json
@@ -6,7 +6,8 @@
 	},
 	"service": "Doodstreams",
 	"description": {
-		"en": "Doodstream redefines video sharing with a commitment to unrivaled HLS streaming, unlimited bandwidth and seamless user experience."
+		"en": "Doodstream redefines video sharing with a commitment to unrivaled HLS streaming, unlimited bandwidth and seamless user experience.",
+		"nl": "Doodstream herdefinieert het delen van video met een toewijding aan ongeëvenaarde HLS streaming, onbeperkte bandbreedte en naadloze gebruikerservaring."
 	},
 	"url": "doods.pro",
 	"regExp": "((ww(w)?([0-9])?[.])?dood(s)?[.][a-z]*)|((ww(w)?([0-9])?[.])?doodstream[.][a-z]*([.][a-z]*)?)",

--- a/websites/D/Doodstreams/presence.ts
+++ b/websites/D/Doodstreams/presence.ts
@@ -3,8 +3,8 @@ const presence = new Presence({
 	}),
 	browsingTimestamp = Math.round(Date.now() / 1000),
 	strings = presence.getStrings({
-		play: "presence.playback.playing",
-		pause: "presence.playback.paused",
+		play: "general.playing",
+		pause: "general.paused",
 	});
 
 presence.on("UpdateData", async () => {

--- a/websites/D/Doodstreams/presence.ts
+++ b/websites/D/Doodstreams/presence.ts
@@ -1,0 +1,35 @@
+const presence = new Presence({
+		clientId: "1190374591995060234",
+	}),
+	browsingTimestamp = Math.round(Date.now() / 1000),
+	strings = presence.getStrings({
+		play: "presence.playback.playing",
+		pause: "presence.playback.paused",
+	});
+
+presence.on("UpdateData", async () => {
+	const presenceData: PresenceData = {
+			startTimestamp: browsingTimestamp,
+			largeImageKey: "https://i.imgur.com/e7SBEQM.png",
+		},
+		{ pathname } = document.location,
+		video = document.querySelector<HTMLVideoElement>("video"),
+		title = document.querySelector("title")?.textContent;
+
+	if (pathname.includes("/e/")) {
+		delete presenceData.startTimestamp;
+		presenceData.details = title?.split(" S0")?.[0] ?? title;
+		presenceData.state = title?.match(/S[0-9]*E[0-9]* /gm)?.[0];
+
+		if (!isNaN(video?.duration)) {
+			if (!video.paused)
+				[, presenceData.endTimestamp] = presence.getTimestampsfromMedia(video);
+			presenceData.smallImageKey = video.paused ? Assets.Pause : Assets.Play;
+			presenceData.smallImageText = video.paused
+				? (await strings).pause
+				: (await strings).play;
+		}
+	}
+
+	presence.setActivity(presenceData);
+});


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
- Added presence for doodstreams (since some series/movies/anime websites now just send you to video hosting sites like doodstreams. E.g. s.to & aniworld.to)
## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

<img src="https://github.com/PreMiD/Presences/assets/42322979/0c3ba2a8-375b-43d5-8d5f-f22a85300518">
<img src="https://github.com/PreMiD/Presences/assets/42322979/a75208c0-153d-47f1-afd6-9ad264ad6711">
<img src="https://github.com/PreMiD/Presences/assets/42322979/12827821-090d-480a-9676-a20989919a43">
<img src="https://github.com/PreMiD/Presences/assets/42322979/72e687a0-495d-473a-957d-b3084ab9c853">

</details>
