### PR TITLE
fix(MangaLife): use working api for cover

### DIFF
--- a/websites/M/MangaLife/metadata.json
+++ b/websites/M/MangaLife/metadata.json
@@ -16,7 +16,7 @@
 		"manga4life.com"
 	],
 	"regExp": "([a-z0-9]+[.])?manga4life[.]com",
-	"version": "1.0.14",
+	"version": "1.0.15",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/M/MangaLife/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/M/MangaLife/assets/thumbnail.png",
 	"color": "#6cabdf",

--- a/websites/M/MangaLife/presence.ts
+++ b/websites/M/MangaLife/presence.ts
@@ -89,7 +89,7 @@ presence.on("UpdateData", async () => {
 		case path.startsWith("/manga/"):
 			presenceData.largeImageKey =
 				!privacy && cover
-					? `https://cover.nep.li/cover/${path.split("/manga/")[1]}.jpg`
+					? `https://temp.compsci88.com/cover/${path.split("/manga/")[1]}.jpg`
 					: Assets.Logo;
 			presenceData.smallImageKey =
 				!privacy && cover ? Assets.LogoPng : Assets.Search;
@@ -106,7 +106,7 @@ presence.on("UpdateData", async () => {
 		case path.startsWith("/read-online/"):
 			presenceData.largeImageKey =
 				!privacy && cover
-					? `https://cover.nep.li/cover/${
+					? `https://temp.compsci88.com/cover/${
 							path.split("/read-online/")[1].split("-chapter-")[0]
 					  }.jpg`
 					: Assets.Logo;


### PR DESCRIPTION
## Description 
The API used before has been shut down, so the cover no longer works. I've used the one MangaLife currently uses in this PR.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img src="https://github.com/PreMiD/Presences/assets/69511006/ec3d3d6d-5c67-41aa-ae3e-f8d7b8338360">
</details>
