### PR TITLE
feat(aniwatch): add regex to support alternative domains

### DIFF
--- a/websites/A/AniWatch/metadata.json
+++ b/websites/A/AniWatch/metadata.json
@@ -9,7 +9,7 @@
 		"en": "AniWatch.to - A site to watch anime online for Free"
 	},
 	"url": "aniwatch.to",
-	"regExp": "[aniwatch]?[.]([a-z]+)",
+	"regExp": "aniwatch[a-z]*[.][a-z]{2,3}",
 	"version": "1.0.3",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/thumbnail.png",

--- a/websites/A/AniWatch/metadata.json
+++ b/websites/A/AniWatch/metadata.json
@@ -10,7 +10,7 @@
 	},
 	"url": "aniwatch.to",
 	"regExp": "aniwatch[a-z]*[.][a-z]{2,3}",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/thumbnail.png",
 	"color": "#ffdd95",

--- a/websites/A/AniWatch/metadata.json
+++ b/websites/A/AniWatch/metadata.json
@@ -10,7 +10,7 @@
 	},
 	"url": "aniwatch.to",
 	"regExp": "[aniwatch]?[.]([a-z]+)",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/thumbnail.png",
 	"color": "#ffdd95",

--- a/websites/A/AniWatch/metadata.json
+++ b/websites/A/AniWatch/metadata.json
@@ -9,6 +9,7 @@
 		"en": "AniWatch.to - A site to watch anime online for Free"
 	},
 	"url": "aniwatch.to",
+	"regExp": "[aniwatch]?[.]([a-z]+)",
 	"version": "1.0.2",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/thumbnail.png",


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Add regular expression matching to support alternative domains as the current presence only supports aniwatch.to which is blocked in some countries. The expression matches the string `aniwatch` followed by any prefix to support domains such as [aniwatchtv.to](https://aniwatchtv.to), it also matches any TLD as I personally use [aniwatch.nz](aniwatch.nz).

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

### Before regex update


![image_2024-02-17_10-42-43](https://github.com/PreMiD/Presences/assets/29902952/1a0e6331-ca9e-49d9-9a03-5491ba30cc80)

### After regex update

![image_2024-02-17_10-49-12](https://github.com/PreMiD/Presences/assets/29902952/0eebb68b-75bd-4ce8-a27d-a472c3a1638a)

![image_2024-02-17_10-48-31](https://github.com/PreMiD/Presences/assets/29902952/e8a949cb-5ddb-4333-8ccf-d7b763b41157)


*tested on `aniwatch.nz` and `aniwatchtv.to`*
</details>
