### PR TITLE
feat(HBO Max): add regex

### DIFF
--- a/websites/H/HBO Max/metadata.json
+++ b/websites/H/HBO Max/metadata.json
@@ -11,12 +11,11 @@
 		"vi_VN": "Nền tảng phát trực tuyến đem tất cả của HBO với nhiều phim và chương trình truyền hình hơn nữa, thêm các bộ Max Originals."
 	},
 	"url": [
-		"hbomax.com",
 		"www.hbomax.com",
-		"play.hbomax.com",
-		"help.hbomax.com"
+		"www.max.com"
 	],
-	"version": "2.2.8",
+	"regExp": "([a-z]*[.])?(hbo)?max[.]com",
+	"version": "2.2.9",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/H/HBO%20Max/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/H/HBO%20Max/assets/thumbnail.jpg",
 	"color": "#c600ff",


### PR DESCRIPTION
Closes #7371 

## Description 
Adds regExp option to enable all subdomains on domains hbomax.com and max.com

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
In max.com:
<img src="https://github.com/PreMiD/Presences/assets/69511006/ded46e54-492e-433b-ae8d-518b6045f06e">
</details>
