### PR TITLE
feat(Tumblr): add support for subdomain profiles

### DIFF
--- a/websites/T/Tumblr/metadata.json
+++ b/websites/T/Tumblr/metadata.json
@@ -11,7 +11,7 @@
 	},
 	"url": "www.tumblr.com",
 	"regExp": "([a-z0-9-]+[.])*tumblr[.]com[/]",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/T/Tumblr/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/T/Tumblr/assets/thumbnail.png",
 	"color": "#395976",

--- a/websites/T/Tumblr/presence.ts
+++ b/websites/T/Tumblr/presence.ts
@@ -176,6 +176,16 @@ presence.on("UpdateData", async () => {
 
 			break;
 		}
+		default: {
+			if (
+				document.querySelector<HTMLMetaElement>('[property="og:type"]')
+					?.content !== "profile"
+			)
+				return;
+			const username = document.querySelector("header h1")?.textContent;
+			presenceData.details = `Viewing user${username ? `: ${username}` : ""}`;
+			break;
+		}
 	}
 
 	if (presenceData.details) presence.setActivity(presenceData);


### PR DESCRIPTION
Closes #7984
## Description 
The existing tumblr presence did not have support for (username).tumblr.com
I have added a simple default case which will check if the page is a profile exactly like the way it is determined in the www.tumblr.com subdomain.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img src="https://github.com/PreMiD/Presences/assets/69511006/fa84722a-9cdb-4a89-8e21-57b6c091a773">
</details>
