### PR TITLE
fix(bilibilitv): not detect watching an anime

### DIFF
--- a/websites/B/bilibilitv/metadata.json
+++ b/websites/B/bilibilitv/metadata.json
@@ -19,7 +19,7 @@
 		"www.bilibili.tv",
 		"studio.bilibili.tv"
 	],
-	"version": "2.0.11",
+	"version": "2.0.12",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/B/bilibilitv/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/B/bilibilitv/assets/thumbnail.png",
 	"color": "#2e62ff",

--- a/websites/B/bilibilitv/presence.ts
+++ b/websites/B/bilibilitv/presence.ts
@@ -50,7 +50,8 @@ presence.on("UpdateData", async () => {
 	}
 	// Main Site
 	if (hostname === "www.bilibili.tv") {
-		switch (pathArray[2]) {
+		const pathKey = isNaN(Number(pathArray[2])) ? pathArray[2] : pathArray[1];
+		switch (pathKey) {
 			case "video": {
 				presenceData.details = strings.watchingVid;
 				presenceData.state = title;
@@ -115,7 +116,7 @@ presence.on("UpdateData", async () => {
 				break;
 			}
 		}
-		if (pathArray[2] === "video" || pathArray[2] === "play") {
+		if (pathKey === "video" || pathKey === "play") {
 			presenceData.largeImageKey = thumbnail;
 			presenceData.smallImageKey = playing ? Assets.Play : Assets.Pause;
 			if (playing) {


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Does not appear or is not detected when watching anime.

This happens when I use the search feature on bilibili and start watching but the Activity Tab doesn't show that I'm watching but in details I'm browsing on the home pages

Because there is no `id` or `en` after `play`
for example:
https://www.bilibili.tv/play/2090295
not like:
https://www.bilibili.tv/en/play/2090295

## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

[Link Anime](https://www.bilibili.tv/en/play/2097863)
![Screenshot 2024-04-17 153211](https://github.com/PreMiD/Presences/assets/107149635/18551396-679b-41bb-9a94-08f099ce44de)
[Link Anime](https://www.bilibili.tv/play/2090295)
![Screenshot 2024-04-17 153447](https://github.com/PreMiD/Presences/assets/107149635/40da0038-bc30-4d48-a313-6b065fc665ad)
</details>


