### PR TITLE
fix(iHeartRadio): inverse statement determining state

### DIFF
--- a/websites/I/iHeartRadio/metadata.json
+++ b/websites/I/iHeartRadio/metadata.json
@@ -10,7 +10,7 @@
 		"nl": "iHeartRadio is een gratis uitzend-, podcast- en streaming radioplatform dat eigendom is van iHeartMedia, Inc. Het werd opgericht in april 2008."
 	},
 	"url": "www.iheart.com",
-	"version": "1.2.16",
+	"version": "1.2.17",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/I/iHeartRadio/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/I/iHeartRadio/assets/thumbnail.png",
 	"color": "#C42224",

--- a/websites/I/iHeartRadio/presence.ts
+++ b/websites/I/iHeartRadio/presence.ts
@@ -40,7 +40,7 @@ presence.on("UpdateData", async () => {
 		largeImageKey:
 			"https://cdn.rcd.gg/PreMiD/websites/I/iHeartRadio/assets/logo.png",
 	};
-	if (!document.querySelector('[data-test="player-container"]')) {
+	if (document.querySelector('[data-test="player-container"]')) {
 		const playerText = document.querySelector('[data-test="player-text"]');
 		if (
 			!document.querySelector('[data-test="controls-container"]').children[1]


### PR DESCRIPTION
Closes #8056

## Description 
I've inversed the statement that determines whether the user is browsing or playing a radio.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img src="https://github.com/PreMiD/Presences/assets/69511006/b76d486f-852f-4c9a-8078-7edee049d415">
</details>
