### PR TITLE
feat(Incels.is): add presence

### DIFF
--- a/websites/I/Incels.is/metadata.json
+++ b/websites/I/Incels.is/metadata.json
@@ -14,7 +14,7 @@
 	],
 	"version": "1.0.0",
 	"logo": "https://incels.is/logo/512x512.png",
-	"thumbnail": "https://incels.is/logo/512x512.png",
+	"thumbnail": "https://i.imgur.com/QM5pXgA.png",
 	"color": "#182139",
 	"category": "socials",
 	"tags": [

--- a/websites/I/Incels.is/metadata.json
+++ b/websites/I/Incels.is/metadata.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.premid.app/metadata/1.9",
+	"$schema": "https://schemas.premid.app/metadata/1.10",
 	"author": {
 		"id": "351653707496292353",
 		"name": "ianhell666"
@@ -8,7 +8,10 @@
 	"description": {
 		"en": "Incels.is is a community for men that struggle with or are unable to get into romantic relationships with women despite trying. We welcome men from all walks of life, and from all cultural and racial backgrounds, as long as you are an incel."
 	},
-	"url": ["incels.is", "www.incels.is"],
+	"url": [
+		"incels.is",
+		"www.incels.is"
+	],
 	"version": "1.0.0",
 	"logo": "https://incels.is/logo/512x512.png",
 	"thumbnail": "https://incels.is/logo/512x512.png",

--- a/websites/I/Incels.is/metadata.json
+++ b/websites/I/Incels.is/metadata.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.9",
+	"author": {
+		"id": "351653707496292353",
+		"name": "ianhell666"
+	},
+	"service": "Incels.is",
+	"description": {
+		"en": "Incels.is is a community for men that struggle with or are unable to get into romantic relationships with women despite trying. We welcome men from all walks of life, and from all cultural and racial backgrounds, as long as you are an incel."
+	},
+	"url": ["incels.is", "www.incels.is"],
+	"version": "1.0.0",
+	"logo": "https://incels.is/logo/512x512.png",
+	"thumbnail": "https://incels.is/logo/512x512.png",
+	"color": "#182139",
+	"category": "socials",
+	"tags": [
+		"community",
+		"nsfw"
+	]
+}

--- a/websites/I/Incels.is/presence.ts
+++ b/websites/I/Incels.is/presence.ts
@@ -12,17 +12,10 @@ presence.on("UpdateData", async () => {
 			largeImageKey: Assets.Logo,
 			startTimestamp: browsingTimestamp,
 		},
-		threadTitleElement = document.querySelectorAll(
-			".p-title-value"
-		)[0] as HTMLHeadingElement,
-		threadTitle: string | undefined = threadTitleElement
-			? threadTitleElement.textContent
-			: // eslint-disable-next-line no-undefined
-			  undefined,
-		threadTag =
-			document.querySelector('[class*="label label--custom-"]').textContent ??
-			// eslint-disable-next-line no-undefined
-			undefined,
+		threadTitle = document.querySelector(".p-title-value")?.textContent,
+		threadTag = document.querySelector(
+			'[class*="label label--custom-"]'
+		)?.textContent,
 		{ pathname } = document.location,
 		{ search } = document.location;
 
@@ -83,13 +76,9 @@ presence.on("UpdateData", async () => {
 	else if (pathname.includes("/account/account-details"))
 		presenceData.details = "Pimpin' out the profile";
 	else if (pathname.includes("/members/")) {
-		const selfElement = document.querySelectorAll(
-			".p-navgroup-user-linkText"
-		)[0] as HTMLSpanElement;
 		if (
 			pathname.includes(
-				// eslint-disable-next-line no-undefined
-				selfElement ? selfElement.textContent : undefined
+				document.querySelector(".p-navgroup-user-linkText")?.textContent
 			)
 		)
 			presenceData.details = "Looking at self with disgust";
@@ -108,12 +97,12 @@ presence.on("UpdateData", async () => {
 		presenceData.details = "Talking to like-minded (based) individuals";
 	else if (pathname.includes("/media/")) {
 		presenceData.details =
-			"Either looking at memes, porn or both (or posting them)";
+			"Either looking at memes, porn, or both (or posting them)";
 	} else if (pathname.includes("/search/") && search.includes("?q=") === false)
 		presenceData.details = "Searching for something really specific";
 	else if (pathname.includes("/search/")) {
 		presenceData.details = `Searching for "${
-			document.querySelectorAll(".p-title-value em")[0].textContent
+			document.querySelector(".p-title-value em").textContent
 		}"`;
 	} else if (pathname.includes("/threads/")) {
 		if (threadTitle) {

--- a/websites/I/Incels.is/presence.ts
+++ b/websites/I/Incels.is/presence.ts
@@ -1,0 +1,88 @@
+const presence = new Presence({
+	clientId: "1094962047906758796",
+}),
+browsingTimestamp = Math.floor(Date.now() / 1000);
+
+const enum Assets {
+Logo = "https://incels.is/logo/512x512.png",
+}
+
+const tags: string[] = ["Blackpill",
+"LifeFuel",
+"SuicideFuel",
+"RageFuel",
+"Serious",	
+"Experiment",
+"JFL",
+"Venting",
+"NSFW",
+"News",
+"Hypocricy",
+"LDAR",
+"Story",
+"It's Over",
+"TeeHee",
+"Soy",
+"Cope",
+"Discussion",
+"Toxic Femininity",
+"[Whitepill]",
+"Theory",
+"Brutal",
+"Based"];
+
+presence.on("UpdateData", async () => {
+const presenceData: PresenceData = {
+	largeImageKey: Assets.Logo,
+	startTimestamp: browsingTimestamp,
+}, threadTitleElement = document.querySelectorAll(".p-title-value")[0] as HTMLHeadingElement,
+// eslint-disable-next-line no-undefined
+threadTitle: string | undefined = threadTitleElement ? threadTitleElement.textContent : undefined;
+
+if (document.location.pathname === "/") presenceData.details = "Hopelessly staring at the home page";
+else if (document.location.pathname.includes("/news-announcements")) presenceData.details = "Doom scrolling through news and announcements";
+else if (document.location.pathname.includes("/suggestions") && document.location.pathname.includes("/post-thread")) presenceData.details = "Typing up a suggestion that will never be implemented";
+else if (document.location.pathname.includes("/suggestions")) presenceData.details = "Looking through suggestions that will never be implemented";
+else if (document.location.pathname.includes("/rules-and-faq")) presenceData.details = "Learning how to sit there and take it, like a good little boy";
+else if (document.location.pathname.includes("/the-bunker") && (document.location.pathname.includes("/post-thread"))) presenceData.details = "Typing up a post for the bunker dwellers";
+else if (document.location.pathname.includes("/the-bunker")) presenceData.details = "Seeking shelter in the bunker";
+else if (document.location.pathname.includes("/must-read-content")) presenceData.details = "Looking through the good stuff";
+else if (document.location.pathname.includes("/inceldom-discussion")) presenceData.details = "Looking through (recycled) discussions";
+else if (document.location.pathname.includes("/the-lounge") && (document.location.pathname.includes("/post-thread"))) presenceData.details = "Typing up something unrelated to inceldom (probably a lie)";
+else if (document.location.pathname.includes("/the-lounge")) presenceData.details = "He be loungin'";
+else if (document.location.pathname.includes("/the-sewers") && document.location.pathname.includes("/post-thread")) presenceData.details = "Typing up a post for the sewer rats";
+else if (document.location.pathname.includes("/the-sewers")) presenceData.details = "Going through the sewers (yuck)";
+else if (document.location.pathname.includes("/ban-appeals") && document.location.pathname.includes("/post-thread")) presenceData.details = "LET ME IN! REEEEEEEE!!!";
+else if (document.location.pathname.includes("/ban-appeals")) presenceData.details = "Trying hard to get back in (or laughing at those who can't)";
+else if (document.location.pathname.includes("/post-thread")) presenceData.details = "Typing up a controversial opinion";
+else if (document.location.pathname.includes("/conversations")) presenceData.details = "Currently e-socializing";
+else if (document.location.pathname.includes("/account/account-details")) presenceData.details = "Pimpin' out the profile";
+else if (document.location.pathname.includes("/members/")) {
+	const selfElement = document.querySelectorAll(".p-navgroup-user-linkText")[0] as HTMLSpanElement;
+	// eslint-disable-next-line no-undefined
+	if (document.location.pathname.includes(selfElement ? selfElement.textContent : undefined)) presenceData.details = "Looking at self with disgust";
+	else presenceData.details = "Watching over other lost souls";
+} else if (document.location.pathname.includes("/account/preferences")) presenceData.details = "Customizing the experience";
+else if (document.location.pathname.includes("/help")) presenceData.details = "Looking for help (all help is too late)";
+else if (document.location.pathname.includes("/whats-new")) presenceData.details = "Looking for something new (it's all the same)";
+else if (document.location.pathname.includes("/find-threads/started")) presenceData.details = "Looking at the only good threads (the ones I made)";
+else if (document.location.pathname.includes("/watched/threads")) presenceData.details = "Checking up on watched threads";
+else if (document.location.pathname.includes("/chat/")) presenceData.details = "Talking to like-minded (based) individuals";
+else if (document.location.pathname.includes("/media/")) presenceData.details = "Either looking at memes, porn or both (or posting them)";
+else if (document.location.pathname.includes("/search/") && (document.location.search.includes("?q=") === false)) presenceData.details = "Searching for something really specific";
+else if (document.location.pathname.includes("/search/")) presenceData.details = `Searching for "${document.querySelectorAll(".p-title-value em")[0].textContent}"`;
+else if (document.location.pathname.includes("/threads/")) {
+	if (threadTitle) {
+		presenceData.details = "Reading a thread:";
+		for (const tag of tags) {
+			if (threadTitle.startsWith(tag) && tag !== "[Whitepill]") {
+				presenceData.state = `${threadTitle.replace(tag, `[${tag}]`)}`;
+				break;
+			} else presenceData.state = threadTitle;
+		}
+	}
+} else presenceData.details = "Wandering around aimlessly";
+
+if(presenceData.details) presence.setActivity(presenceData);
+else presence.setActivity();
+});

--- a/websites/I/Incels.is/presence.ts
+++ b/websites/I/Incels.is/presence.ts
@@ -7,32 +7,6 @@ const enum Assets {
 	Logo = "https://incels.is/logo/512x512.png",
 }
 
-const tags: string[] = [
-	"Blackpill",
-	"LifeFuel",
-	"SuicideFuel",
-	"RageFuel",
-	"Serious",
-	"Experiment",
-	"JFL",
-	"Venting",
-	"NSFW",
-	"News",
-	"Hypocricy",
-	"LDAR",
-	"Story",
-	"It's Over",
-	"TeeHee",
-	"Soy",
-	"Cope",
-	"Discussion",
-	"Toxic Femininity",
-	"[Whitepill]",
-	"Theory",
-	"Brutal",
-	"Based",
-];
-
 presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
 			largeImageKey: Assets.Logo,
@@ -44,109 +18,109 @@ presence.on("UpdateData", async () => {
 		threadTitle: string | undefined = threadTitleElement
 			? threadTitleElement.textContent
 			: // eslint-disable-next-line no-undefined
-			  undefined;
+			  undefined,
+		threadTag =
+			document.querySelector('[class*="label label--custom-"]').textContent ??
+		  // eslint-disable-next-line no-undefined
+			undefined,
+		{ pathname } = document.location,
+		{ search } = document.location;
 
-	if (document.location.pathname === "/")
+	if (pathname === "/")
 		presenceData.details = "Hopelessly staring at the home page";
-	else if (document.location.pathname.includes("/news-announcements"))
+	else if (pathname.includes("/news-announcements"))
 		presenceData.details = "Doom scrolling through news and announcements";
 	else if (
-		document.location.pathname.includes("/suggestions") &&
-		document.location.pathname.includes("/post-thread")
+		pathname.includes("/suggestions") &&
+		pathname.includes("/post-thread")
 	) {
 		presenceData.details =
 			"Typing up a suggestion that will never be implemented";
-	} else if (document.location.pathname.includes("/suggestions")) {
+	} else if (pathname.includes("/suggestions")) {
 		presenceData.details =
 			"Looking through suggestions that will never be implemented";
-	} else if (document.location.pathname.includes("/rules-and-faq")) {
+	} else if (pathname.includes("/rules-and-faq")) {
 		presenceData.details =
 			"Learning how to sit there and take it, like a good little boy";
 	} else if (
-		document.location.pathname.includes("/the-bunker") &&
-		document.location.pathname.includes("/post-thread")
+		pathname.includes("/the-bunker") &&
+		pathname.includes("/post-thread")
 	)
 		presenceData.details = "Typing up a post for the bunker dwellers";
-	else if (document.location.pathname.includes("/the-bunker"))
+	else if (pathname.includes("/the-bunker"))
 		presenceData.details = "Seeking shelter in the bunker";
-	else if (document.location.pathname.includes("/must-read-content"))
+	else if (pathname.includes("/must-read-content"))
 		presenceData.details = "Looking through the good stuff";
-	else if (document.location.pathname.includes("/inceldom-discussion"))
+	else if (pathname.includes("/inceldom-discussion"))
 		presenceData.details = "Looking through (recycled) discussions";
 	else if (
-		document.location.pathname.includes("/the-lounge") &&
-		document.location.pathname.includes("/post-thread")
+		pathname.includes("/the-lounge") &&
+		pathname.includes("/post-thread")
 	) {
 		presenceData.details =
 			"Typing up something unrelated to inceldom (probably a lie)";
-	} else if (document.location.pathname.includes("/the-lounge"))
+	} else if (pathname.includes("/the-lounge"))
 		presenceData.details = "He be loungin'";
 	else if (
-		document.location.pathname.includes("/the-sewers") &&
-		document.location.pathname.includes("/post-thread")
+		pathname.includes("/the-sewers") &&
+		pathname.includes("/post-thread")
 	)
 		presenceData.details = "Typing up a post for the sewer rats";
-	else if (document.location.pathname.includes("/the-sewers"))
+	else if (pathname.includes("/the-sewers"))
 		presenceData.details = "Going through the sewers (yuck)";
 	else if (
-		document.location.pathname.includes("/ban-appeals") &&
-		document.location.pathname.includes("/post-thread")
+		pathname.includes("/ban-appeals") &&
+		pathname.includes("/post-thread")
 	)
 		presenceData.details = "LET ME IN! REEEEEEEE!!!";
-	else if (document.location.pathname.includes("/ban-appeals")) {
+	else if (pathname.includes("/ban-appeals")) {
 		presenceData.details =
 			"Trying hard to get back in (or laughing at those who can't)";
-	} else if (document.location.pathname.includes("/post-thread"))
+	} else if (pathname.includes("/post-thread"))
 		presenceData.details = "Typing up a controversial opinion";
-	else if (document.location.pathname.includes("/conversations"))
+	else if (pathname.includes("/conversations"))
 		presenceData.details = "Currently e-socializing";
-	else if (document.location.pathname.includes("/account/account-details"))
+	else if (pathname.includes("/account/account-details"))
 		presenceData.details = "Pimpin' out the profile";
-	else if (document.location.pathname.includes("/members/")) {
+	else if (pathname.includes("/members/")) {
 		const selfElement = document.querySelectorAll(
 			".p-navgroup-user-linkText"
 		)[0] as HTMLSpanElement;
 		if (
-			document.location.pathname.includes(
+			pathname.includes(
 				// eslint-disable-next-line no-undefined
 				selfElement ? selfElement.textContent : undefined
 			)
 		)
 			presenceData.details = "Looking at self with disgust";
 		else presenceData.details = "Watching over other lost souls";
-	} else if (document.location.pathname.includes("/account/preferences"))
+	} else if (pathname.includes("/account/preferences"))
 		presenceData.details = "Customizing the experience";
-	else if (document.location.pathname.includes("/help"))
+	else if (pathname.includes("/help"))
 		presenceData.details = "Looking for help (all help is too late)";
-	else if (document.location.pathname.includes("/whats-new"))
+	else if (pathname.includes("/whats-new"))
 		presenceData.details = "Looking for something new (it's all the same)";
-	else if (document.location.pathname.includes("/find-threads/started"))
+	else if (pathname.includes("/find-threads/started"))
 		presenceData.details = "Looking at the only good threads (the ones I made)";
-	else if (document.location.pathname.includes("/watched/threads"))
+	else if (pathname.includes("/watched/threads"))
 		presenceData.details = "Checking up on watched threads";
-	else if (document.location.pathname.includes("/chat/"))
+	else if (pathname.includes("/chat/"))
 		presenceData.details = "Talking to like-minded (based) individuals";
-	else if (document.location.pathname.includes("/media/")) {
+	else if (pathname.includes("/media/")) {
 		presenceData.details =
 			"Either looking at memes, porn or both (or posting them)";
-	} else if (
-		document.location.pathname.includes("/search/") &&
-		document.location.search.includes("?q=") === false
-	)
+	} else if (pathname.includes("/search/") && search.includes("?q=") === false)
 		presenceData.details = "Searching for something really specific";
-	else if (document.location.pathname.includes("/search/")) {
+	else if (pathname.includes("/search/")) {
 		presenceData.details = `Searching for "${
 			document.querySelectorAll(".p-title-value em")[0].textContent
 		}"`;
-	} else if (document.location.pathname.includes("/threads/")) {
+	} else if (pathname.includes("/threads/")) {
 		if (threadTitle) {
 			presenceData.details = "Reading a thread:";
-			for (const tag of tags) {
-				if (threadTitle.startsWith(tag) && tag !== "[Whitepill]") {
-					presenceData.state = `${threadTitle.replace(tag, `[${tag}]`)}`;
-					break;
-				} else presenceData.state = threadTitle;
-			}
+			presenceData.state = threadTag
+				? threadTitle.replace(threadTag, `[${threadTag}]`)
+				: threadTitle;
 		}
 	} else presenceData.details = "Wandering around aimlessly";
 

--- a/websites/I/Incels.is/presence.ts
+++ b/websites/I/Incels.is/presence.ts
@@ -1,88 +1,155 @@
 const presence = new Presence({
-	clientId: "1094962047906758796",
-}),
-browsingTimestamp = Math.floor(Date.now() / 1000);
+		clientId: "1094962047906758796",
+	}),
+	browsingTimestamp = Math.floor(Date.now() / 1000);
 
 const enum Assets {
-Logo = "https://incels.is/logo/512x512.png",
+	Logo = "https://incels.is/logo/512x512.png",
 }
 
-const tags: string[] = ["Blackpill",
-"LifeFuel",
-"SuicideFuel",
-"RageFuel",
-"Serious",	
-"Experiment",
-"JFL",
-"Venting",
-"NSFW",
-"News",
-"Hypocricy",
-"LDAR",
-"Story",
-"It's Over",
-"TeeHee",
-"Soy",
-"Cope",
-"Discussion",
-"Toxic Femininity",
-"[Whitepill]",
-"Theory",
-"Brutal",
-"Based"];
+const tags: string[] = [
+	"Blackpill",
+	"LifeFuel",
+	"SuicideFuel",
+	"RageFuel",
+	"Serious",
+	"Experiment",
+	"JFL",
+	"Venting",
+	"NSFW",
+	"News",
+	"Hypocricy",
+	"LDAR",
+	"Story",
+	"It's Over",
+	"TeeHee",
+	"Soy",
+	"Cope",
+	"Discussion",
+	"Toxic Femininity",
+	"[Whitepill]",
+	"Theory",
+	"Brutal",
+	"Based",
+];
 
 presence.on("UpdateData", async () => {
-const presenceData: PresenceData = {
-	largeImageKey: Assets.Logo,
-	startTimestamp: browsingTimestamp,
-}, threadTitleElement = document.querySelectorAll(".p-title-value")[0] as HTMLHeadingElement,
-// eslint-disable-next-line no-undefined
-threadTitle: string | undefined = threadTitleElement ? threadTitleElement.textContent : undefined;
+	const presenceData: PresenceData = {
+			largeImageKey: Assets.Logo,
+			startTimestamp: browsingTimestamp,
+		},
+		threadTitleElement = document.querySelectorAll(
+			".p-title-value"
+		)[0] as HTMLHeadingElement,
+		threadTitle: string | undefined = threadTitleElement
+			? threadTitleElement.textContent
+			: // eslint-disable-next-line no-undefined
+			  undefined;
 
-if (document.location.pathname === "/") presenceData.details = "Hopelessly staring at the home page";
-else if (document.location.pathname.includes("/news-announcements")) presenceData.details = "Doom scrolling through news and announcements";
-else if (document.location.pathname.includes("/suggestions") && document.location.pathname.includes("/post-thread")) presenceData.details = "Typing up a suggestion that will never be implemented";
-else if (document.location.pathname.includes("/suggestions")) presenceData.details = "Looking through suggestions that will never be implemented";
-else if (document.location.pathname.includes("/rules-and-faq")) presenceData.details = "Learning how to sit there and take it, like a good little boy";
-else if (document.location.pathname.includes("/the-bunker") && (document.location.pathname.includes("/post-thread"))) presenceData.details = "Typing up a post for the bunker dwellers";
-else if (document.location.pathname.includes("/the-bunker")) presenceData.details = "Seeking shelter in the bunker";
-else if (document.location.pathname.includes("/must-read-content")) presenceData.details = "Looking through the good stuff";
-else if (document.location.pathname.includes("/inceldom-discussion")) presenceData.details = "Looking through (recycled) discussions";
-else if (document.location.pathname.includes("/the-lounge") && (document.location.pathname.includes("/post-thread"))) presenceData.details = "Typing up something unrelated to inceldom (probably a lie)";
-else if (document.location.pathname.includes("/the-lounge")) presenceData.details = "He be loungin'";
-else if (document.location.pathname.includes("/the-sewers") && document.location.pathname.includes("/post-thread")) presenceData.details = "Typing up a post for the sewer rats";
-else if (document.location.pathname.includes("/the-sewers")) presenceData.details = "Going through the sewers (yuck)";
-else if (document.location.pathname.includes("/ban-appeals") && document.location.pathname.includes("/post-thread")) presenceData.details = "LET ME IN! REEEEEEEE!!!";
-else if (document.location.pathname.includes("/ban-appeals")) presenceData.details = "Trying hard to get back in (or laughing at those who can't)";
-else if (document.location.pathname.includes("/post-thread")) presenceData.details = "Typing up a controversial opinion";
-else if (document.location.pathname.includes("/conversations")) presenceData.details = "Currently e-socializing";
-else if (document.location.pathname.includes("/account/account-details")) presenceData.details = "Pimpin' out the profile";
-else if (document.location.pathname.includes("/members/")) {
-	const selfElement = document.querySelectorAll(".p-navgroup-user-linkText")[0] as HTMLSpanElement;
-	// eslint-disable-next-line no-undefined
-	if (document.location.pathname.includes(selfElement ? selfElement.textContent : undefined)) presenceData.details = "Looking at self with disgust";
-	else presenceData.details = "Watching over other lost souls";
-} else if (document.location.pathname.includes("/account/preferences")) presenceData.details = "Customizing the experience";
-else if (document.location.pathname.includes("/help")) presenceData.details = "Looking for help (all help is too late)";
-else if (document.location.pathname.includes("/whats-new")) presenceData.details = "Looking for something new (it's all the same)";
-else if (document.location.pathname.includes("/find-threads/started")) presenceData.details = "Looking at the only good threads (the ones I made)";
-else if (document.location.pathname.includes("/watched/threads")) presenceData.details = "Checking up on watched threads";
-else if (document.location.pathname.includes("/chat/")) presenceData.details = "Talking to like-minded (based) individuals";
-else if (document.location.pathname.includes("/media/")) presenceData.details = "Either looking at memes, porn or both (or posting them)";
-else if (document.location.pathname.includes("/search/") && (document.location.search.includes("?q=") === false)) presenceData.details = "Searching for something really specific";
-else if (document.location.pathname.includes("/search/")) presenceData.details = `Searching for "${document.querySelectorAll(".p-title-value em")[0].textContent}"`;
-else if (document.location.pathname.includes("/threads/")) {
-	if (threadTitle) {
-		presenceData.details = "Reading a thread:";
-		for (const tag of tags) {
-			if (threadTitle.startsWith(tag) && tag !== "[Whitepill]") {
-				presenceData.state = `${threadTitle.replace(tag, `[${tag}]`)}`;
-				break;
-			} else presenceData.state = threadTitle;
+	if (document.location.pathname === "/")
+		presenceData.details = "Hopelessly staring at the home page";
+	else if (document.location.pathname.includes("/news-announcements"))
+		presenceData.details = "Doom scrolling through news and announcements";
+	else if (
+		document.location.pathname.includes("/suggestions") &&
+		document.location.pathname.includes("/post-thread")
+	) {
+		presenceData.details =
+			"Typing up a suggestion that will never be implemented";
+	} else if (document.location.pathname.includes("/suggestions")) {
+		presenceData.details =
+			"Looking through suggestions that will never be implemented";
+	} else if (document.location.pathname.includes("/rules-and-faq")) {
+		presenceData.details =
+			"Learning how to sit there and take it, like a good little boy";
+	} else if (
+		document.location.pathname.includes("/the-bunker") &&
+		document.location.pathname.includes("/post-thread")
+	)
+		presenceData.details = "Typing up a post for the bunker dwellers";
+	else if (document.location.pathname.includes("/the-bunker"))
+		presenceData.details = "Seeking shelter in the bunker";
+	else if (document.location.pathname.includes("/must-read-content"))
+		presenceData.details = "Looking through the good stuff";
+	else if (document.location.pathname.includes("/inceldom-discussion"))
+		presenceData.details = "Looking through (recycled) discussions";
+	else if (
+		document.location.pathname.includes("/the-lounge") &&
+		document.location.pathname.includes("/post-thread")
+	) {
+		presenceData.details =
+			"Typing up something unrelated to inceldom (probably a lie)";
+	} else if (document.location.pathname.includes("/the-lounge"))
+		presenceData.details = "He be loungin'";
+	else if (
+		document.location.pathname.includes("/the-sewers") &&
+		document.location.pathname.includes("/post-thread")
+	)
+		presenceData.details = "Typing up a post for the sewer rats";
+	else if (document.location.pathname.includes("/the-sewers"))
+		presenceData.details = "Going through the sewers (yuck)";
+	else if (
+		document.location.pathname.includes("/ban-appeals") &&
+		document.location.pathname.includes("/post-thread")
+	)
+		presenceData.details = "LET ME IN! REEEEEEEE!!!";
+	else if (document.location.pathname.includes("/ban-appeals")) {
+		presenceData.details =
+			"Trying hard to get back in (or laughing at those who can't)";
+	} else if (document.location.pathname.includes("/post-thread"))
+		presenceData.details = "Typing up a controversial opinion";
+	else if (document.location.pathname.includes("/conversations"))
+		presenceData.details = "Currently e-socializing";
+	else if (document.location.pathname.includes("/account/account-details"))
+		presenceData.details = "Pimpin' out the profile";
+	else if (document.location.pathname.includes("/members/")) {
+		const selfElement = document.querySelectorAll(
+			".p-navgroup-user-linkText"
+		)[0] as HTMLSpanElement;
+		if (
+			document.location.pathname.includes(
+				// eslint-disable-next-line no-undefined
+				selfElement ? selfElement.textContent : undefined
+			)
+		)
+			presenceData.details = "Looking at self with disgust";
+		else presenceData.details = "Watching over other lost souls";
+	} else if (document.location.pathname.includes("/account/preferences"))
+		presenceData.details = "Customizing the experience";
+	else if (document.location.pathname.includes("/help"))
+		presenceData.details = "Looking for help (all help is too late)";
+	else if (document.location.pathname.includes("/whats-new"))
+		presenceData.details = "Looking for something new (it's all the same)";
+	else if (document.location.pathname.includes("/find-threads/started"))
+		presenceData.details = "Looking at the only good threads (the ones I made)";
+	else if (document.location.pathname.includes("/watched/threads"))
+		presenceData.details = "Checking up on watched threads";
+	else if (document.location.pathname.includes("/chat/"))
+		presenceData.details = "Talking to like-minded (based) individuals";
+	else if (document.location.pathname.includes("/media/")) {
+		presenceData.details =
+			"Either looking at memes, porn or both (or posting them)";
+	} else if (
+		document.location.pathname.includes("/search/") &&
+		document.location.search.includes("?q=") === false
+	)
+		presenceData.details = "Searching for something really specific";
+	else if (document.location.pathname.includes("/search/")) {
+		presenceData.details = `Searching for "${
+			document.querySelectorAll(".p-title-value em")[0].textContent
+		}"`;
+	} else if (document.location.pathname.includes("/threads/")) {
+		if (threadTitle) {
+			presenceData.details = "Reading a thread:";
+			for (const tag of tags) {
+				if (threadTitle.startsWith(tag) && tag !== "[Whitepill]") {
+					presenceData.state = `${threadTitle.replace(tag, `[${tag}]`)}`;
+					break;
+				} else presenceData.state = threadTitle;
+			}
 		}
-	}
-} else presenceData.details = "Wandering around aimlessly";
+	} else presenceData.details = "Wandering around aimlessly";
 
-if(presenceData.details) presence.setActivity(presenceData);
-else presence.setActivity();
+	if (presenceData.details) presence.setActivity(presenceData);
+	else presence.setActivity();
 });

--- a/websites/I/Incels.is/presence.ts
+++ b/websites/I/Incels.is/presence.ts
@@ -21,7 +21,7 @@ presence.on("UpdateData", async () => {
 			  undefined,
 		threadTag =
 			document.querySelector('[class*="label label--custom-"]').textContent ??
-		  // eslint-disable-next-line no-undefined
+			// eslint-disable-next-line no-undefined
 			undefined,
 		{ pathname } = document.location,
 		{ search } = document.location;


### PR DESCRIPTION
## Description 
Added "incels.is". There is really not much else to it. Depending on which sites you visit within incels.is, the funny text in your Discord presence changes. And it also shows you how long you have been on the same page for.

Disclaimer: When you share their website link, you get an embedded image. I took that image, and am using it for both the logo, as it meets the size requirements, and the thumbnail, as it is the official "thumbnail" of the website URL. Hope that works!

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://github.com/PreMiD/Presences/assets/123654152/2843562e-726a-4945-ad01-f643fa23420d)

</details>
