### PR TITLE
fix(Otakudesu): use new domain

### DIFF
--- a/websites/O/Otakudesu/metadata.json
+++ b/websites/O/Otakudesu/metadata.json
@@ -11,7 +11,7 @@
 		"id": "Download, nonton dan streaming anime subtitle Indonesia dengan resolusi 240p, 360p, 480p, & 720p dengan format MP4 & MKV bersama dengan batchnya"
 	},
 	"url": "otakudesu.cloud",
-	"version": "2.0.18",
+	"version": "2.0.19",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/O/Otakudesu/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/O/Otakudesu/assets/thumbnail.png",
 	"color": "#ffffff",

--- a/websites/O/Otakudesu/metadata.json
+++ b/websites/O/Otakudesu/metadata.json
@@ -10,7 +10,7 @@
 		"nl": "Download, bekijk en stream anime met Indonesische ondertiteling en met 240p, 360p, 480p en 720p resolutie met MP4-formaat en MKV samen met de batch.",
 		"id": "Download, nonton dan streaming anime subtitle Indonesia dengan resolusi 240p, 360p, 480p, & 720p dengan format MP4 & MKV bersama dengan batchnya"
 	},
-	"url": "otakudesu.cam",
+	"url": "otakudesu.cloud",
 	"version": "2.0.18",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/O/Otakudesu/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/O/Otakudesu/assets/thumbnail.png",


### PR DESCRIPTION
Closes #8014
## Description 
Uses otakudesu.cloud domain, which is redirected to by the original domain otakudesu.cam

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img src="https://github.com/PreMiD/Presences/assets/69511006/32eb8090-cf04-447e-a671-fabf510456b7">
</details>
