### PR TITLE
fix(YouTube): remove shorts cache

### DIFF
--- a/websites/Y/YouTube/metadata.json
+++ b/websites/Y/YouTube/metadata.json
@@ -75,7 +75,7 @@
 		"www.youtube.com",
 		"studio.youtube.com"
 	],
-	"version": "5.8.0",
+	"version": "5.8.1",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/thumbnail.jpg",
 	"color": "#E40813",

--- a/websites/Y/YouTube/presence.ts
+++ b/websites/Y/YouTube/presence.ts
@@ -71,16 +71,15 @@ presence.on("UpdateData", async () => {
 
 	if (video) {
 		const resolver = [
-			youtubeEmbedResolver,
-			youtubeShortsResolver,
-			youtubeOldResolver,
-			youtubeTVResolver,
-			youtubeResolver,
-			youtubeMoviesResolver,
-			nullResolver,
-		].find(resolver => resolver.isActive());
-
-		const title = resolver.getTitle(),
+				youtubeEmbedResolver,
+				youtubeShortsResolver,
+				youtubeOldResolver,
+				youtubeTVResolver,
+				youtubeResolver,
+				youtubeMoviesResolver,
+				nullResolver,
+			].find(resolver => resolver.isActive()),
+			title = resolver.getTitle(),
 			uploaderName = resolver.getUploader();
 
 		let pfp: string;

--- a/websites/Y/YouTube/presence.ts
+++ b/websites/Y/YouTube/presence.ts
@@ -1,8 +1,5 @@
 import youtubeOldResolver from "./video_sources/old";
-import youtubeShortsResolver, {
-	cacheShortData,
-	getCache as getShortsCache,
-} from "./video_sources/shorts";
+import youtubeShortsResolver from "./video_sources/shorts";
 import youtubeEmbedResolver from "./video_sources/embed";
 import youtubeMoviesResolver from "./video_sources/movies";
 import youtubeTVResolver from "./video_sources/tv";
@@ -35,6 +32,7 @@ const nullResolver: Resolver = {
 	isActive: () => true,
 	getTitle: () => document.title,
 	getUploader: () => "",
+	getChannelURL: () => "",
 };
 
 presence.on("UpdateData", async () => {
@@ -81,8 +79,6 @@ presence.on("UpdateData", async () => {
 			youtubeMoviesResolver,
 			nullResolver,
 		].find(resolver => resolver.isActive());
-		if (resolver === youtubeShortsResolver)
-			await cacheShortData(hostname, pathname.split("/shorts/")[1]);
 
 		const title = resolver.getTitle(),
 			uploaderName = resolver.getUploader();
@@ -228,11 +224,7 @@ presence.on("UpdateData", async () => {
 				},
 				{
 					label: strings.viewChannelButton,
-					url:
-						getShortsCache()?.channelURL ??
-						document.querySelector<HTMLLinkElement>(
-							"#top-row ytd-video-owner-renderer > a"
-						)?.href,
+					url: resolver.getChannelURL(),
 				},
 			];
 		}

--- a/websites/Y/YouTube/util/index.ts
+++ b/websites/Y/YouTube/util/index.ts
@@ -16,6 +16,7 @@ export interface Resolver {
 	isActive(): boolean;
 	getTitle(): string;
 	getUploader(): string;
+	getChannelURL(): string;
 }
 
 const stringMap = {

--- a/websites/Y/YouTube/util/pvPrivacyUI.ts
+++ b/websites/Y/YouTube/util/pvPrivacyUI.ts
@@ -23,7 +23,7 @@ export function pvPrivacyUI(
 	videoId: string,
 	privacyTtl: number
 ): boolean {
-	let perVideoPrivacy = false;
+	let perVideoPrivacy = true;
 	const isVideoInArray = (videoId: string, array: VPArray) => {
 		return array.some(entry => entry.videoId === videoId);
 	};

--- a/websites/Y/YouTube/video_sources/default.ts
+++ b/websites/Y/YouTube/video_sources/default.ts
@@ -22,10 +22,17 @@ function getUploader(): string {
 	);
 }
 
+export function getChannelURL(): string {
+	return document.querySelector<HTMLLinkElement>(
+		"#top-row ytd-video-owner-renderer > a"
+	)?.href;
+}
+
 const resolver: Resolver = {
 	isActive,
 	getTitle,
 	getUploader,
+	getChannelURL,
 };
 
 export default resolver;

--- a/websites/Y/YouTube/video_sources/embed.ts
+++ b/websites/Y/YouTube/video_sources/embed.ts
@@ -1,4 +1,5 @@
 import { Resolver } from "../util";
+import { getChannelURL } from "./default";
 
 function isActive(): boolean {
 	return document.location.pathname.includes("/embed");
@@ -23,6 +24,7 @@ const resolver: Resolver = {
 	isActive,
 	getTitle,
 	getUploader,
+	getChannelURL,
 };
 
 export default resolver;

--- a/websites/Y/YouTube/video_sources/movies.ts
+++ b/websites/Y/YouTube/video_sources/movies.ts
@@ -1,4 +1,5 @@
 import { Resolver } from "../util";
+import { getChannelURL } from "./default";
 
 function isActive(): boolean {
 	return !!getTitle() && !!getUploader();
@@ -23,6 +24,7 @@ const resolver: Resolver = {
 	isActive,
 	getTitle,
 	getUploader,
+	getChannelURL,
 };
 
 export default resolver;

--- a/websites/Y/YouTube/video_sources/old.ts
+++ b/websites/Y/YouTube/video_sources/old.ts
@@ -1,4 +1,5 @@
 import { Resolver } from "../util";
+import { getChannelURL } from "./default";
 
 function isActive(): boolean {
 	return (
@@ -19,6 +20,7 @@ const resolver: Resolver = {
 	isActive,
 	getTitle,
 	getUploader,
+	getChannelURL,
 };
 
 export default resolver;

--- a/websites/Y/YouTube/video_sources/shorts.ts
+++ b/websites/Y/YouTube/video_sources/shorts.ts
@@ -5,9 +5,12 @@ function isActive(): boolean {
 }
 
 function getTitle(): string {
-	return document
-		.querySelector('[class="ytp-title-link yt-uix-sessionlink"]')
-		?.textContent.trim();
+	return (
+		getShortsElement()
+			?.closest("ytd-reel-player-header-renderer")
+			.querySelector(".title")
+			?.textContent.trim() || "Loading..."
+	);
 }
 
 function getShortsElement(): HTMLElement {
@@ -27,6 +30,7 @@ function getShortsElement(): HTMLElement {
 
 function getUploader(): string {
 	const closest = getShortsElement();
+	if (!closest?.textContent) return "";
 	return `${closest
 		?.querySelector("a")
 		?.getAttribute("href")

--- a/websites/Y/YouTube/video_sources/shorts.ts
+++ b/websites/Y/YouTube/video_sources/shorts.ts
@@ -10,60 +10,41 @@ function getTitle(): string {
 		?.textContent.trim();
 }
 
+function getShortsElement(): HTMLElement {
+	return (
+		document
+			.querySelector("video")
+			?.closest("ytd-reel-video-renderer")
+			?.querySelector(
+				"yt-formatted-string#text.style-scope.ytd-channel-name"
+			) ??
+		document
+			.querySelectorAll("video")[1]
+			?.closest("ytd-reel-video-renderer")
+			?.querySelector("yt-formatted-string#text.style-scope.ytd-channel-name")
+	);
+}
+
 function getUploader(): string {
-	return cached?.uploader;
+	const closest = getShortsElement();
+	return `${closest
+		?.querySelector("a")
+		?.getAttribute("href")
+		?.replace("/", "")
+		?.replace("@", "")} (${closest?.textContent})`;
 }
 
-function delay(ms: number): Promise<void> {
-	return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-interface Cache {
-	id: string;
-	uploader: string;
-	channelURL: string;
-}
-
-let cached: Cache;
-export async function cacheShortData(
-	hostname: string,
-	shortsPath: string
-): Promise<Cache> {
-	if (!cached?.id || cached.id !== shortsPath) {
-		await delay(300);
-		const closest =
-			document
-				.querySelector("video")
-				?.closest("ytd-reel-video-renderer")
-				?.querySelector(
-					"yt-formatted-string#text.style-scope.ytd-channel-name"
-				) ??
-			document
-				.querySelectorAll("video")[1]
-				?.closest("ytd-reel-video-renderer")
-				?.querySelector(
-					"yt-formatted-string#text.style-scope.ytd-channel-name"
-				);
-		cached = {
-			id: shortsPath,
-			uploader: `${closest
-				?.querySelector("a")
-				?.getAttribute("href")
-				?.replace("/", "")
-				?.replace("@", "")} (${closest?.textContent})`,
-			channelURL: `https://${hostname}/${closest?.textContent}`,
-		};
-		return cached;
-	} else return cached;
-}
-export function getCache(): Cache {
-	return cached;
+function getChannelURL(): string {
+	return `https://${document.location.hostname}/${
+		getShortsElement()?.textContent
+	}`;
 }
 
 const resolver: Resolver = {
 	isActive,
 	getTitle,
 	getUploader,
+	getChannelURL,
 };
 
 export default resolver;

--- a/websites/Y/YouTube/video_sources/tv.ts
+++ b/websites/Y/YouTube/video_sources/tv.ts
@@ -1,4 +1,5 @@
 import { Resolver, truncateAfter } from "../util";
+import { getChannelURL } from "./default";
 
 function isActive(): boolean {
 	return !!document.querySelector(".player-video-title");
@@ -20,6 +21,7 @@ const resolver: Resolver = {
 	isActive,
 	getTitle,
 	getUploader,
+	getChannelURL,
 };
 
 export default resolver;


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
* Removes the shorts cache and uses different selectors and checks to retrieve the current title/user
* Adds a method to resolvers for fetching channel urls
* Fixes #7934 

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->


![image](https://github.com/PreMiD/Presences/assets/32113157/bae40c0e-76a8-40a4-8fef-90a9ed997784)
![image](https://github.com/PreMiD/Presences/assets/32113157/744599d3-f75c-433c-8d4f-971486157787)



</details>
