### PR TITLE
feat(Mahjong Soul): add more domains

### DIFF
--- a/websites/M/Mahjong Soul/metadata.json
+++ b/websites/M/Mahjong Soul/metadata.json
@@ -11,14 +11,18 @@
 	"url": [
 		"mahjongsoul.game.yo-star.com",
 		"mahjongsoul.yo-star.com",
-		"game.maj-soul.com"
+		"game.maj-soul.com",
+		"game.mahjongsoul.com",
+		"mahjongsoul.com"
 	],
 	"matches": [
 		"*://mahjongsoul.game.yo-star.com/*",
 		"*://mahjongsoul.yo-star.com/*",
-		"*://game.maj-soul.com/*"
+		"*://game.maj-soul.com/*",
+		"*://game.mahjongsoul.com/*",
+		"*://mahjongsoul.com/*"
 	],
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/M/Mahjong%20Soul/assets/logo.jpeg",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/M/Mahjong%20Soul/assets/thumbnail.jpg",
 	"color": "#A83A36",

--- a/websites/M/Mahjong Soul/presence.ts
+++ b/websites/M/Mahjong Soul/presence.ts
@@ -39,7 +39,10 @@ presence.on("UpdateData", async () => {
 		pathList = pathname.split("/").filter(Boolean);
 
 	let usesSlideshow = false;
-	if (hostname === "mahjongsoul.yo-star.com") {
+	if (
+		hostname === "mahjongsoul.yo-star.com" ||
+		hostname === "mahjongsoul.com"
+	) {
 		switch (pathList[0]) {
 			case "news": {
 				if (pathList[1]) {


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Adds the Japanese version domains to the metadata. The internal code and structure appears to be the same

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)
