### PR TITLE
feat(AnimeDrive): add support for iFrame and Hungarian description

### DIFF
--- a/websites/A/AnimeDrive/iframe.ts
+++ b/websites/A/AnimeDrive/iframe.ts
@@ -1,0 +1,13 @@
+const iframe = new iFrame();
+
+iframe.on("UpdateData", async () => {
+	const video = document.querySelector("video");
+
+	if (video) {
+		iframe.send({
+			currentTime: video.currentTime,
+			paused: video.paused,
+			duration: video.duration,
+		});
+	} else console.error("Video element not found.");
+});

--- a/websites/A/AnimeDrive/iframe.ts
+++ b/websites/A/AnimeDrive/iframe.ts
@@ -9,5 +9,5 @@ iframe.on("UpdateData", async () => {
 			paused: video.paused,
 			duration: video.duration,
 		});
-	} else console.error("Video element not found.");
+	}
 });

--- a/websites/A/AnimeDrive/metadata.json
+++ b/websites/A/AnimeDrive/metadata.json
@@ -13,7 +13,7 @@
 		"animedrive.hu",
 		"www.animedrive.hu"
 	],
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"logo": "https://cdn.discordapp.com/icons/702098578251841577/be50b5dbcb30bd99512b6df29284db0c.webp",
 	"thumbnail": "https://i.imgur.com/uP6s5yc.png",
 	"color": "#6f0094",

--- a/websites/A/AnimeDrive/metadata.json
+++ b/websites/A/AnimeDrive/metadata.json
@@ -14,8 +14,8 @@
 		"www.animedrive.hu"
 	],
 	"version": "1.0.2",
-	"logo": "https://cdn.discordapp.com/icons/702098578251841577/be50b5dbcb30bd99512b6df29284db0c.webp",
-	"thumbnail": "https://i.imgur.com/uP6s5yc.png",
+	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeDrive/assets/logo.png",
+	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeDrive/assets/thumbnail.png",
 	"color": "#6f0094",
 	"category": "anime",
 	"tags": [

--- a/websites/A/AnimeDrive/metadata.json
+++ b/websites/A/AnimeDrive/metadata.json
@@ -13,7 +13,7 @@
 		"animedrive.hu",
 		"www.animedrive.hu"
 	],
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"logo": "https://cdn.discordapp.com/icons/702098578251841577/be50b5dbcb30bd99512b6df29284db0c.webp",
 	"thumbnail": "https://i.imgur.com/uP6s5yc.png",
 	"color": "#6f0094",

--- a/websites/A/AnimeDrive/metadata.json
+++ b/websites/A/AnimeDrive/metadata.json
@@ -6,20 +6,23 @@
 	},
 	"service": "AnimeDrive",
 	"description": {
-		"en": "AnimeDrive is an anime streaming website with Hungarian subs/dubs"
+		"en": "AnimeDrive is an anime streaming website with Hungarian subs/dubs",
+		"hu": "Az AnimeDrive egy anime streaming weboldal Magyar felirattal/szinkronnal"
 	},
 	"url": [
 		"animedrive.hu",
 		"www.animedrive.hu"
 	],
-	"version": "1.0.1",
-	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeDrive/assets/logo.png",
-	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeDrive/assets/thumbnail.png",
+	"version": "1.0.0",
+	"logo": "https://cdn.discordapp.com/icons/702098578251841577/be50b5dbcb30bd99512b6df29284db0c.webp",
+	"thumbnail": "https://i.imgur.com/uP6s5yc.png",
 	"color": "#6f0094",
 	"category": "anime",
 	"tags": [
 		"anime",
 		"animes",
 		"animedrive"
-	]
+	],
+	"iframe": true,
+	"iFrameRegExp": ".*"
 }

--- a/websites/A/AnimeDrive/presence.ts
+++ b/websites/A/AnimeDrive/presence.ts
@@ -1,13 +1,20 @@
 const presence = new Presence({
-		clientId: "1211027222815711282",
-	}),
-	browsingTimestamp = Math.floor(Date.now() / 1000);
+	clientId: "1211027222815711282",
+});
+
+let videoData: {
+	duration: number;
+	paused: boolean;
+	currentTime: number;
+};
+
+presence.on("iFrameData", (data: typeof videoData) => {
+	videoData = data;
+});
 
 presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
-			largeImageKey:
-				"https://cdn.rcd.gg/PreMiD/websites/A/AnimeDrive/assets/logo.png",
-			startTimestamp: browsingTimestamp,
+			largeImageKey: "https://i.imgur.com/VlBtvJo.png",
 		},
 		{ pathname, search } = document.location;
 
@@ -60,7 +67,9 @@ presence.on("UpdateData", async () => {
 					);
 				if (h2Element && h2Element.textContent.trim()) {
 					presenceData.details = `${h2Element.textContent.trim()}`;
-					presenceData.state = `Epizód: ${episodeElement.textContent.trim()}`;
+					presenceData.state = `${
+						episodeElement.textContent.match(/\d+/)[0]
+					}. rész`;
 				} else {
 					presenceData.details = "Adatlap böngészése:";
 					presenceData.state = `ID: ${animeId}`;
@@ -74,6 +83,22 @@ presence.on("UpdateData", async () => {
 						}`,
 					},
 				];
+
+				if (videoData) {
+					presenceData.smallImageKey = videoData.paused
+						? Assets.Pause
+						: Assets.Play;
+					presenceData.smallImageText = videoData.paused ? "Szünet" : "Néz";
+
+					if (!videoData.paused) {
+						const [startTimestamp, endTimestamp] = presence.getTimestamps(
+							videoData.currentTime,
+							videoData.duration
+						);
+						presenceData.startTimestamp = startTimestamp;
+						presenceData.endTimestamp = endTimestamp;
+					}
+				}
 			} else presenceData.details = "Anime Nézése";
 
 			break;


### PR DESCRIPTION
## Description 
I added support so know you can see how much is left from an Anime.
Added hungarian translation to the metadata.json and the iframe things.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![animedrive-2](https://github.com/PreMiD/Presences/assets/36544651/f408a086-2a59-4017-b455-7a8354a71c40)
![animedrive-1](https://github.com/PreMiD/Presences/assets/36544651/ebd25292-b66b-4473-9c6d-c6b6a0ad36b8)


</details>
