### PR TITLE
feat(AniWatch): add aniwatchtv.to proxy

### DIFF
--- a/websites/A/AniWatch/metadata.json
+++ b/websites/A/AniWatch/metadata.json
@@ -8,7 +8,7 @@
 	"description": {
 		"en": "AniWatch.to - A site to watch anime online for Free"
 	},
-	"url": "aniwatch.to",
+	"url": ["aniwatch.to", "aniwatchtv.to"],
 	"version": "1.0.2",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/thumbnail.png",

--- a/websites/A/AniWatch/metadata.json
+++ b/websites/A/AniWatch/metadata.json
@@ -9,7 +9,7 @@
 		"en": "AniWatch.to - A site to watch anime online for Free"
 	},
 	"url": ["aniwatch.to", "aniwatchtv.to"],
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/thumbnail.png",
 	"color": "#ffdd95",


### PR DESCRIPTION
## Description 
In many countries like India, the main domain (aniwatch.to) has been inaccessible for a while. Aniwatchtv.to is an official proxy site that works for now.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary>Proof of working</summary>
Without:
<img src="https://github.com/PreMiD/Presences/assets/69511006/f1d3a4c7-c3ff-4428-ab9c-baebf05994d9">
<br>
With:
<img src="https://github.com/PreMiD/Presences/assets/69511006/3c648e73-592d-43bf-a091-2de83537ad30">
</details>