### PR TITLE
feat(KEXP): add presence

### DIFF
--- a/websites/K/KEXP/metadata.json
+++ b/websites/K/KEXP/metadata.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.9",
+	"author": {
+		"id": "408039555296395264",
+		"name": "indium."
+	},
+	"service": "KEXP",
+	"description": {
+		"en": "Digging indie gems & underground bangers? KEXP Seattle's your radio refuge.  DJs handpick a global mixtape, from garage rock to dream pop, all spun with heart and Seattle swagger. Tune in and discover your next obsession! ✨",
+		"es": "¿Te cansa la misma música aburrida? KEXP Seattle es tu nuevo refugio sonoro. DJs expertos te preparan una mezcla global, desde garage rock hasta dream pop, con todo el corazón y la onda de Seattle. ¡Sintoniza y descubre tu próxima obsesión! ✨"
+	},
+	"url": [
+		"www.kexp.org",
+		"kexp.org"
+	],
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/Ywk7b7q.png",
+	"thumbnail": "https://i.imgur.com/GJT7mBf.png",
+	"color": "#fbab2c",
+	"category": "music",
+	"tags": [
+		"radio",
+		"music",
+		"kexp",
+		"seattle"
+	]
+}

--- a/websites/K/KEXP/presence.ts
+++ b/websites/K/KEXP/presence.ts
@@ -1,0 +1,75 @@
+const presence = new Presence({ clientId: "1138970637440917504" }),
+	browsingTimestamp = Math.floor(Date.now() / 1000),
+	defaultImageUrl = "https://i.imgur.com/Ywk7b7q.png",
+	watchPaths = ["/archive/", "/podcasts/", "/shows/", "/djs/", "/schedule/"];
+
+async function updatePresence() {
+	const strings = await presence.getStrings({
+			pause: "general.paused",
+			play: "general.playing",
+			profile: "general.readingAbout",
+			reading: "general.readingAnArticle",
+			watching: "general.watching",
+		}),
+		currentPagePath = document.location.pathname,
+		presenceData: PresenceData = {
+			startTimestamp: browsingTimestamp,
+			largeImageKey: defaultImageUrl,
+		};
+
+	function setDetails(detailsKey: keyof typeof strings, imageKey: string) {
+		presenceData.details = strings[detailsKey];
+		presenceData.smallImageKey = imageKey;
+		presenceData.smallImageText = strings[detailsKey];
+	}
+
+	switch (true) {
+		case watchPaths.includes(currentPagePath):
+			setDetails("watching", Assets.Viewing);
+			presenceData.state = document.querySelector(".InlineMenu-current");
+			break;
+
+		case ["/podcasts/", "/shows/"].some(path =>
+			currentPagePath.startsWith(path)
+		):
+			setDetails("reading", Assets.Reading);
+			presenceData.state = document.querySelector("h1")?.textContent;
+			break;
+
+		case currentPagePath.startsWith("/djs/"):
+			setDetails("profile", Assets.Reading);
+			presenceData.state = document.querySelector("h3")?.textContent;
+			break;
+
+		default: {
+			const coverImage = document
+				.querySelector(".Player-coverImage")
+				?.getAttribute("src");
+
+			presenceData.details =
+				document.querySelector("a.Player-show")?.textContent;
+			presenceData.largeImageKey = coverImage?.startsWith("https://")
+				? coverImage
+				: defaultImageUrl;
+			presenceData.state =
+				document.querySelector("div.Player-title")?.textContent;
+
+			const playBackStatus = document.querySelector("button.Player-ctaButton");
+			if (playBackStatus) {
+				presenceData.smallImageKey =
+					playBackStatus.ariaLabel === "Play Stream"
+						? Assets.Pause
+						: Assets.Play;
+				presenceData.smallImageText =
+					strings[
+						playBackStatus.ariaLabel === "Play Stream" ? "pause" : "play"
+					];
+			}
+			break;
+		}
+	}
+
+	presence.setActivity(presenceData);
+}
+
+presence.on("UpdateData", updatePresence);


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

- Add presence for [KEXP](https://kexp.org/)
- The presence updates based on whether the radio is being listened to or not
- The presence image is taken from the cover of the currently playing song; if not available, it uses the station logo
- It includes a button to listen along simultaneously
- If there's no song playing, only the show name is shown
- Given support for the following parts of the page: [archive](https://kexp.org/archive/), [podcasts](https://kexp.org/podcasts/), [shows](https://kexp.org/shows/), [djs](https://kexp.org/djs/), [schedule](https://kexp.org/schedule/)
- Shows information about articles if the user is reading one, take these articles as examples:
  - [50 Years of Hip-Hop](https://kexp.org/podcasts/50-years-of-hip-hop/) under Podcasts
  - [90.TEEN](https://kexp.org/shows/90.-teen/) under Shows
  - [Abbie](https://kexp.org/djs/abbie/) under DJs

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes, thus speeding up the process of the pull request being merged
-->

![image](https://github.com/PreMiD/Presences/assets/86681635/bb573c4f-66b2-4e1b-a866-f6aa1c67a6ee)
![image](https://github.com/PreMiD/Presences/assets/86681635/a85eed6d-ff54-4d6b-bc94-4f9d0279af60)
![image](https://github.com/PreMiD/Presences/assets/86681635/1f344e20-bb97-45d7-a425-20f0f76f5067)
![image](https://github.com/PreMiD/Presences/assets/86681635/df0943c8-3385-46df-a972-c69a3266d0d3)
![image](https://github.com/PreMiD/Presences/assets/86681635/95c685a8-efaf-40b4-8b17-12ba59e28dd1)
![image](https://github.com/PreMiD/Presences/assets/86681635/16f7a55a-ac9c-437a-9ea0-a2bfaeec75be)
![image](https://github.com/PreMiD/Presences/assets/86681635/91271de4-eb6e-4742-bd9e-57e239a26f9c)
![image](https://github.com/PreMiD/Presences/assets/86681635/0803a599-de28-42d0-a5d7-77bd912b7524)


</details>
