### PR TITLE
feat(Neko-sama.fr): display anime img if episode img is not present

### DIFF
--- a/websites/N/Neko-sama.fr/metadata.json
+++ b/websites/N/Neko-sama.fr/metadata.json
@@ -13,7 +13,7 @@
 		"www.neko-sama.fr",
 		"neko-sama.fr"
 	],
-	"version": "1.0.11",
+	"version": "1.0.12",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/N/Neko-sama.fr/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/N/Neko-sama.fr/assets/thumbnail.png",
 	"color": "#1CB9F4",

--- a/websites/N/Neko-sama.fr/metadata.json
+++ b/websites/N/Neko-sama.fr/metadata.json
@@ -11,7 +11,9 @@
 	},
 	"url": [
 		"www.neko-sama.fr",
-		"neko-sama.fr"
+		"neko-sama.fr",
+		"www.animecat.net",
+		"animecat.net"
 	],
 	"version": "1.0.12",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/N/Neko-sama.fr/assets/logo.png",

--- a/websites/N/Neko-sama.fr/presence.ts
+++ b/websites/N/Neko-sama.fr/presence.ts
@@ -36,7 +36,7 @@ function timeToString(nbr: number): string {
 	return nbrString;
 }
 
-const websiteDomain = "https://neko-sama.fr";
+const websiteDomain = "https://animecat.net";
 
 let video: Video = null;
 

--- a/websites/N/Neko-sama.fr/presence.ts
+++ b/websites/N/Neko-sama.fr/presence.ts
@@ -61,18 +61,24 @@ presence.on("UpdateData", async () => {
 			switch (pathSplit[2]) {
 				case "episode": {
 					const episodeImage: string = document.querySelector<HTMLMetaElement>(
-						'meta[property="og:image"]'
-					).content;
+							'meta[property="og:image"]'
+						).content,
+						animeImage: string =
+							document.querySelector<HTMLImageElement>("a.cover img").src,
+						defaultThumbnail = `${websiteDomain}/images/default_thumbnail.png`;
+					presenceData.largeImageKey =
+						episodeImage === defaultThumbnail
+							? animeImage === defaultThumbnail
+								? Assets.Logo
+								: animeImage
+							: episodeImage;
 					if (video === null) {
 						presenceData.details = `Regarde ${
 							document.querySelector<HTMLMetaElement>(
 								'meta[property="og:title"]'
 							).content
 						}`;
-						presenceData.largeImageKey =
-							episodeImage === `${websiteDomain}/images/default_thumbnail.png`
-								? Assets.Logo
-								: episodeImage;
+
 						presenceData.buttons = [
 							{
 								label: "Voir Épisode",
@@ -94,10 +100,6 @@ presence.on("UpdateData", async () => {
 						document.querySelector<HTMLMetaElement>('meta[property="og:title"]')
 							.content
 					}`;
-					presenceData.largeImageKey =
-						episodeImage === `${websiteDomain}/images/default_thumbnail.png`
-							? Assets.Logo
-							: episodeImage;
 					presenceData.smallImageKey = paused ? Assets.Pause : Assets.Play;
 					presenceData.smallImageText = paused
 						? "En pause"


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Before, when an episode didn't have a thumbnail, the default logo of neko-sama was displayed.
Now, when an episode doesn't have a thumbnail, the anime thumbnail is displayed (and if there's no anime thumbnail, then the default thumbnail is displayed).
I also fixed the domain name, which was replaced by "animecat.net"

## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
Before the bug fix:
![image](https://github.com/PreMiD/Presences/assets/35999932/40820dfe-692f-4a82-bc32-3064fb85acce)
Before the feature:
 ![image](https://github.com/PreMiD/Presences/assets/35999932/f114a1d3-f9d9-4c4f-849d-5d0496c6f515)
After:
 ![image](https://github.com/PreMiD/Presences/assets/35999932/e30025b6-5319-4dbf-8e69-55e6a59c2159)



</details>
