### PR TITLE
fix(Audible): replace broken selectors on webplayer, add chapter info and timestamps

### DIFF
--- a/websites/A/Audible/metadata.json
+++ b/websites/A/Audible/metadata.json
@@ -10,7 +10,7 @@
 	},
 	"url": "www.audible.com",
 	"regExp": "www[.]audible([.][a-z]+)",
-	"version": "1.1.8",
+	"version": "1.1.9",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/Audible/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/Audible/assets/thumbnail.png",
 	"color": "#f7991c",

--- a/websites/A/Audible/presence.ts
+++ b/websites/A/Audible/presence.ts
@@ -33,7 +33,7 @@ presence.on("UpdateData", async () => {
 			.querySelector("img.bc-pub-block.bc-image-inset-border.js-only-element")
 			.getAttribute("src");
 	} else if (document.location.pathname.includes("/webplayer")) {
-		presenceData.details = `Listenting to ${document
+		presenceData.details = `Listening to ${document
 			.querySelector("#adbl-cloud-player-container-data")
 			.getAttribute("data-title")}`;
 		presenceData.state = document.querySelector(

--- a/websites/A/Audible/presence.ts
+++ b/websites/A/Audible/presence.ts
@@ -1,57 +1,71 @@
 const presence = new Presence({
-		clientId: "991933219719086080",
-	}),
-	browsingTimestamp = Math.floor(Date.now() / 1000);
+	clientId: "991933219719086080",
+}),
+browsingTimestamp = Math.floor(Date.now() / 1000);
 
 presence.on("UpdateData", async () => {
-	const presenceData: PresenceData = {
-		largeImageKey:
-			"https://cdn.rcd.gg/PreMiD/websites/A/Audible/assets/logo.png",
-		startTimestamp: browsingTimestamp,
-	};
-	if (document.location.pathname.includes("/account"))
-		presenceData.details = "Viewing account";
-	else if (document.location.pathname.includes("/wl"))
-		presenceData.details = "Viewing wishlist";
-	else if (document.location.pathname.includes("/library"))
-		presenceData.details = "Viewing library";
-	else if (document.location.pathname.includes("plus"))
-		presenceData.details = "Viewing plus catalog";
-	else if (document.location.pathname.includes("gift"))
-		presenceData.details = "Viewing gift center";
-	else if (document.location.pathname.includes("/pd")) {
-		presenceData.details = `Viewing ${
-			document.querySelector(
-				"h1.bc-heading.bc-color-base.bc-pub-break-word.bc-text-bold"
-			).textContent
-		} by ${
-			document.querySelector(
-				"li.bc-list-item.authorLabel > a.bc-link.bc-color-link"
-			).textContent
-		}`;
-		presenceData.largeImageKey = document
-			.querySelector("img.bc-pub-block.bc-image-inset-border.js-only-element")
-			.getAttribute("src");
-	} else if (document.location.pathname.includes("/webplayer")) {
-		presenceData.details = `Listening to ${document
-			.querySelector("input[name=title]")
-			.getAttribute("value")}`;
-		presenceData.state = document.querySelector(
-			"span.bc-text.timeLeft"
-		).textContent;
-		presenceData.largeImageKey = document
-			.querySelector("img[id=adbl-cloudBook]")
-			.getAttribute("src");
-		if (
-			document
-				.querySelector("img[title='Play/Pause']")
-				.className.includes("bc-hidden")
-		)
-			presenceData.smallImageKey = Assets.Pause;
-		else presenceData.smallImageKey = Assets.Play;
+const presenceData: PresenceData = {
+	largeImageKey:
+		"https://cdn.rcd.gg/PreMiD/websites/A/Audible/assets/logo.png",
+	startTimestamp: browsingTimestamp,
+};
+if (document.location.pathname.includes("/account"))
+	presenceData.details = "Viewing account";
+else if (document.location.pathname.includes("/wl"))
+	presenceData.details = "Viewing wishlist";
+else if (document.location.pathname.includes("/library"))
+	presenceData.details = "Viewing library";
+else if (document.location.pathname.includes("plus"))
+	presenceData.details = "Viewing plus catalog";
+else if (document.location.pathname.includes("gift"))
+	presenceData.details = "Viewing gift center";
+else if (document.location.pathname.includes("/pd")) {
+	presenceData.details = `Viewing ${
+		document.querySelector(
+			"h1.bc-heading.bc-color-base.bc-pub-break-word.bc-text-bold",
+		).textContent
+	} by ${
+		document.querySelector(
+			"li.bc-list-item.authorLabel > a.bc-link.bc-color-link",
+		).textContent
+	}`;
+	presenceData.largeImageKey = document
+		.querySelector("img.bc-pub-block.bc-image-inset-border.js-only-element")
+		.getAttribute("src");
+} else if (document.location.pathname.includes("/webplayer")) {
+	presenceData.details = `Listenting to ${
+		document.getElementById("adbl-cloud-player-container-data").dataset
+			.parenttitle
+	}`;
+	presenceData.state = document.getElementById(
+		"cp-Top-chapter-display",
+	).innerText;
+	const chapterTimeLeft = document
+		.getElementById("adblMediaBarTimeLeft")
+		.innerText.replace("– ", "");
+	const chapterTimeSpent = document.getElementById(
+		"adblMediaBarTimeSpent",
+	).innerText;
+	const chapterRemaining = presence.getTimestamps(
+		presence.timestampFromFormat(chapterTimeSpent),
+		presence.timestampFromFormat(chapterTimeLeft) +
+			presence.timestampFromFormat(chapterTimeSpent),
+	);
+	presenceData.startTimestamp = chapterRemaining[0];
+	presenceData.endTimestamp = chapterRemaining[1];
+	presenceData.largeImageKey = document
+		.getElementById("adbl-cloudBook")
+		.getAttribute("src");
+	if (
+		document.querySelector(".adblPlayButton").classList.contains("bc-hidden")
+	) {
+		presenceData.smallImageKey = Assets.Pause;
 	} else {
-		presenceData.details = "Browsing";
-		delete presenceData.state;
+		presenceData.smallImageKey = Assets.Play;
 	}
-	presence.setActivity(presenceData);
+} else {
+	presenceData.details = "Browsing";
+	delete presenceData.state;
+}
+presence.setActivity(presenceData);
 });

--- a/websites/A/Audible/presence.ts
+++ b/websites/A/Audible/presence.ts
@@ -1,71 +1,73 @@
 const presence = new Presence({
-	clientId: "991933219719086080",
-}),
-browsingTimestamp = Math.floor(Date.now() / 1000);
+		clientId: "991933219719086080",
+	}),
+	browsingTimestamp = Math.floor(Date.now() / 1000);
 
 presence.on("UpdateData", async () => {
-const presenceData: PresenceData = {
-	largeImageKey:
-		"https://cdn.rcd.gg/PreMiD/websites/A/Audible/assets/logo.png",
-	startTimestamp: browsingTimestamp,
-};
-if (document.location.pathname.includes("/account"))
-	presenceData.details = "Viewing account";
-else if (document.location.pathname.includes("/wl"))
-	presenceData.details = "Viewing wishlist";
-else if (document.location.pathname.includes("/library"))
-	presenceData.details = "Viewing library";
-else if (document.location.pathname.includes("plus"))
-	presenceData.details = "Viewing plus catalog";
-else if (document.location.pathname.includes("gift"))
-	presenceData.details = "Viewing gift center";
-else if (document.location.pathname.includes("/pd")) {
-	presenceData.details = `Viewing ${
-		document.querySelector(
-			"h1.bc-heading.bc-color-base.bc-pub-break-word.bc-text-bold",
-		).textContent
-	} by ${
-		document.querySelector(
-			"li.bc-list-item.authorLabel > a.bc-link.bc-color-link",
-		).textContent
-	}`;
-	presenceData.largeImageKey = document
-		.querySelector("img.bc-pub-block.bc-image-inset-border.js-only-element")
-		.getAttribute("src");
-} else if (document.location.pathname.includes("/webplayer")) {
-	presenceData.details = `Listenting to ${
-		document.getElementById("adbl-cloud-player-container-data").dataset
-			.parenttitle
-	}`;
-	presenceData.state = document.getElementById(
-		"cp-Top-chapter-display",
-	).innerText;
-	const chapterTimeLeft = document
-		.getElementById("adblMediaBarTimeLeft")
-		.innerText.replace("– ", "");
-	const chapterTimeSpent = document.getElementById(
-		"adblMediaBarTimeSpent",
-	).innerText;
-	const chapterRemaining = presence.getTimestamps(
-		presence.timestampFromFormat(chapterTimeSpent),
-		presence.timestampFromFormat(chapterTimeLeft) +
-			presence.timestampFromFormat(chapterTimeSpent),
-	);
-	presenceData.startTimestamp = chapterRemaining[0];
-	presenceData.endTimestamp = chapterRemaining[1];
-	presenceData.largeImageKey = document
-		.getElementById("adbl-cloudBook")
-		.getAttribute("src");
-	if (
-		document.querySelector(".adblPlayButton").classList.contains("bc-hidden")
-	) {
-		presenceData.smallImageKey = Assets.Pause;
+	const presenceData: PresenceData = {
+		largeImageKey:
+			"https://cdn.rcd.gg/PreMiD/websites/A/Audible/assets/logo.png",
+		startTimestamp: browsingTimestamp,
+	};
+	if (document.location.pathname.includes("/account"))
+		presenceData.details = "Viewing account";
+	else if (document.location.pathname.includes("/wl"))
+		presenceData.details = "Viewing wishlist";
+	else if (document.location.pathname.includes("/library"))
+		presenceData.details = "Viewing library";
+	else if (document.location.pathname.includes("plus"))
+		presenceData.details = "Viewing plus catalog";
+	else if (document.location.pathname.includes("gift"))
+		presenceData.details = "Viewing gift center";
+	else if (document.location.pathname.includes("/pd")) {
+		presenceData.details = `Viewing ${
+			document.querySelector(
+				"h1.bc-heading.bc-color-base.bc-pub-break-word.bc-text-bold"
+			).textContent
+		} by ${
+			document.querySelector(
+				"li.bc-list-item.authorLabel > a.bc-link.bc-color-link"
+			).textContent
+		}`;
+		presenceData.largeImageKey = document
+			.querySelector("img.bc-pub-block.bc-image-inset-border.js-only-element")
+			.getAttribute("src");
+	} else if (document.location.pathname.includes("/webplayer")) {
+		presenceData.details = `Listenting to ${document
+			.querySelector("#adbl-cloud-player-container-data")
+			.getAttribute("data-title")}`;
+		presenceData.state = document.querySelector(
+			"#cp-Top-chapter-display"
+		).textContent;
+
+		const chapterRemaining = presence.getTimestamps(
+			presence.timestampFromFormat(
+				document.querySelector("#adblMediaBarTimeSpent")?.textContent
+			),
+			presence.timestampFromFormat(
+				document
+					.querySelector("#adblMediaBarTimeLeft")
+					?.textContent.replace("– ", "")
+			) +
+				presence.timestampFromFormat(
+					document.querySelector("#adblMediaBarTimeSpent")?.textContent
+				)
+		);
+		presenceData.startTimestamp = chapterRemaining[0];
+		presenceData.endTimestamp = chapterRemaining[1];
+		presenceData.largeImageKey = document
+			.querySelector("#adbl-cloudBook")
+			.getAttribute("src");
+		if (
+			document.querySelector(".adblPlayButton").classList.contains("bc-hidden")
+		)
+			presenceData.smallImageKey = Assets.Pause;
+		else presenceData.smallImageKey = Assets.Play;
 	} else {
-		presenceData.smallImageKey = Assets.Play;
+		presenceData.details = "Browsing";
+		delete presenceData.state;
+		delete presenceData.startTimestamp;
+		delete presenceData.endTimestamp;
 	}
-} else {
-	presenceData.details = "Browsing";
-	delete presenceData.state;
-}
-presence.setActivity(presenceData);
+	presence.setActivity(presenceData);
 });


### PR DESCRIPTION
## Description 
Replaced old element selectors for webplayer, that were no longer valid. Added chapter information to state as well as timestamps.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![msedge_Bh0brNfQQ2](https://github.com/PreMiD/Presences/assets/74920104/cd95c77a-9686-49dd-b84b-3bc52075a350)

![msedge_wGVE8ZtuN1](https://github.com/PreMiD/Presences/assets/74920104/027c445f-e9b8-421b-8aeb-a4971c279689)

</details>
