### PR TITLE
feat(movie-web): add more sites from official docs

### DIFF
--- a/websites/M/movie-web/metadata.json
+++ b/websites/M/movie-web/metadata.json
@@ -9,10 +9,17 @@
 		"en": "The place for your favorite movies & shows"
 	},
 	"url": [
-		"movie-web.app",
+		"watch.qtchaos.de",
 		"mw.lonelil.com",
 		"mw.lonelil.ru",
-		"mv-web.netlify.app"
+		"mv-web.netlify.app",
+		"bmov.vercel.app",
+		"stream.thehairy.me",
+		"scootydooter.vercel.app",
+		"movie-web-me.vercel.app",
+		"sudo-flix.lol",
+		"movie.exorbgn.net",
+		"movie-web.x"
 	],
 	"regExp": "(dev[.])?(movie-web[.]app)",
 	"matches": [

--- a/websites/M/movie-web/metadata.json
+++ b/websites/M/movie-web/metadata.json
@@ -23,10 +23,17 @@
 	],
 	"regExp": "(dev[.])?(movie-web[.]app)",
 	"matches": [
-		"*://movie-web.app/*",
+		"*://watch.qtchaos.de/*",
 		"*://mw.lonelil.com/*",
 		"*://mw.lonelil.ru/*",
-		"*://mv-web.netlify.app/*"
+		"*://mv-web.netlify.app/*",
+		"*://bmov.vercel.app/*",
+		"*://stream.thehairy.me/*",
+		"*://scootydooter.vercel.app/*",
+		"*://movie-web-me.vercel.app/*",
+		"*://sudo-flix.lol/*",
+		"*://movie.exorbgn.net/*",
+		"*://movie-web.x/*"
 	],
 	"version": "1.0.9",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/M/movie-web/assets/logo.png",

--- a/websites/M/movie-web/metadata.json
+++ b/websites/M/movie-web/metadata.json
@@ -28,7 +28,7 @@
 		"*://mw.lonelil.ru/*",
 		"*://mv-web.netlify.app/*"
 	],
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/M/movie-web/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/M/movie-web/assets/thumbnail.png",
 	"color": "#533670",


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Added sites from the official movie-web docs, and removed the old non working ones since the takedown.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
The screenshots will look literally exact same.
</details>
