### PR TITLE
feat(Japanese Mahjong Wiki): add presence

### DIFF
--- a/websites/J/Japanese Mahjong Wiki/metadata.json
+++ b/websites/J/Japanese Mahjong Wiki/metadata.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.10",
+	"author": {
+		"id": "193714715631812608",
+		"name": "theusaf"
+	},
+	"service": "Japanese Mahjong Wiki",
+	"description": {
+		"en": "A wiki whose main purpose is to provide English speakers easy access and material pertaining to Japanese mahjong."
+	},
+	"url": "riichi.wiki",
+	"matches": [
+		"https://riichi.wiki/*"
+	],
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/3xMqFwy.png",
+	"thumbnail": "https://riichi.wiki/images/Mahjong_Tiles.jpg",
+	"color": "#F1ECE6",
+	"category": "games",
+	"tags": [
+		"mahjong",
+		"japan",
+		"japanese",
+		"riichi",
+		"wiki",
+		"culture"
+	]
+}

--- a/websites/J/Japanese Mahjong Wiki/pages/special.ts
+++ b/websites/J/Japanese Mahjong Wiki/pages/special.ts
@@ -2,25 +2,64 @@ import { findNearestAboveElement } from "../util/util";
 
 // Wiki-specific groups of pages
 const strategies = new Set([
-	"Sakigiri",
-	"Suji",
-	"Kabe",
-	"Betaori",
-	"Kawa",
-	"Sashikomi",
-	"Defense",
-	"Tile_efficiency",
-	"Atozuke",
-	"Yaku_compatibility",
-	"Damaten",
-	"Kan",
-	"Machi",
-	"Riichi_strategy",
-	"Shanten",
-	"Tenpai",
-	"Ukeire",
-	"What_would_you_discard",
-]);
+		"Sakigiri",
+		"Suji",
+		"Kabe",
+		"Betaori",
+		"Kawa",
+		"Sashikomi",
+		"Defense",
+		"Tile_efficiency",
+		"Atozuke",
+		"Yaku_compatibility",
+		"Damaten",
+		"Kan",
+		"Machi",
+		"Riichi_strategy",
+		"Shanten",
+		"Tenpai",
+		"Ukeire",
+		"What_would_you_discard",
+	]),
+	yaku = new Set([
+		"Menzenchin_tsumohou",
+		"Riichi",
+		"Ippatsu",
+		"Pinfu",
+		"Iipeikou",
+		"Haitei raoyue and houtei raoyui",
+		"Rinshan_kaihou",
+		"Chankan",
+		"Tanyao",
+		"Yakuhai",
+		"Daburu_riichi",
+		"Chanta",
+		"Sanshouku_doujun",
+		"Ikkitsuukan",
+		"Toitoihou",
+		"Sanankou",
+		"Sanshoku_doukou",
+		"Sankantsu",
+		"Chiitoitsu",
+		"Honroutou",
+		"Shousangen",
+		"Honiisou",
+		"Junchantaiyaochuu",
+		"Ryanpeikou",
+		"Chiniisou",
+		"Kazoe_yakuman",
+		"Kokushi_musou",
+		"Suuankou",
+		"Daisangen",
+		"Suushiihou",
+		"Tsuuiisou",
+		"Chinroutou",
+		"Ryuuiisou",
+		"Chuuren_poutou",
+		"Suukantsu",
+		"Tenhou_and_chiihou",
+		"Nagashi_mangan",
+	]);
 
 /**
  * Applies page details based on the current location.
@@ -177,6 +216,14 @@ export function specialPageHandler(
 				presenceData.details = "Reading about a strategy";
 				presenceData.state = pageTitle;
 				presenceData.buttons = [{ label: "View Strategy", url: href }];
+				break;
+			}
+		}
+		for (const yakuPage of yaku) {
+			if (firstPath === yakuPage) {
+				presenceData.details = "Reading about a yaku";
+				presenceData.state = pageTitle;
+				presenceData.buttons = [{ label: "View Yaku", url: href }];
 				break;
 			}
 		}

--- a/websites/J/Japanese Mahjong Wiki/pages/special.ts
+++ b/websites/J/Japanese Mahjong Wiki/pages/special.ts
@@ -20,6 +20,7 @@ const strategies = new Set([
 		"Tenpai",
 		"Ukeire",
 		"What_would_you_discard",
+		"Dora",
 	]),
 	yaku = new Set([
 		"Menzenchin_tsumohou",
@@ -59,7 +60,8 @@ const strategies = new Set([
 		"Suukantsu",
 		"Tenhou_and_chiihou",
 		"Nagashi_mangan",
-	]);
+	]),
+	games = new Set(["Riichi_City", "Majsoul", "Sega_MJ", "Tenhou.net"]);
 
 /**
  * Applies page details based on the current location.
@@ -148,6 +150,10 @@ export function specialPageHandler(
 				presenceData.details = "Reading about seat winds";
 				break;
 			}
+			case "List_of_mahjong_video_games": {
+				presenceData.details = "Viewing the list of mahjong video games";
+				break;
+			}
 			case "List_of_yaku": {
 				const tables = document.querySelectorAll<HTMLDivElement>(
 					".content-table-wrapper"
@@ -168,6 +174,10 @@ export function specialPageHandler(
 					tmpPresenceData.buttons = [{ label: "View Yaku", url: mainName }];
 					slideshow.addSlide(mainName.textContent, tmpPresenceData, 5e3);
 				}
+				break;
+			}
+			case "Local_yaku": {
+				presenceData.details = "Viewing local yaku";
 				break;
 			}
 			case "Mahjong_equipment": {
@@ -224,6 +234,14 @@ export function specialPageHandler(
 				presenceData.details = "Reading about a yaku";
 				presenceData.state = pageTitle;
 				presenceData.buttons = [{ label: "View Yaku", url: href }];
+				break;
+			}
+		}
+		for (const game of games) {
+			if (firstPath === game) {
+				presenceData.details = "Reading about a mahjong game";
+				presenceData.state = pageTitle;
+				presenceData.buttons = [{ label: "View Game", url: href }];
 				break;
 			}
 		}

--- a/websites/J/Japanese Mahjong Wiki/pages/special.ts
+++ b/websites/J/Japanese Mahjong Wiki/pages/special.ts
@@ -1,4 +1,4 @@
-import { findNearestAboveElement } from "../util/util";
+import { findNearestAboveElement, squareImage } from "../util/util";
 
 // Wiki-specific groups of pages
 const strategies = new Set([
@@ -61,9 +61,8 @@ const strategies = new Set([
 		"Tenhou_and_chiihou",
 		"Nagashi_mangan",
 	]),
-	games = new Set(["Riichi_City", "Majsoul", "Sega_MJ", "Tenhou.net"]);
-
-const SLIDESHOW_TIMEOUT = 6e3;
+	games = new Set(["Riichi_City", "Majsoul", "Sega_MJ", "Tenhou.net"]),
+	SLIDESHOW_TIMEOUT = 6e3;
 
 /**
  * Applies page details based on the current location.
@@ -71,10 +70,10 @@ const SLIDESHOW_TIMEOUT = 6e3;
  * @param presenceData
  * @returns Whether the page uses slideshows.
  */
