### PR TITLE
feat(Library of Babel): fix presence bug

### DIFF
--- a/websites/L/Library of Babel/metadata.json
+++ b/websites/L/Library of Babel/metadata.json
@@ -16,7 +16,7 @@
 		"*://libraryofbabel.info/*",
 		"*://www.libraryofbabel.info/*"
 	],
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/L/Library%20of%20Babel/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/L/Library%20of%20Babel/assets/thumbnail.png",
 	"color": "#808080",

--- a/websites/L/Library of Babel/presence.ts
+++ b/websites/L/Library of Babel/presence.ts
@@ -79,16 +79,16 @@ presence.on("UpdateData", async () => {
 				)} (page ${pageInp})`;
 				presenceData.details = `Reading ${
 					document.querySelector(".bookcont > h3")?.textContent
-				} (page ${pageInp})`;
+				} (page ${pageInp}, Anglishized)`;
 			}
 			break;
 
 		case Pages.book:
 		case Pages.bookmark:
-			presenceData.details = `Reading ${title.replace(
+			presenceData.details = `Reading Bookmark ${title.replace(
 				` ${pageInp}`,
 				""
-			)} (page ${pageInp})`;
+			)}`;
 			break;
 
 		case Pages.browse:


### PR DESCRIPTION
## Description 
I fixed a bug where if the user was viewing a bookmark or anglicized page, the presence wouldn't show the page or title. I also removed the "page number" from the bookmark presence status as bookmarks are single page only.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/PreMiD/Presences/assets/58801387/19f78f2b-d3d8-4546-9367-550d1056ea52)

![image](https://github.com/PreMiD/Presences/assets/58801387/9f38fe63-6c26-4821-b6ef-9c19563c500c)




</details>
