### PR TITLE
feat(Vidoza): add presence

### DIFF
--- a/websites/V/Vidoza/metadata.json
+++ b/websites/V/Vidoza/metadata.json
@@ -6,7 +6,8 @@
 	},
 	"service": "Vidoza",
 	"description": {
-		"en": "Absolutely free video hosting and streaming. Share your videos without any limitations via a HTML5 video player."
+		"en": "Absolutely free video hosting and streaming. Share your videos without any limitations via a HTML5 video player.",
+		"nl": "Volledig gratis video's hosten en steamen. Deel jouw video's zonder enige beperkingen via een HTML5 video speler."
 	},
 	"url": "vidoza.net",
 	"regExp": "(ww(w)?([0-9])?[.])?vidoza[.][a-z]*",

--- a/websites/V/Vidoza/metadata.json
+++ b/websites/V/Vidoza/metadata.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.9",
+	"author": {
+		"id": "638080361179512853",
+		"name": "dark_ville"
+	},
+	"service": "Vidoza",
+	"description": {
+		"en": "Absolutely free video hosting and streaming. Share your videos without any limitations via a HTML5 video player."
+	},
+	"url": "vidoza.net",
+	"regExp": "(ww(w)?([0-9])?[.])?vidoza[.][a-z]*",
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/y23NjvR.png",
+	"thumbnail": "https://i.imgur.com/mYpatQ2.png",
+	"color": "#43A047",
+	"category": "videos",
+	"tags": ["anime", "video", "stream", "streaming", "sharing"]
+}

--- a/websites/V/Vidoza/presence.ts
+++ b/websites/V/Vidoza/presence.ts
@@ -1,0 +1,42 @@
+const presence = new Presence({
+		clientId: "1191396494381694976",
+	}),
+	browsingTimestamp = Math.round(Date.now() / 1000),
+	strings = presence.getStrings({
+		play: "general.playing",
+		pause: "general.paused",
+	});
+
+presence.on("UpdateData", async () => {
+	const presenceData: PresenceData = {
+			startTimestamp: browsingTimestamp,
+			largeImageKey: "https://i.imgur.com/y23NjvR.png",
+		},
+		{ pathname } = document.location,
+		video = document.querySelector<HTMLVideoElement>("video");
+
+	if (pathname.includes("embed-")) {
+		delete presenceData.startTimestamp;
+		const el = document
+				.querySelector(".body-container")
+				.querySelectorAll('[type="text/javascript"]'),
+			title = el[el.length - 1].innerHTML
+				.split("var curFileName =")?.[1]
+				?.replace(/([.])/gm, " ")
+				.replace('"', "");
+
+		presenceData.details = title?.split(" S0")?.[0] ?? title;
+		presenceData.state = title?.match(/S[0-9]*E[0-9]* /gm)?.[0];
+
+		if (!isNaN(video?.duration)) {
+			if (!video.paused)
+				[, presenceData.endTimestamp] = presence.getTimestampsfromMedia(video);
+			presenceData.smallImageKey = video.paused ? Assets.Pause : Assets.Play;
+			presenceData.smallImageText = video.paused
+				? (await strings).pause
+				: (await strings).play;
+		}
+	}
+
+	presence.setActivity(presenceData);
+});


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
- Added presence for vidoza (since some series/movies/anime websites now just send you to video hosting sites like vidoza. E.g. s.to & aniworld.to)
## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

<img src="https://github.com/PreMiD/Presences/assets/42322979/71a18e50-4b98-4a56-9a7f-b3a35e94a9c3">


</details>
