### PR TITLE
fix(YouTube): added auto-hide option

### DIFF
--- a/websites/Y/YouTube/metadata.json
+++ b/websites/Y/YouTube/metadata.json
@@ -96,6 +96,15 @@
 			"value": false
 		},
 		{
+			"id": "hidePaused",
+			"title": "Hide Paused",
+			"icon": "fad fa-pause-circle",
+			"value": false,
+			"if": {
+				"privacy": false
+			}
+		},
+		{
 			"id": "privacy-shown",
 			"title": "Show Privacy Button",
 			"icon": "fad fa-eye-low-vision",

--- a/websites/Y/YouTube/metadata.json
+++ b/websites/Y/YouTube/metadata.json
@@ -75,7 +75,7 @@
 		"*://www.youtube.com/*",
 		"*://studio.youtube.com/*"
 	],
-	"version": "5.10.4",
+	"version": "5.10.5",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/thumbnail.jpg",
 	"color": "#E40813",

--- a/websites/Y/YouTube/presence.ts
+++ b/websites/Y/YouTube/presence.ts
@@ -77,8 +77,9 @@ presence.on("UpdateData", async () => {
 
 	if (video) {
 		const { mediaSession } = navigator;
-		if (mediaSession.playbackState !== "playing" && hidePaused) return presence.clearActivity();
-		
+		if (mediaSession.playbackState !== "playing" && hidePaused)
+			return presence.clearActivity();
+
 		const resolver = [
 				youtubeEmbedResolver,
 				youtubeShortsResolver,

--- a/websites/Y/YouTube/presence.ts
+++ b/websites/Y/YouTube/presence.ts
@@ -51,6 +51,7 @@ presence.on("UpdateData", async () => {
 			channelPic,
 			logo,
 			buttons,
+			hidePaused,
 		] = [
 			getSetting<string>("lang", "en"),
 			getSetting<boolean>("privacy", true),
@@ -62,6 +63,7 @@ presence.on("UpdateData", async () => {
 			getSetting<boolean>("channelPic", false),
 			getSetting<number>("logo", 0),
 			getSetting<boolean>("buttons", true),
+			getSetting<boolean>("hidePaused", true),
 		],
 		{ pathname, hostname, search, href } = document.location;
 
@@ -74,6 +76,9 @@ presence.on("UpdateData", async () => {
 	).find(video => video.duration);
 
 	if (video) {
+		const { mediaSession } = navigator;
+		if (mediaSession.playbackState !== "playing" && hidePaused) return presence.clearActivity();
+		
 		const resolver = [
 				youtubeEmbedResolver,
 				youtubeShortsResolver,


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Added a toggle that clears/hides the presence when the video is paused.

resolves https://github.com/PreMiD/Presences/issues/8061

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>

![image](https://github.com/PreMiD/Presences/assets/58801387/574ee19c-6d16-4669-931f-00a6e492b889)

<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

</details>
