### PR TITLE
fix(TuMangaOnline): add new redirect domain

### DIFF
--- a/websites/T/TuMangaOnline/metadata.json
+++ b/websites/T/TuMangaOnline/metadata.json
@@ -11,7 +11,8 @@
 	},
 	"url": [
 		"lectortmo.com",
-		"tmocommunity.com"
+		"tmocommunity.com",
+		"visortmo.com"
 	],
 	"version": "1.2.19",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/T/TuMangaOnline/assets/logo.png",

--- a/websites/T/TuMangaOnline/metadata.json
+++ b/websites/T/TuMangaOnline/metadata.json
@@ -14,7 +14,7 @@
 		"tmocommunity.com",
 		"visortmo.com"
 	],
-	"version": "1.2.19",
+	"version": "1.2.20",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/T/TuMangaOnline/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/T/TuMangaOnline/assets/thumbnail.png",
 	"color": "#3366cc",

--- a/websites/T/TuMangaOnline/presence.ts
+++ b/websites/T/TuMangaOnline/presence.ts
@@ -10,7 +10,10 @@ presence.on("UpdateData", async () => {
 		startTimestamp: browsingTimestamp,
 	};
 
-	if (document.location.hostname === "lectortmo.com" || document.location.hostname === "visortmo.com") {
+	if (
+		document.location.hostname === "lectortmo.com" ||
+		document.location.hostname === "visortmo.com"
+	) {
 		if (document.location.pathname === "/")
 			presenceData.details = "Browsing...";
 		else if (document.location.pathname.includes("/library/manga/")) {

--- a/websites/T/TuMangaOnline/presence.ts
+++ b/websites/T/TuMangaOnline/presence.ts
@@ -10,7 +10,7 @@ presence.on("UpdateData", async () => {
 		startTimestamp: browsingTimestamp,
 	};
 
-	if (document.location.hostname === "lectortmo.com") {
+	if (document.location.hostname === "lectortmo.com" || document.location.hostname === "visortmo.com") {
 		if (document.location.pathname === "/")
 			presenceData.details = "Browsing...";
 		else if (document.location.pathname.includes("/library/manga/")) {


### PR DESCRIPTION
Closes #7929 

## Description 
Add the new visortmo.com domain. This domain gets redirected from the original domain.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img src="https://github.com/PreMiD/Presences/assets/69511006/63af8647-3613-4203-a076-ec1d5f71e200">
</details>
