### PR TITLE
feat(BeatLeader): add OST blob images support

### DIFF
--- a/websites/B/BeatLeader/iframe.ts
+++ b/websites/B/BeatLeader/iframe.ts
@@ -1,15 +1,27 @@
 const iframe = new iFrame();
+function blobToDataURL(blob: Blob, callback: (dataurl: string) => void) {
+	const reader = new FileReader();
+	reader.onload = function (e) {
+		callback(e.target.result.toString());
+	};
+	reader.readAsDataURL(blob);
+}
 
 if (document.location.href.includes("https://replay.beatleader.xyz")) {
 	iframe.on("UpdateData", async () => {
-		iframe.send({
-			name: document.querySelector("#songName")?.textContent,
-			subName: document.querySelector("#songSubName")?.textContent,
-			currentTime: document.querySelector("#songProgress")?.textContent,
-			playing: Boolean(document.querySelector(".btn.pause")),
-			duration: document.querySelector("#songDuration")?.textContent,
-			playerName: document.querySelector("#playerName")?.textContent,
-			cover: document.querySelector<HTMLImageElement>("#songImage").src,
+		const blob = await fetch(
+			document.querySelector<HTMLImageElement>("#songImage").src
+		).then(response => response.blob());
+		blobToDataURL(blob, function (dataurl: string) {
+			iframe.send({
+				name: document.querySelector("#songName")?.textContent,
+				subName: document.querySelector("#songSubName")?.textContent,
+				currentTime: document.querySelector("#songProgress")?.textContent,
+				playing: Boolean(document.querySelector(".btn.pause")),
+				duration: document.querySelector("#songDuration")?.textContent,
+				playerName: document.querySelector("#playerName")?.textContent,
+				cover: dataurl,
+			});
 		});
 	});
 }

--- a/websites/B/BeatLeader/metadata.json
+++ b/websites/B/BeatLeader/metadata.json
@@ -14,8 +14,8 @@
 		"replay.beatleader.xyz",
 		"royale.beatleader.xyz"
 	],
-	"regExp": ".+\\.beatleader.xyz",
-	"version": "1.6.0",
+	"regExp": ".+\\.beatleader\\.(?:xyz)|(?:net)",
+	"version": "1.7.0",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/thumbnail.png",
 	"color": "#c81c9f",

--- a/websites/B/BeatLeader/presence.ts
+++ b/websites/B/BeatLeader/presence.ts
@@ -230,7 +230,7 @@ presence.on("UpdateData", async () => {
 
 	if (hostname.split(".")[0] === "replay") {
 		presenceData.largeImageKey = cover
-			? document.querySelector<HTMLImageElement>("#songImage").src
+			? document.querySelector<HTMLImageElement>("#songImage")
 			: Assets.Replay;
 		presenceData.details = document.querySelector("#songName").textContent;
 		presenceData.state = document.querySelector("#playerName").textContent;
@@ -259,7 +259,7 @@ presence.on("UpdateData", async () => {
 		];
 	} else if (hostname.split(".")[0] === "royale") {
 		presenceData.largeImageKey = cover
-			? document.querySelector<HTMLImageElement>("#songImage").src
+			? document.querySelector<HTMLImageElement>("#songImage")
 			: Assets.Replay;
 		presenceData.details = document.querySelector("#songName").textContent;
 		presenceData.state = `${
@@ -297,20 +297,27 @@ presence.on("UpdateData", async () => {
 					".player-nickname .nickname"
 				)?.textContent;
 				presenceData.smallImageKey =
-					document.querySelector<HTMLImageElement>(".countryIcon")?.src;
+					document.querySelector<HTMLImageElement>(".countryIcon");
 				if (cover) {
 					presenceData.largeImageKey =
-						document.querySelector<HTMLImageElement>(".avatar")?.src;
+						document.querySelector<HTMLImageElement>(".avatar");
 				}
 				presenceData.buttons = [button];
 				break;
 			}
 			case "leaderboard": {
 				const previewURL = new URL(
-					document.querySelector<HTMLAnchorElement>(
-						'a[href^="https://allpoland.github.io"]'
-					)?.href
-				);
+						document.querySelector<HTMLAnchorElement>(
+							'a[href^="https://allpoland.github.io"]'
+						)?.href ?? "https://allpoland.github.io"
+					),
+					difficulty =
+						previewURL.searchParams.get("difficulty") ??
+						document.querySelector(".primary > span:last-of-type").textContent,
+					mode =
+						previewURL.searchParams.get("mode") ??
+						document.querySelector<HTMLDivElement>(".primary > span > div")
+							?.title;
 				presenceData.details =
 					document.querySelector(".title .name")?.textContent;
 				presenceData.state =
@@ -319,24 +326,14 @@ presence.on("UpdateData", async () => {
 					delete presenceData.smallImageText;
 				if (mapSmallImages !== 3) {
 					presenceData.smallImageText = `${
-						mapSmallImages === 0 || mapSmallImages === 1
-							? previewURL.searchParams.get("mode")
-							: ""
-					} ${
-						mapSmallImages === 0 || mapSmallImages === 2
-							? previewURL.searchParams.get("difficulty").replace("Plus", "+")
-							: ""
-					}`;
+						mapSmallImages === 0 || mapSmallImages === 1 ? mode : ""
+					} ${mapSmallImages === 0 || mapSmallImages === 2 ? difficulty : ""}`;
 					presenceData.smallImageKey =
 						OtherAssets[
 							simplifyKey(
-								`${
-									mapSmallImages === 0 || mapSmallImages === 1
-										? previewURL.searchParams.get("mode")
-										: ""
-								}${
+								`${mapSmallImages === 0 || mapSmallImages === 1 ? mode : ""}${
 									mapSmallImages === 0 || mapSmallImages === 2
-										? previewURL.searchParams.get("difficulty")
+										? difficulty.replace("+", "Plus")
 										: ""
 								}`
 							) as keyof typeof OtherAssets
@@ -344,7 +341,7 @@ presence.on("UpdateData", async () => {
 						OtherAssets[
 							`Unknown${
 								mapSmallImages === 0 || mapSmallImages === 2
-									? previewURL.searchParams.get("difficulty")
+									? difficulty.replace("+", "Plus")
 									: ""
 							}` as keyof typeof OtherAssets
 						];
@@ -366,7 +363,7 @@ presence.on("UpdateData", async () => {
 				presenceData.buttons = [button];
 				if (cover) {
 					presenceData.largeImageKey =
-						document.querySelector<HTMLImageElement>(".event > img")?.src;
+						document.querySelector<HTMLImageElement>(".event > img");
 				}
 				break;
 			}
@@ -376,7 +373,7 @@ presence.on("UpdateData", async () => {
 				presenceData.buttons = [button];
 				if (cover) {
 					presenceData.largeImageKey =
-						document.querySelector<HTMLImageElement>(".clanImage").src;
+						document.querySelector<HTMLImageElement>(".clanImage");
 				}
 				break;
 			}
@@ -388,7 +385,7 @@ presence.on("UpdateData", async () => {
 				if (cover) {
 					presenceData.largeImageKey = document.querySelector<HTMLImageElement>(
 						".content-box .playlistImage"
-					).src;
+					);
 				}
 				presenceData.buttons = [button];
 				break;
@@ -439,6 +436,9 @@ presence.on("UpdateData", async () => {
 			case "followed": {
 				presenceData.details = "Viewing their follows";
 				break;
+			}
+			case "clansmap": {
+				presenceData.details = "Viewing clans map";
 			}
 		}
 		if (

--- a/websites/B/BeatLeader/presence.ts
+++ b/websites/B/BeatLeader/presence.ts
@@ -327,7 +327,11 @@ presence.on("UpdateData", async () => {
 				if (mapSmallImages !== 3) {
 					presenceData.smallImageText = `${
 						mapSmallImages === 0 || mapSmallImages === 1 ? mode : ""
-					} ${mapSmallImages === 0 || mapSmallImages === 2 ? difficulty : ""}`;
+					} ${
+						mapSmallImages === 0 || mapSmallImages === 2
+							? difficulty.replace("Plus", "+")
+							: ""
+					}`;
 					presenceData.smallImageKey =
 						OtherAssets[
 							simplifyKey(


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Pass image element directly into LargeImageKey instead of .src so the covers for OST maps (which are blobs) work
In Iframe.ts send cover as DataURL, because of potential blobs
Updated regExp for URL
Added fallbacks for getting difficulty and mode from leaderboard pages

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![NVIDIA_Share_8X7D8aakTy](https://github.com/PreMiD/Presences/assets/44418429/5bb58418-d9bb-4654-bcf5-c0e212b1d738)
![NVIDIA_Share_eJWdXzdIYW](https://github.com/PreMiD/Presences/assets/44418429/715ffb3b-fae9-4d21-9ad0-b814a01dac88)
![NVIDIA_Share_MGLASnFFJO](https://github.com/PreMiD/Presences/assets/44418429/9e6d2cf6-85b9-48e2-ae1f-e892af8c386f)
![NVIDIA_Share_Qaih7k3VcU](https://github.com/PreMiD/Presences/assets/44418429/d111337a-2676-4486-a0bc-6a1f8674bd8f)
![Discord_shLcZbwtjt](https://github.com/PreMiD/Presences/assets/44418429/ab143518-7178-4bb9-afe5-b5b53cf8b033)



</details>
