### PR TITLE
fix(YouTube/pvPrivacyUI): stop privacy ui from blocking interactions

### DIFF
--- a/websites/Y/YouTube/metadata.json
+++ b/websites/Y/YouTube/metadata.json
@@ -75,7 +75,7 @@
 		"www.youtube.com",
 		"studio.youtube.com"
 	],
-	"version": "5.8.2",
+	"version": "5.8.3",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/thumbnail.jpg",
 	"color": "#E40813",

--- a/websites/Y/YouTube/util/pvPrivacyUI.ts
+++ b/websites/Y/YouTube/util/pvPrivacyUI.ts
@@ -84,6 +84,7 @@ export function pvPrivacyUI(
 			parent.appendChild(button);
 			parent.appendChild(tooltip);
 			tooltip.style.opacity = "0";
+			tooltip.style.pointerEvents = "none";
 			tooltip.style.position = "absolute";
 			tooltip.style.padding = "5px";
 			tooltip.style.borderRadius = "5px";


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
* Makes the hover text ignore pointer events, no longer blocking interaction with the title behind it.
* Fixes #7977 

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/PreMiD/Presences/assets/32113157/860d7444-4900-455f-97c4-9425d9491366)
![image](https://github.com/PreMiD/Presences/assets/32113157/111ecf2f-296b-4126-b38b-3766d81df667)


</details>
