### PR TITLE
feat(Jet Set Radio Live): use v2.6 types, images, new stations

### DIFF
--- a/websites/J/Jet Set Radio Live/metadata.json
+++ b/websites/J/Jet Set Radio Live/metadata.json
@@ -19,7 +19,7 @@
 		"jetsetradio.live",
 		"jetsetradiofuture.live"
 	],
-	"version": "2.2.10",
+	"version": "2.3.0",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/J/Jet%20Set%20Radio%20Live/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/J/Jet%20Set%20Radio%20Live/assets/thumbnail.jpg",
 	"color": "#FFE222",

--- a/websites/J/Jet Set Radio Live/presence.ts
+++ b/websites/J/Jet Set Radio Live/presence.ts
@@ -50,14 +50,14 @@ const presence = new Presence({
 		brc: "Bomb Rush Cyberfunk",
 		elaquent: "Elaquent",
 		turntablism: "Turntablism",
-		sonicrush: "Sonic Rush"
+		sonicrush: "Sonic Rush",
 	};
 
 presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
 			type: ActivityType.Listening,
 			largeImageKey:
-				"https://cdn.rcd.gg/PreMiD/websites/J/Jet%20Set%20Radio%20Live/assets/logo.png"
+				"https://cdn.rcd.gg/PreMiD/websites/J/Jet%20Set%20Radio%20Live/assets/logo.png",
 		},
 		audio = document.querySelector<HTMLAudioElement>("#audioPlayer"),
 		songName = document.querySelector(
@@ -65,12 +65,12 @@ presence.on("UpdateData", async () => {
 		),
 		buttons = await presence.getSetting<boolean>("buttons");
 
-	if (songName.textContent.length < 1 || !audio) presenceData.details = "Not tuned in.";
+	if (songName.textContent.length < 1 || !audio)
+		presenceData.details = "Not tuned in.";
 	else {
-		const stationImage = document
-			.querySelector<HTMLImageElement>("#graffitiSoul")
-			.src,
-		 stationName = stationIDMap[stationImage.split("/")[5]];
+		const stationImage =
+				document.querySelector<HTMLImageElement>("#graffitiSoul").src,
+			stationName = stationIDMap[stationImage.split("/")[5]];
 		presenceData.largeImageKey = stationImage;
 		if (stationName) presenceData.state = stationName;
 

--- a/websites/J/Jet Set Radio Live/presence.ts
+++ b/websites/J/Jet Set Radio Live/presence.ts
@@ -39,7 +39,7 @@ const presence = new Presence({
 		toejamandearl: "Toe Jam & Earl",
 		hover: "Hover",
 		butterflies: "Butterflies",
-		lethalleagueblaze: "Lethal League Blace",
+		lethalleagueblaze: "Lethal League Blaze",
 		bonafidebloom: "BonafideBloom",
 		djchidow: "DJ Chidow",
 		verafx: "VeraFX",
@@ -47,12 +47,17 @@ const presence = new Presence({
 		halloween: "Halloween",
 		christmas: "Christmas",
 		snowfi: "Snow-Fi",
+		brc: "Bomb Rush Cyberfunk",
+		elaquent: "Elaquent",
+		turntablism: "Turntablism",
+		sonicrush: "Sonic Rush"
 	};
 
 presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
+			type: ActivityType.Listening,
 			largeImageKey:
-				"https://cdn.rcd.gg/PreMiD/websites/J/Jet%20Set%20Radio%20Live/assets/logo.png",
+				"https://cdn.rcd.gg/PreMiD/websites/J/Jet%20Set%20Radio%20Live/assets/logo.png"
 		},
 		audio = document.querySelector<HTMLAudioElement>("#audioPlayer"),
 		songName = document.querySelector(
@@ -60,16 +65,15 @@ presence.on("UpdateData", async () => {
 		),
 		buttons = await presence.getSetting<boolean>("buttons");
 
-	if (songName.textContent.length < 1 || !audio) {
-		presenceData.details = "Not tuned in.";
-		presenceData.smallImageKey = Assets.Pause;
-		presenceData.smallImageText = (await strings).pause;
-	} else {
-		const stationID = document
+	if (songName.textContent.length < 1 || !audio) presenceData.details = "Not tuned in.";
+	else {
+		const stationImage = document
 			.querySelector<HTMLImageElement>("#graffitiSoul")
-			.src.split("/")[5];
-		presenceData.largeImageKey = stationID;
-		presenceData.state = stationIDMap[stationID];
+			.src,
+		 stationName = stationIDMap[stationImage.split("/")[5]];
+		presenceData.largeImageKey = stationImage;
+		if (stationName) presenceData.state = stationName;
+
 		if (
 			!audio.paused &&
 			!document.querySelector('#loadingTrackCircle:not([style*="hidden"])')


### PR DESCRIPTION
This PR adds updates to the Jet Set Radio Live presence:
- Use "Listening" type for v2.6
- Use images as large image keys
- Update station names
- Remove "Paused" small image when not tuned in

<details>
<summary>Presence Screenshot</summary>

![DiscordCanary_P7k8Hgh9LG](https://github.com/PreMiD/Presences/assets/7025343/248b33ec-d565-4215-a8be-aca3816d44a2)
![DiscordCanary_ZdHuVCoXFj](https://github.com/PreMiD/Presences/assets/7025343/2d259946-2f4f-4fcb-a03e-62a9e4d2ab63)

</details>