### PR TITLE
feat(SoundCloud): add hide when paused

### DIFF
--- a/websites/S/SoundCloud/metadata.json
+++ b/websites/S/SoundCloud/metadata.json
@@ -53,6 +53,12 @@
 			"value": true
 		},
 		{
+			"id": "hidePaused",
+			"title": "Hide while paused",
+			"icon": "fas fa-pause",
+			"value": false
+		},
+		{
 			"id": "timestamp",
 			"title": "Show Timestamps",
 			"icon": "fas fa-clock",

--- a/websites/S/SoundCloud/metadata.json
+++ b/websites/S/SoundCloud/metadata.json
@@ -26,7 +26,7 @@
 		"vi_VN": "SoundCloud là nền tảng phát nhạc và podcast trực tuyến nơi bạn có thể nghe hàng triệu bài hát từ khắp thế giới, hoặc tự đăng tải tác phẩm của riêng mình."
 	},
 	"url": "soundcloud.com",
-	"version": "2.4.7",
+	"version": "2.4.8",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/S/SoundCloud/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/S/SoundCloud/assets/thumbnail.jpg",
 	"color": "#FF7E30",

--- a/websites/S/SoundCloud/presence.ts
+++ b/websites/S/SoundCloud/presence.ts
@@ -129,9 +129,8 @@ presence.on("UpdateData", async () => {
 		strings = await getStrings();
 	}
 
-	if (showSong && (hidePaused && !playing) && !showBrowsing) {
+	if (showSong && (hidePaused && !playing) && !showBrowsing)
 		return presence.clearActivity();
-	}
 
 	let presenceData: PresenceData = {
 		largeImageKey:
@@ -266,7 +265,7 @@ presence.on("UpdateData", async () => {
 		}
 	}
 
-	if (presenceData.details && typeof presenceData.details == 'string') {
+	if (presenceData.details && typeof presenceData.details === "string") {
 		if (presenceData.details.match("(Browsing|Viewing|Discovering)")) {
 			presenceData.smallImageKey = Assets.Reading;
 			presenceData.smallImageText = strings.browse;

--- a/websites/S/SoundCloud/presence.ts
+++ b/websites/S/SoundCloud/presence.ts
@@ -112,16 +112,23 @@ const statics = {
 
 presence.on("UpdateData", async () => {
 	const path = location.pathname.replace(/\/?$/, "/"),
-		[showBrowsing, showSong, hidePaused, showTimestamps, showCover, showButtons, newLang] =
-			await Promise.all([
-				presence.getSetting<boolean>("browse"),
-				presence.getSetting<boolean>("song"),
-				presence.getSetting<boolean>("hidePaused"),
-				presence.getSetting<boolean>("timestamp"),
-				presence.getSetting<boolean>("cover"),
-				presence.getSetting<boolean>("buttons"),
-				presence.getSetting<string>("lang").catch(() => "en"),
-			]),
+		[
+			showBrowsing,
+			showSong,
+			hidePaused,
+			showTimestamps,
+			showCover,
+			showButtons,
+			newLang,
+		] = await Promise.all([
+			presence.getSetting<boolean>("browse"),
+			presence.getSetting<boolean>("song"),
+			presence.getSetting<boolean>("hidePaused"),
+			presence.getSetting<boolean>("timestamp"),
+			presence.getSetting<boolean>("cover"),
+			presence.getSetting<boolean>("buttons"),
+			presence.getSetting<string>("lang").catch(() => "en"),
+		]),
 		playing = Boolean(document.querySelector(".playControls__play.playing"));
 
 	if (oldLang !== newLang || !strings) {
@@ -129,7 +136,7 @@ presence.on("UpdateData", async () => {
 		strings = await getStrings();
 	}
 
-	if (showSong && (hidePaused && !playing) && !showBrowsing)
+	if (showSong && hidePaused && !playing && !showBrowsing)
 		return presence.clearActivity();
 
 	let presenceData: PresenceData = {
@@ -283,3 +290,4 @@ presence.on("UpdateData", async () => {
 		presence.setActivity(presenceData);
 	} else presence.setActivity();
 });
+

--- a/websites/S/SoundCloud/presence.ts
+++ b/websites/S/SoundCloud/presence.ts
@@ -290,4 +290,3 @@ presence.on("UpdateData", async () => {
 		presence.setActivity(presenceData);
 	} else presence.setActivity();
 });
-

--- a/websites/S/SoundCloud/presence.ts
+++ b/websites/S/SoundCloud/presence.ts
@@ -112,10 +112,11 @@ const statics = {
 
 presence.on("UpdateData", async () => {
 	const path = location.pathname.replace(/\/?$/, "/"),
-		[showBrowsing, showSong, showTimestamps, showCover, showButtons, newLang] =
+		[showBrowsing, showSong, hidePaused, showTimestamps, showCover, showButtons, newLang] =
 			await Promise.all([
 				presence.getSetting<boolean>("browse"),
 				presence.getSetting<boolean>("song"),
+				presence.getSetting<boolean>("hidePaused"),
 				presence.getSetting<boolean>("timestamp"),
 				presence.getSetting<boolean>("cover"),
 				presence.getSetting<boolean>("buttons"),
@@ -126,6 +127,10 @@ presence.on("UpdateData", async () => {
 	if (oldLang !== newLang || !strings) {
 		oldLang = newLang;
 		strings = await getStrings();
+	}
+
+	if (showSong && (hidePaused && !playing) && !showBrowsing) {
+		return presence.clearActivity();
 	}
 
 	let presenceData: PresenceData = {
@@ -261,7 +266,7 @@ presence.on("UpdateData", async () => {
 		}
 	}
 
-	if (presenceData.details) {
+	if (presenceData.details && typeof presenceData.details == 'string') {
 		if (presenceData.details.match("(Browsing|Viewing|Discovering)")) {
 			presenceData.smallImageKey = Assets.Reading;
 			presenceData.smallImageText = strings.browse;


### PR DESCRIPTION
## Description 
- Add toggle to chose whether presence is hidden when nothing is playing and browsing status is disabled
- Fix TS2339 'string | Node' (line 269)

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<image src="https://github.com/PreMiD/Presences/assets/150862116/6cc30dab-eb9a-45fa-a122-bc06e79dc9a2">


Active playback:
<image src="https://github.com/PreMiD/Presences/assets/150862116/0ea4fab3-edac-4a8d-a5ef-f307f15ef041">
Inactive playback - 'hide while paused' enabled, 'browsing status' disabled
<image src="https://github.com/PreMiD/Presences/assets/150862116/827e0f5e-621b-4aa9-af5e-43aaee95dacd">
Inactive playback - 'hide while paused' enabled, 'browsing status' enabled
<image src="https://github.com/PreMiD/Presences/assets/150862116/9c94c09b-5614-4654-84e9-dd4a669511fc">
</details>
