### PR TITLE
feat(AniWatch): add HiAnime rebrand

### DIFF
--- a/websites/A/AniWatch/metadata.json
+++ b/websites/A/AniWatch/metadata.json
@@ -10,7 +10,8 @@
 	},
 	"url": [
 		"aniwatch.to",
-		"aniwatchtv.to"
+		"aniwatchtv.to",
+		"hianime.to"
 	],
 	"version": "1.0.5",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/logo.png",

--- a/websites/A/AniWatch/metadata.json
+++ b/websites/A/AniWatch/metadata.json
@@ -13,7 +13,7 @@
 		"aniwatchtv.to",
 		"hianime.to"
 	],
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/thumbnail.png",
 	"color": "#ffdd95",

--- a/websites/A/AniWatch/presence.ts
+++ b/websites/A/AniWatch/presence.ts
@@ -11,6 +11,7 @@ let data: {
 
 const enum Assets {
 	AniWatchLogo = "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/0.png",
+	HiAnimeLogo = "https://i.imgur.com/a9gT2wg.png",
 	Settings = "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/1.png",
 	Notifications = "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/2.png",
 }
@@ -27,15 +28,16 @@ presence.on(
 );
 
 presence.on("UpdateData", async () => {
-	const presenceData: PresenceData = {
-			largeImageKey: Assets.AniWatchLogo,
+	const isHiAnime = document.location.hostname === "hianime.to",
+		presenceData: PresenceData = {
+			largeImageKey: isHiAnime ? Assets.HiAnimeLogo : Assets.AniWatchLogo,
 			startTimestamp: browsingTimestamp,
 		},
 		{ pathname, href } = document.location,
 		buttons = await presence.getSetting<boolean>("buttons");
 
 	if (pathname === "/" || pathname === "/home")
-		presenceData.details = "Exploring AniWatch.to";
+		presenceData.details = `Exploring ${isHiAnime ? "HiAnime" : "AniWatch"}.to`;
 	else if (
 		/\/(most-favorite|most-popular|movie|recently-added|recently-updated|tv|top-airing|top-upcoming|ona|ova|special|(genre\/.*))/.test(
 			pathname


### PR DESCRIPTION
Closes #8146

## Description 
Adds HiAnime.to domain support.
Note: The application name needs to be changed when they completely phase out the name AniWatch.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img src="https://github.com/PreMiD/Presences/assets/69511006/64d31f63-910b-4f14-898f-01b07bbb878c" />
</details>