-export function specialPageHandler(
+export async function specialPageHandler(
 	presenceData: PresenceData,
 	slideshow: Slideshow
-): boolean {
+): Promise<boolean> {
 	const { pathname, href, search } = document.location,
 		searchParams = new URLSearchParams(search),
 		pageTitle = document.querySelector<HTMLSpanElement>(".mw-page-title-main");
@@ -124,8 +123,9 @@ export function specialPageHandler(
 			case firstPath.startsWith("File:"): {
 				presenceData.details = "Viewing a file";
 				presenceData.state = pageTitle;
-				presenceData.smallImageKey =
-					document.querySelector<HTMLImageElement>("#file img");
+				presenceData.smallImageKey = await squareImage(
+					document.querySelector<HTMLImageElement>("#file img")
+				);
 				break;
 			}
 			case firstPath.startsWith("Category:"): {
@@ -162,7 +162,7 @@ export function specialPageHandler(
 					const tmpPresenceData: PresenceData = { ...presenceData },
 						characterImage = character.querySelector("img"),
 						characterName = character.querySelector("p > b");
-					tmpPresenceData.smallImageKey = characterImage;
+					tmpPresenceData.smallImageKey = await squareImage(characterImage);
 					tmpPresenceData.smallImageText = characterName.textContent;
 					tmpPresenceData.state = characterName.textContent;
 					slideshow.addSlide(
@@ -187,7 +187,7 @@ export function specialPageHandler(
 					const tmpPresenceData: PresenceData = { ...presenceData },
 						characterImage = character.querySelector("img"),
 						characterName = character.querySelector("p > b");
-					tmpPresenceData.smallImageKey = characterImage;
+					tmpPresenceData.smallImageKey = await squareImage(characterImage);
 					tmpPresenceData.smallImageText = characterName.textContent;
 					tmpPresenceData.state = characterName.textContent;
 					slideshow.addSlide(
@@ -248,9 +248,9 @@ export function specialPageHandler(
 						descriptions = table
 							.querySelector<HTMLTableRowElement>("tbody > tr + tr")
 							.querySelectorAll<HTMLTableCellElement>("td");
-					for (let i = 0; i < images.length; i++) {
+					for (const [i, image] of images.entries()) {
 						const tmpPresenceData: PresenceData = { ...presenceData };
-						tmpPresenceData.smallImageKey = images[i];
+						tmpPresenceData.smallImageKey = await squareImage(image);
 						tmpPresenceData.smallImageText = descriptions[i];
 						tmpPresenceData.state = sectionTitle;
 						slideshow.addSlide(

--- a/websites/J/Japanese Mahjong Wiki/pages/special.ts
+++ b/websites/J/Japanese Mahjong Wiki/pages/special.ts
@@ -1,3 +1,27 @@
+import { findNearestAboveElement } from "../util/util";
+
+// Wiki-specific groups of pages
+const strategies = new Set([
+	"Sakigiri",
+	"Suji",
+	"Kabe",
+	"Betaori",
+	"Kawa",
+	"Sashikomi",
+	"Defense",
+	"Tile_efficiency",
+	"Atozuke",
+	"Yaku_compatibility",
+	"Damaten",
+	"Kan",
+	"Machi",
+	"Riichi_strategy",
+	"Shanten",
+	"Tenpai",
+	"Ukeire",
+	"What_would_you_discard",
+]);
+
 /**
  * Applies page details based on the current location.
  *
@@ -78,13 +102,35 @@ export function specialPageHandler(
 				);
 				break;
 			}
-			default: {
-				presenceData.details = "Viewing a page";
-				presenceData.state = pageTitle;
-			}
 		}
 		// Wiki-specific pages
 		switch (firstPath) {
+			case "Jikaze": {
+				presenceData.details = "Reading about seat winds";
+				break;
+			}
+			case "List_of_yaku": {
+				const tables = document.querySelectorAll<HTMLDivElement>(
+					".content-table-wrapper"
+				);
+				presenceData.details = "Viewing list of yaku";
+				usesSlideshows = true;
+				for (const table of tables) {
+					const tmpPresenceData: PresenceData = { ...presenceData },
+						mainName = table.querySelector("a"),
+						englishName = table.querySelector("dd dl"),
+						closed = table.querySelector("dd + dd"),
+						description =
+							table.querySelector<HTMLTableCellElement>("td:last-child"),
+						sectionHeader = findNearestAboveElement(table, "h2");
+					tmpPresenceData.state = `${mainName.textContent} (${englishName.textContent}) - ${sectionHeader.textContent}`;
+					tmpPresenceData.smallImageKey = Assets.Question;
+					tmpPresenceData.smallImageText = `${closed.textContent} - ${description.textContent}`;
+					tmpPresenceData.buttons = [{ label: "View Yaku", url: mainName }];
+					slideshow.addSlide(mainName.textContent, tmpPresenceData, 5e3);
+				}
+				break;
+			}
 			case "Mahjong_equipment": {
 				const tables = document.querySelectorAll<HTMLDivElement>(
 					".content-table-wrapper"
@@ -116,10 +162,28 @@ export function specialPageHandler(
 				}
 				break;
 			}
-			case "Rules_overview": {
-				presenceData.details = "Reading about the rules";
+			case "Mentsu": {
+				presenceData.details = "Reading about tile groups";
 				break;
 			}
+			case "Rules_overview": {
+				presenceData.details = "Reading the rules";
+				break;
+			}
+		}
+		// Wiki-specific groups of pages
+		for (const strategy of strategies) {
+			if (firstPath === strategy) {
+				presenceData.details = "Reading about a strategy";
+				presenceData.state = pageTitle;
+				presenceData.buttons = [{ label: "View Strategy", url: href }];
+				break;
+			}
+		}
+
+		if (!presenceData.details) {
+			presenceData.details = "Viewing a page";
+			presenceData.state = pageTitle;
 		}
 	}
 	return usesSlideshows;

--- a/websites/J/Japanese Mahjong Wiki/pages/special.ts
+++ b/websites/J/Japanese Mahjong Wiki/pages/special.ts
@@ -62,7 +62,7 @@ const strategies = new Set([
 		"Nagashi_mangan",
 	]),
 	games = new Set(["Riichi_City", "Majsoul", "Sega_MJ", "Tenhou.net"]),
-	SLIDESHOW_TIMEOUT = 6e3;
+	SLIDESHOW_TIMEOUT = 6000;
 
 /**
  * Applies page details based on the current location.

--- a/websites/J/Japanese Mahjong Wiki/pages/special.ts
+++ b/websites/J/Japanese Mahjong Wiki/pages/special.ts
@@ -150,8 +150,41 @@ export function specialPageHandler(
 				presenceData.details = "Reading about seat winds";
 				break;
 			}
+			case "List_of_Mahjong_Soul_characters": {
+				const characters =
+					document.querySelectorAll<HTMLLIElement>("h2 + ul > li");
+				presenceData.details = "Viewing Mahjong Soul characters";
+				usesSlideshows = true;
+				for (const character of characters) {
+					const tmpPresenceData: PresenceData = { ...presenceData },
+						characterImage = character.querySelector("img"),
+						characterName = character.querySelector("p > b");
+					tmpPresenceData.smallImageKey = characterImage;
+					tmpPresenceData.smallImageText = characterName.textContent;
+					tmpPresenceData.state = characterName.textContent;
+					slideshow.addSlide(characterName.textContent, tmpPresenceData, 5e3);
+				}
+				break;
+			}
 			case "List_of_mahjong_video_games": {
 				presenceData.details = "Viewing the list of mahjong video games";
+				break;
+			}
+			case "List_of_Riichi_City_characters": {
+				const characters = document.querySelectorAll<HTMLLIElement>(
+					"h2 + ul > li, h3 + ul > li"
+				);
+				presenceData.details = "Viewing Riichi City characters";
+				usesSlideshows = true;
+				for (const character of characters) {
+					const tmpPresenceData: PresenceData = { ...presenceData },
+						characterImage = character.querySelector("img"),
+						characterName = character.querySelector("p > b");
+					tmpPresenceData.smallImageKey = characterImage;
+					tmpPresenceData.smallImageText = characterName.textContent;
+					tmpPresenceData.state = characterName.textContent;
+					slideshow.addSlide(characterName.textContent, tmpPresenceData, 5e3);
+				}
 				break;
 			}
 			case "List_of_yaku": {

--- a/websites/J/Japanese Mahjong Wiki/pages/special.ts
+++ b/websites/J/Japanese Mahjong Wiki/pages/special.ts
@@ -63,6 +63,8 @@ const strategies = new Set([
 	]),
 	games = new Set(["Riichi_City", "Majsoul", "Sega_MJ", "Tenhou.net"]);
 
+const SLIDESHOW_TIMEOUT = 6e3;
+
 /**
  * Applies page details based on the current location.
  *
@@ -85,8 +87,8 @@ export function specialPageHandler(
 		presenceData.state = document.querySelector<HTMLInputElement>(
 			"#searchText > input"
 		)?.value;
-	} else if (searchParams.has("action")) {
-		const action = searchParams.get("action");
+	} else if (searchParams.has("action") || searchParams.has("veaction")) {
+		const action = searchParams.get("action") ?? searchParams.get("veaction");
 		switch (action) {
 			case "edit": {
 				presenceData.details = "Editing a page";
@@ -105,7 +107,7 @@ export function specialPageHandler(
 		// Common WikiMedia pages
 		switch (true) {
 			case firstPath.startsWith("Talk:"): {
-				presenceData.details = `Viewing the talk page for '${pageTitle}'`;
+				presenceData.details = `Viewing the talk page for '${pageTitle.textContent}'`;
 				break;
 			}
 			case firstPath.startsWith("User:"): {
@@ -151,8 +153,9 @@ export function specialPageHandler(
 				break;
 			}
 			case "List_of_Mahjong_Soul_characters": {
-				const characters =
-					document.querySelectorAll<HTMLLIElement>("h2 + ul > li");
+				const characters = document.querySelectorAll<HTMLLIElement>(
+					"h2 + ul[style] > li"
+				);
 				presenceData.details = "Viewing Mahjong Soul characters";
 				usesSlideshows = true;
 				for (const character of characters) {
@@ -162,7 +165,11 @@ export function specialPageHandler(
 					tmpPresenceData.smallImageKey = characterImage;
 					tmpPresenceData.smallImageText = characterName.textContent;
 					tmpPresenceData.state = characterName.textContent;
-					slideshow.addSlide(characterName.textContent, tmpPresenceData, 5e3);
+					slideshow.addSlide(
+						characterName.textContent,
+						tmpPresenceData,
+						SLIDESHOW_TIMEOUT
+					);
 				}
 				break;
 			}
@@ -172,7 +179,7 @@ export function specialPageHandler(
 			}
 			case "List_of_Riichi_City_characters": {
 				const characters = document.querySelectorAll<HTMLLIElement>(
-					"h2 + ul > li, h3 + ul > li"
+					".riichi-city-characters > li"
 				);
 				presenceData.details = "Viewing Riichi City characters";
 				usesSlideshows = true;
@@ -183,7 +190,11 @@ export function specialPageHandler(
 					tmpPresenceData.smallImageKey = characterImage;
 					tmpPresenceData.smallImageText = characterName.textContent;
 					tmpPresenceData.state = characterName.textContent;
-					slideshow.addSlide(characterName.textContent, tmpPresenceData, 5e3);
+					slideshow.addSlide(
+						characterName.textContent,
+						tmpPresenceData,
+						SLIDESHOW_TIMEOUT
+					);
 				}
 				break;
 			}
@@ -200,12 +211,19 @@ export function specialPageHandler(
 						closed = table.querySelector("dd + dd"),
 						description =
 							table.querySelector<HTMLTableCellElement>("td:last-child"),
-						sectionHeader = findNearestAboveElement(table, "h2");
+						sectionHeader = findNearestAboveElement(table, "h2").querySelector(
+							".mw-headline"
+						);
+					if (!table.querySelector(".wikitable")) continue;
 					tmpPresenceData.state = `${mainName.textContent} (${englishName.textContent}) - ${sectionHeader.textContent}`;
 					tmpPresenceData.smallImageKey = Assets.Question;
 					tmpPresenceData.smallImageText = `${closed.textContent} - ${description.textContent}`;
 					tmpPresenceData.buttons = [{ label: "View Yaku", url: mainName }];
-					slideshow.addSlide(mainName.textContent, tmpPresenceData, 5e3);
+					slideshow.addSlide(
+						mainName.textContent,
+						tmpPresenceData,
+						SLIDESHOW_TIMEOUT
+					);
 				}
 				break;
 			}
@@ -238,7 +256,7 @@ export function specialPageHandler(
 						slideshow.addSlide(
 							descriptions[i].textContent,
 							tmpPresenceData,
-							5e3
+							SLIDESHOW_TIMEOUT
 						);
 					}
 				}

--- a/websites/J/Japanese Mahjong Wiki/pages/special.ts
+++ b/websites/J/Japanese Mahjong Wiki/pages/special.ts
@@ -1,0 +1,126 @@
+/**
+ * Applies page details based on the current location.
+ *
+ * @param presenceData
+ * @returns Whether the page uses slideshows.
+ */
+export function specialPageHandler(
+	presenceData: PresenceData,
+	slideshow: Slideshow
+): boolean {
+	const { pathname, href, search } = document.location,
+		searchParams = new URLSearchParams(search),
+		pageTitle = document.querySelector<HTMLSpanElement>(".mw-page-title-main");
+	let firstPath = pathname.split("/").find(Boolean),
+		usesSlideshows = false;
+	if (firstPath === "index.php") firstPath = searchParams.get("title");
+
+	if (searchParams.has("search")) {
+		presenceData.details = "Searching for a page";
+		presenceData.state = document.querySelector<HTMLInputElement>(
+			"#searchText > input"
+		)?.value;
+	} else if (searchParams.has("action")) {
+		const action = searchParams.get("action");
+		switch (action) {
+			case "edit": {
+				presenceData.details = "Editing a page";
+				presenceData.state =
+					document.querySelector<HTMLSpanElement>("#firstHeadingTitle") ??
+					pageTitle;
+				break;
+			}
+			case "history": {
+				presenceData.details = "Viewing the revision history of a page";
+				presenceData.state = pageTitle;
+				break;
+			}
+		}
+	} else {
+		// Common WikiMedia pages
+		switch (true) {
+			case firstPath.startsWith("Talk:"): {
+				presenceData.details = `Viewing the talk page for '${pageTitle}'`;
+				break;
+			}
+			case firstPath.startsWith("User:"): {
+				presenceData.details = "Viewing a user page";
+				presenceData.state = pageTitle;
+				presenceData.buttons = [{ label: "View User Page", url: href }];
+				break;
+			}
+			case firstPath.startsWith("User_talk:"): {
+				presenceData.details = "Viewing a user's talk page";
+				presenceData.state = pageTitle;
+				break;
+			}
+			case firstPath.startsWith("File:"): {
+				presenceData.details = "Viewing a file";
+				presenceData.state = pageTitle;
+				presenceData.smallImageKey =
+					document.querySelector<HTMLImageElement>("#file img");
+				break;
+			}
+			case firstPath.startsWith("Category:"): {
+				presenceData.details = "Viewing a category";
+				presenceData.state = pageTitle;
+				presenceData.buttons = [{ label: "View Category", url: href }];
+				break;
+			}
+			case firstPath === "Special:Upload": {
+				presenceData.details = "Uploading a file";
+				break;
+			}
+			case firstPath === "Special:Contributions": {
+				presenceData.details = "Viewing a user's contributions";
+				presenceData.state = document.querySelector<HTMLAnchorElement>(
+					".mw-contributions-user-tools > a"
+				);
+				break;
+			}
+			default: {
+				presenceData.details = "Viewing a page";
+				presenceData.state = pageTitle;
+			}
+		}
+		// Wiki-specific pages
+		switch (firstPath) {
+			case "Mahjong_equipment": {
+				const tables = document.querySelectorAll<HTMLDivElement>(
+					".content-table-wrapper"
+				);
+				presenceData.details = "Reading about the mahjong equipment";
+				usesSlideshows = true;
+				for (const table of tables) {
+					const sectionTitle =
+							table.previousElementSibling.querySelector<HTMLSpanElement>(
+								".mw-headline"
+							),
+						images = table
+							.querySelector<HTMLTableRowElement>("tbody > tr")
+							.querySelectorAll<HTMLImageElement>("td img"),
+						descriptions = table
+							.querySelector<HTMLTableRowElement>("tbody > tr + tr")
+							.querySelectorAll<HTMLTableCellElement>("td");
+					for (let i = 0; i < images.length; i++) {
+						const tmpPresenceData: PresenceData = { ...presenceData };
+						tmpPresenceData.smallImageKey = images[i];
+						tmpPresenceData.smallImageText = descriptions[i];
+						tmpPresenceData.state = sectionTitle;
+						slideshow.addSlide(
+							descriptions[i].textContent,
+							tmpPresenceData,
+							5e3
+						);
+					}
+				}
+				break;
+			}
+			case "Rules_overview": {
+				presenceData.details = "Reading about the rules";
+				break;
+			}
+		}
+	}
+	return usesSlideshows;
+}

--- a/websites/J/Japanese Mahjong Wiki/pages/static.ts
+++ b/websites/J/Japanese Mahjong Wiki/pages/static.ts
@@ -1,3 +1,4 @@
+// MediaWiki static pages
 export const staticPages: Record<string, PresenceData> = {
 	"/Main_Page": {
 		details: "Viewing the main page",

--- a/websites/J/Japanese Mahjong Wiki/pages/static.ts
+++ b/websites/J/Japanese Mahjong Wiki/pages/static.ts
@@ -1,0 +1,17 @@
+export const staticPages: Record<string, PresenceData> = {
+	"/Main_Page": {
+		details: "Viewing the main page",
+	},
+	"/Special:RecentChanges": {
+		details: "Viewing recent changes",
+	},
+	"/Special:SpecialPages": {
+		details: "Viewing special pages",
+	},
+	"/Special:Preferences": {
+		details: "Managing their preferences",
+	},
+	"/Special:Watchlist": {
+		details: "Viewing their watchlist",
+	},
+};

--- a/websites/J/Japanese Mahjong Wiki/presence.ts
+++ b/websites/J/Japanese Mahjong Wiki/presence.ts
@@ -17,6 +17,7 @@ presence.on("UpdateData", () => {
 	const presenceData: PresenceData = {
 			largeImageKey: Assets.Logo,
 			startTimestamp: browsingTimestamp,
+			name: "Japanese Mahjong Wiki",
 		},
 		{ pathname } = document.location;
 

--- a/websites/J/Japanese Mahjong Wiki/presence.ts
+++ b/websites/J/Japanese Mahjong Wiki/presence.ts
@@ -13,7 +13,7 @@ const enum Assets {
 	Logo = "https://i.imgur.com/3xMqFwy.png",
 }
 
-presence.on("UpdateData", () => {
+presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
 			largeImageKey: Assets.Logo,
 			startTimestamp: browsingTimestamp,
@@ -36,11 +36,9 @@ presence.on("UpdateData", () => {
 		}
 	}
 
-	if (!isStatic) usesSlideshows = specialPageHandler(presenceData, slideshow);
+	if (!isStatic)
+		usesSlideshows = await specialPageHandler(presenceData, slideshow);
 
-	if (usesSlideshows) {
-		presence.setActivity(slideshow);
-	} else if (presenceData.details) {
-		presence.setActivity(presenceData);
-	}
+	if (usesSlideshows) presence.setActivity(slideshow);
+	else if (presenceData.details) presence.setActivity(presenceData);
 });

--- a/websites/J/Japanese Mahjong Wiki/presence.ts
+++ b/websites/J/Japanese Mahjong Wiki/presence.ts
@@ -1,0 +1,45 @@
+import { specialPageHandler } from "./pages/special";
+import { staticPages } from "./pages/static";
+
+const presence = new Presence({
+		clientId: "1221269583567261786",
+	}),
+	slideshow = presence.createSlideshow(),
+	browsingTimestamp = Math.floor(Date.now() / 1000);
+
+let oldPage: string;
+
+const enum Assets {
+	Logo = "https://i.imgur.com/3xMqFwy.png",
+}
+
+presence.on("UpdateData", () => {
+	const presenceData: PresenceData = {
+			largeImageKey: Assets.Logo,
+			startTimestamp: browsingTimestamp,
+		},
+		{ pathname } = document.location;
+
+	if (oldPage !== pathname) {
+		oldPage = pathname;
+		slideshow.deleteAllSlides();
+	}
+
+	let isStatic = false,
+		usesSlideshows = false;
+	for (const [path, data] of Object.entries(staticPages)) {
+		if (path === pathname) {
+			isStatic = true;
+			Object.assign(presenceData, data);
+			break;
+		}
+	}
+
+	if (!isStatic) usesSlideshows = specialPageHandler(presenceData, slideshow);
+
+	if (usesSlideshows) {
+		presence.setActivity(slideshow);
+	} else if (presenceData.details) {
+		presence.setActivity(presenceData);
+	}
+});

--- a/websites/J/Japanese Mahjong Wiki/util/util.ts
+++ b/websites/J/Japanese Mahjong Wiki/util/util.ts
@@ -9,3 +9,34 @@ export function findNearestAboveElement(
 	}
 	return null;
 }
+
+const imageCache: Record<string, Promise<Blob | string>> = {};
+export async function squareImage(
+	image: HTMLImageElement
+): Promise<Blob | string> {
+	const { src, width, height } = image;
+	if (imageCache[src]) return imageCache[src];
+	const canvas = document.createElement("canvas"),
+		ctx = canvas.getContext("2d");
+	canvas.width = width;
+	canvas.height = height;
+	if (width > height) canvas.height = width;
+	if (height > width) canvas.width = height;
+	if (width === height) {
+		imageCache[src] = Promise.resolve(src);
+		return src;
+	}
+	ctx.clearRect(0, 0, canvas.width, canvas.height);
+	ctx.drawImage(
+		image,
+		(canvas.width - width) / 2,
+		(canvas.height - height) / 2
+	);
+	const output = new Promise<Blob>(resolve => {
+		canvas.toBlob(blob => {
+			resolve(blob);
+		});
+	});
+	imageCache[src] = output;
+	return output;
+}

--- a/websites/J/Japanese Mahjong Wiki/util/util.ts
+++ b/websites/J/Japanese Mahjong Wiki/util/util.ts
@@ -1,0 +1,11 @@
+export function findNearestAboveElement(
+	element: Element,
+	selector: string
+): Element | null {
+	let currentElement: Element | null = element;
+	while (currentElement) {
+		if (currentElement.matches(selector)) return currentElement;
+		currentElement = currentElement.previousElementSibling;
+	}
+	return null;
+}


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Adds a presence for the Japanese Mahjong Wiki (riichi.wiki)

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![2024-03-23 21_34_13](https://github.com/PreMiD/Presences/assets/32113157/8bad7969-0453-4927-9500-8bc8b5c320eb)
![2024-03-23 21_35_29](https://github.com/PreMiD/Presences/assets/32113157/f87498eb-b02a-4cd1-9cd1-f483520525e0)
![2024-03-23 21_16_04](https://github.com/PreMiD/Presences/assets/32113157/10e635a4-54a1-46c7-8e84-490e7ae46869)
![2024-03-23 21_24_58](https://github.com/PreMiD/Presences/assets/32113157/a11debba-607b-45ff-b2b1-f5a2dec777df)


</details>
