### PR TITLE
feat(AnimeDrive): add presence

### DIFF
--- a/websites/A/AnimeDrive/metadata.json
+++ b/websites/A/AnimeDrive/metadata.json
@@ -1,0 +1,25 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.9",
+	"author": {
+		"id": "291136400068444161",
+		"name": "ferivoq"
+	},
+	"service": "AnimeDrive",
+	"description": {
+		"en": "AnimeDrive is an anime streaming website with Hungarian subs/dubs"
+	},
+	"url": [
+		"animedrive.hu",
+		"www.animedrive.hu"
+	],
+	"version": "1.0.0",
+	"logo": "https://cdn.discordapp.com/icons/702098578251841577/be50b5dbcb30bd99512b6df29284db0c.webp",
+	"thumbnail": "https://i.imgur.com/uP6s5yc.png",
+	"color": "#6f0094",
+	"category": "anime",
+	"tags": [
+		"anime",
+		"animes",
+		"animedrive"
+	]
+}

--- a/websites/A/AnimeDrive/presence.ts
+++ b/websites/A/AnimeDrive/presence.ts
@@ -1,0 +1,83 @@
+const presence = new Presence({
+	clientId: "1211027222815711282",
+}), browsingTimestamp = Math.floor(Date.now() / 1000);;
+
+presence.on("UpdateData", async () => {
+	const presenceData: PresenceData = {
+		largeImageKey:
+			"https://cdn.discordapp.com/icons/702098578251841577/be50b5dbcb30bd99512b6df29284db0c.webp",
+		startTimestamp: browsingTimestamp,
+		buttons: [{ 
+            label: "Meglátogatás", 
+            url: "https://animedrive.hu/" 
+        }]
+	},
+		{ pathname, search } = document.location;
+
+	switch (pathname) {
+		case "/": {
+			presenceData.details = "Főoldal Böngészése";
+			break;
+		}
+		case "/search/": {
+			presenceData.details = "Anime Keresése";
+			break;
+		}
+		case "/anime/": {
+			if (search.startsWith("?id=")) {
+				const animeId = search.split("?id=")[1].split("&")[0];
+				const contentDiv = document.querySelector('.col-sm-12.col-md-8.col-lg-9');
+				const h2Content = contentDiv ? contentDiv.querySelector('h2') : null;
+				const h4Content = contentDiv ? contentDiv.querySelector('h4') : null;
+
+				if (h4Content && h4Content.textContent.trim()) {
+					presenceData.details = `Adatlap böngészése:`;
+					presenceData.state = `${h2Content.textContent.trim()}`;
+				} else if (h2Content && h2Content.textContent.trim()) {
+					presenceData.details = `Adatlap böngészése:`;
+					presenceData.state = `${h2Content.textContent.trim()}`;
+				} else {
+					presenceData.details = `Adatlap böngészése:`;
+					presenceData.state = `ID: ${animeId}`;
+				}
+
+				presenceData.buttons.push({
+					label: "Adatlap",
+					url: `https://animedrive.hu/anime/?id=${animeId}`
+				});
+			} else {
+				presenceData.details = "Anime Böngészése";
+			}
+			break;
+		}
+		case "/watch/": {
+			if (search.startsWith("?id=")) {
+				const animeId = search.split("?id=")[1].split("&")[0];
+				const linkElement = document.querySelector('a.text-white[href^="https://animedrive.hu/anime/?id="]');
+				const h2Element = linkElement ? linkElement.querySelector('h2') : null;
+
+				const episodeElement = document.querySelector('a.nk-pagination-current-white');
+				const epModified = episodeElement.textContent.match(/\d+/)[0];
+		
+				if (h2Element && h2Element.textContent.trim()) {
+					presenceData.details = `${h2Element.textContent.trim()}`;
+					presenceData.state = `Epizód: ${episodeElement.textContent.trim()}`;
+				} else {
+					presenceData.details = `Adatlap böngészése:`;
+					presenceData.state = `ID: ${animeId}`;
+				}
+		
+				presenceData.buttons.push({
+					label: "Lejátszás",
+					url: `https://animedrive.hu/watch/?id=${animeId}&ep=${epModified}`
+				});
+			} else {
+				presenceData.details = "Anime Nézése";
+			}
+			break;
+		}		
+		default:
+			presenceData.details = "AnimeDrive Böngészése";
+	}
+	presence.setActivity(presenceData);
+});


### PR DESCRIPTION
## Description 
I added support for AnimeDrive.hu.
With the following routes: /, /search /anime/, /watch

## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
![animedrive-proof](https://github.com/PreMiD/Presences/assets/36544651/245b4cb3-0ee0-47c2-bd2c-79212c986b92)
![animedrive-proof-2](https://github.com/PreMiD/Presences/assets/36544651/226d6674-fc39-4da9-a0ac-7a9b8ac39a31)
</details>
