### PR TITLE
feat(KEXP): copies and thumbnail improvements

### DIFF
--- a/websites/K/KEXP/metadata.json
+++ b/websites/K/KEXP/metadata.json
@@ -13,9 +13,9 @@
 		"www.kexp.org",
 		"kexp.org"
 	],
-	"version": "1.0.1",
+	"version": "1.1.1",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/K/KEXP/assets/logo.png",
-	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/K/KEXP/assets/thumbnail.png",
+	"thumbnail": "https://i.imgur.com/Ov4YRDM.png",
 	"color": "#fbab2c",
 	"category": "music",
 	"tags": [
@@ -23,5 +23,11 @@
 		"music",
 		"kexp",
 		"seattle"
+	],
+	"settings": [
+		{
+			"id": "lang",
+			"multiLanguage": true
+		}
 	]
 }

--- a/websites/K/KEXP/presence.ts
+++ b/websites/K/KEXP/presence.ts
@@ -1,14 +1,15 @@
 const presence = new Presence({ clientId: "1138970637440917504" }),
 	browsingTimestamp = Math.floor(Date.now() / 1000),
 	defaultImageUrl = "https://cdn.rcd.gg/PreMiD/websites/K/KEXP/assets/logo.png",
-	watchPaths = ["/archive/", "/podcasts/", "/shows/", "/djs/", "/schedule/"];
+	watchPaths = ["/archive/", "/djs/", "/podcasts/", "/schedule/", "/shows/"];
 
 async function updatePresence() {
 	const strings = await presence.getStrings({
+			about: "general.readingAbout",
+			article: "general.readingAnArticle",
 			pause: "general.paused",
 			play: "general.playing",
-			profile: "general.readingAbout",
-			reading: "general.readingAnArticle",
+			searching: "general.searchSomething",
 			watching: "general.watching",
 		}),
 		currentPagePath = document.location.pathname,
@@ -17,28 +18,44 @@ async function updatePresence() {
 			largeImageKey: defaultImageUrl,
 		};
 
-	function setDetails(detailsKey: keyof typeof strings, imageKey: string) {
+	function setDetails(
+		detailsKey: keyof typeof strings,
+		imageKey: string,
+		textKey: keyof typeof strings,
+		selectElement: string
+	) {
 		presenceData.details = strings[detailsKey];
 		presenceData.smallImageKey = imageKey;
-		presenceData.smallImageText = strings[detailsKey];
+		presenceData.smallImageText = strings[textKey];
+		presenceData.state = document.querySelector(selectElement)?.textContent;
 	}
 
 	switch (true) {
 		case watchPaths.includes(currentPagePath):
-			setDetails("watching", Assets.Viewing);
-			presenceData.state = document.querySelector(".InlineMenu-current");
-			break;
-
-		case ["/podcasts/", "/shows/"].some(path =>
-			currentPagePath.startsWith(path)
-		):
-			setDetails("reading", Assets.Reading);
-			presenceData.state = document.querySelector("h1")?.textContent;
+			setDetails(
+				"watching",
+				Assets.Viewing,
+				"searching",
+				".InlineMenu-current"
+			);
 			break;
 
 		case currentPagePath.startsWith("/djs/"):
-			setDetails("profile", Assets.Reading);
-			presenceData.state = document.querySelector("h3")?.textContent;
+			setDetails("about", Assets.Reading, "article", "h3");
+			break;
+
+		case currentPagePath.startsWith("/podcasts/"):
+			setDetails("article", Assets.Reading, "article", "h1");
+			break;
+
+		case currentPagePath.startsWith("/read/") &&
+			/^\/read\/\d{4}\/\d{1,2}\/\d{1,2}\/[\w-]+\/?$/.test(currentPagePath): {
+			setDetails("about", Assets.Reading, "article", "h1");
+			break;
+		}
+
+		case currentPagePath.startsWith("/shows/"):
+			setDetails("about", Assets.Reading, "article", "h1");
 			break;
 
 		default: {


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

- Changed the thumbnail in the hopes of making it look better on the store.
- Multilingual support.
- Changed the copies for the `smallImageText` in some cases, since I was using the same copy for the `details` and `smallImageText`, which in some cases doesn't look good (e.g.`Viewing:` as `smallImageText`).
- Made a little refactor for the `setDetails` function to avoid using the `document.querySelector` on every case statement.
- Added support for the articles under the `/read/` route.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://github.com/PreMiD/Presences/assets/86681635/8320bcb3-051c-4baf-b0ef-2fba299f29fb)

![image](https://github.com/PreMiD/Presences/assets/86681635/d00d128d-9e68-4597-80e4-079ef2999e5a)

![image](https://github.com/PreMiD/Presences/assets/86681635/968074f0-fb4d-4fb8-89d4-335249f17dbd)

![image](https://github.com/PreMiD/Presences/assets/86681635/bac632c7-d68c-43cd-80d6-a7edf7d7ff1e)

In Spanish:

![image](https://github.com/PreMiD/Presences/assets/86681635/7dc54e32-2a61-4c2f-9656-687aac03dc96)

![image](https://github.com/PreMiD/Presences/assets/86681635/2c7cfc3e-d720-41a4-a692-ec648db994b4)

![image](https://github.com/PreMiD/Presences/assets/86681635/7b6b63c1-3e5c-4206-ac34-91ab3833633c)

![image](https://github.com/PreMiD/Presences/assets/86681635/e0134c65-8eec-4380-9782-bc6f39a9d00f)

</details>
