### PR TITLE
fix(AssetsManager): ignore query selector when extracting file extension

### DIFF
--- a/tools/classes/AssetsManager.ts
+++ b/tools/classes/AssetsManager.ts
@@ -48,7 +48,7 @@ export default class AssetsManager {
 	}
 
 	getFileExtension(url: string) {
-		return extname(url);
+		return extname(new URL(url).pathname);
 	}
 
 	async allTsFiles() {


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
* Passes only the pathname to path.extname, rather than the entire url

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)
