### PR TITLE
fix(Youtube Music): timestamps

### DIFF
--- a/websites/Y/YouTube Music/metadata.json
+++ b/websites/Y/YouTube Music/metadata.json
@@ -82,7 +82,7 @@
 		},
 		{
 			"id": "usetimeleft",
-			"title": "Use time left",
+			"title": "Use Time Left",
 			"icon": "fad fa-stopwatch",
 			"value": true
 		}

--- a/websites/Y/YouTube Music/metadata.json
+++ b/websites/Y/YouTube Music/metadata.json
@@ -79,6 +79,12 @@
 			"if": {
 				"privacy": false
 			}
+		},
+		{
+			"id": "usetimeleft",
+			"title": "Use time left",
+			"icon": "fad fa-stopwatch",
+			"value": true
 		}
 	]
 }

--- a/websites/Y/YouTube Music/metadata.json
+++ b/websites/Y/YouTube Music/metadata.json
@@ -22,7 +22,7 @@
 	"matches": [
 		"*://music.youtube.com/*"
 	],
-	"version": "3.0.18",
+	"version": "3.0.19",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/thumbnail.png",
 	"color": "#E40813",

--- a/websites/Y/YouTube Music/metadata.json
+++ b/websites/Y/YouTube Music/metadata.json
@@ -81,7 +81,7 @@
 			}
 		},
 		{
-			"id": "usetimeleft",
+			"id": "useTimeLeft",
 			"title": "Use Time Left",
 			"icon": "fad fa-stopwatch",
 			"value": true

--- a/websites/Y/YouTube Music/presence.ts
+++ b/websites/Y/YouTube Music/presence.ts
@@ -18,7 +18,7 @@ presence.on("UpdateData", async () => {
 			hidePaused,
 			showBrowsing,
 			privacyMode,
-			usetimeleft,
+			useTimeLeft,
 		] = await Promise.all([
 			presence.getSetting<boolean>("buttons"),
 			presence.getSetting<boolean>("timestamps"),
@@ -26,7 +26,7 @@ presence.on("UpdateData", async () => {
 			presence.getSetting<boolean>("hidePaused"),
 			presence.getSetting<boolean>("browsing"),
 			presence.getSetting<boolean>("privacy"),
-			presence.getSetting<boolean>("usetimeleft"),
+			presence.getSetting<boolean>("useTimeLeft"),
 		]),
 		{ mediaSession } = navigator,
 		watchID =
@@ -44,11 +44,11 @@ presence.on("UpdateData", async () => {
 		if (!videoListenerAttached) {
 			//* If video scrobbled, update timestamps
 			videoElement.addEventListener("seeked", () =>
-				updateSongTimestamps(usetimeleft)
+				updateSongTimestamps(useTimeLeft)
 			);
 			//* If video resumes playing, update timestamps
 			videoElement.addEventListener("play", () =>
-				updateSongTimestamps(usetimeleft)
+				updateSongTimestamps(useTimeLeft)
 			);
 
 			videoListenerAttached = true;
@@ -86,7 +86,7 @@ presence.on("UpdateData", async () => {
 					.querySelector<HTMLSpanElement>("#left-controls > span")
 					.textContent.trim()
 		) {
-			updateSongTimestamps(usetimeleft);
+			updateSongTimestamps(useTimeLeft);
 
 			if (mediaTimestamps[0] === mediaTimestamps[1]) return;
 
@@ -270,7 +270,7 @@ presence.on("UpdateData", async () => {
 	presence.setActivity(presenceData);
 });
 
-function updateSongTimestamps(usetimeleft: boolean) {
+function updateSongTimestamps(useTimeLeft: boolean) {
 	const element = document
 			.querySelector<HTMLSpanElement>("#left-controls > span")
 			.textContent.trim()
@@ -278,7 +278,7 @@ function updateSongTimestamps(usetimeleft: boolean) {
 		[currTimes, totalTimes] = element;
 
 	mediaTimestamps = presence.getTimestamps(
-		usetimeleft ? presence.timestampFromFormat(currTimes) : Date.now(),
-		usetimeleft ? presence.timestampFromFormat(totalTimes) : null
+		useTimeLeft ? presence.timestampFromFormat(currTimes) : Date.now(),
+		useTimeLeft ? presence.timestampFromFormat(totalTimes) : null
 	);
 }


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
* Changed all `ActivityType.Listening` to `ActivityType.Playing` so the timestamps are actually displayed
* Added the "Use Time Left" setting that allows a user to switch between displaying the time left and displaying the time elapsed

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>

![image](https://github.com/PreMiD/Presences/assets/58801387/19974c40-4d16-4c27-a07f-2c3dcd16d252)

![image](https://github.com/PreMiD/Presences/assets/58801387/02532c9c-4c39-4d72-99b7-a1b00da3a808)

![image](https://github.com/PreMiD/Presences/assets/58801387/cce0c91d-8c4f-4ec9-9197-341e5092d500)


<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

</details>

Resolves https://github.com/PreMiD/Presences/issues/8262
