### PR TITLE
feat(Reddit): Add support for old layout

### DIFF
--- a/websites/R/Reddit/metadata.json
+++ b/websites/R/Reddit/metadata.json
@@ -36,6 +36,7 @@
 	},
 	"url": [
 		"www.reddit.com",
+		"new.reddit.com",
 		"old.reddit.com"
 	],
 	"version": "3.1.10",

--- a/websites/R/Reddit/metadata.json
+++ b/websites/R/Reddit/metadata.json
@@ -39,7 +39,7 @@
 		"new.reddit.com",
 		"old.reddit.com"
 	],
-	"version": "3.1.10",
+	"version": "3.1.11",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/R/Reddit/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/R/Reddit/assets/thumbnail.png",
 	"color": "#ff4500",


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Reddit's layout changed and the old one can be found at new.reddit.com. This URL was added so the presence can work on there as well.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)