### PR TITLE
fix(Animeflix): Fixed watch page status

### DIFF
--- a/websites/A/Animeflix/presence.ts
+++ b/websites/A/Animeflix/presence.ts
@@ -32,21 +32,9 @@ presence.on("UpdateData", async () => {
 		}
 		default:
 			if (pathname.includes("/watch")) {
-				const episodeName = document.querySelector<HTMLMetaElement>(
-					'meta[name="anime-skip.episode.name"]'
-				);
-				presenceData.details = `Watching ${
-					document.querySelector<HTMLMetaElement>(
-						'meta[name="anime-skip.show.name"]'
-					).content
-				}`;
-				presenceData.state = episodeName.content.includes("Episode")
-					? episodeName.content
-					: `${
-							document.querySelector<HTMLMetaElement>(
-								'meta[name="anime-skip.episode.number"]'
-							).content
-					  }. ${episodeName.content}`;
+				const epData = JSON.parse(document.querySelector<HTMLMetaElement>('script[id="syncData"]').textContent);
+				presenceData.details = `Watching ${epData.name.replace(/\b[a-z]/g, (letter: string) => letter.toUpperCase())}`;
+				presenceData.state = `Watch for free on Animeflix!`;
 			} else presenceData.details = "Exploring Animeflix";
 	}
 	presence.setActivity(presenceData);


### PR DESCRIPTION
Fixes the Animeflix watch page status which didn't display the anime name correctly.

## Description 
<!-- Fixes the Animeflix watching status which didn't display the anime name correctly due to site updates. -->

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    https://i.imgur.com/K4bslwC.png
    https://i.imgur.com/PLvgdoH.png
-->



</details>
