### PR TITLE
fix(youtube): channel name and viewed content

### DIFF
--- a/websites/Y/YouTube/metadata.json
+++ b/websites/Y/YouTube/metadata.json
@@ -75,7 +75,7 @@
 		"*://www.youtube.com/*",
 		"*://studio.youtube.com/*"
 	],
-	"version": "5.11.0",
+	"version": "5.11.1",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/thumbnail.jpg",
 	"color": "#E40813",

--- a/websites/Y/YouTube/presence.ts
+++ b/websites/Y/YouTube/presence.ts
@@ -41,19 +41,19 @@ const nullResolver: Resolver = {
 
 presence.on("UpdateData", async () => {
 	const [
-		newLang,
-		privacy,
-		privacyTtl,
-		privacyButtonShown,
-		time,
-		vidDetail,
-		vidState,
-		channelPic,
-		logo,
-		buttons,
-		hideHome,
-		hidePaused,
-	] = [
+			newLang,
+			privacy,
+			privacyTtl,
+			privacyButtonShown,
+			time,
+			vidDetail,
+			vidState,
+			channelPic,
+			logo,
+			buttons,
+			hideHome,
+			hidePaused,
+		] = [
 			getSetting<string>("lang", "en"),
 			getSetting<boolean>("privacy", true),
 			getSetting<number>("privacy-ttl", 1),
@@ -83,16 +83,16 @@ presence.on("UpdateData", async () => {
 			return presence.clearActivity();
 
 		const resolver = [
-			youtubeEmbedResolver,
-			youtubeShortsResolver,
-			youtubeOldResolver,
-			youtubeTVResolver,
-			youtubeResolver,
-			youtubeMiniplayerResolver,
-			youtubeMoviesResolver,
-			youtubeApiResolver,
-			nullResolver,
-		].find(resolver => resolver.isActive()),
+				youtubeEmbedResolver,
+				youtubeShortsResolver,
+				youtubeOldResolver,
+				youtubeTVResolver,
+				youtubeResolver,
+				youtubeMiniplayerResolver,
+				youtubeMoviesResolver,
+				youtubeApiResolver,
+				nullResolver,
+			].find(resolver => resolver.isActive()),
 			title = resolver.getTitle(),
 			uploaderName = resolver.getUploader();
 
@@ -128,14 +128,14 @@ presence.on("UpdateData", async () => {
 				resolver === youtubeMiniplayerResolver
 					? ""
 					: document
-						.querySelector<HTMLImageElement>(
-							"#avatar.ytd-video-owner-renderer > img"
-						)
-						?.src.replace(/=s\d+/, "=s512");
+							.querySelector<HTMLImageElement>(
+								"#avatar.ytd-video-owner-renderer > img"
+							)
+							?.src.replace(/=s\d+/, "=s512");
 		}
 		const unlistedPathElement = document.querySelector<SVGPathElement>(
-			"g#privacy_unlisted > path"
-		),
+				"g#privacy_unlisted > path"
+			),
 			unlistedBadgeElement = document.querySelector<SVGPathElement>(
 				"h1.title+ytd-badge-supported-renderer path"
 			),
@@ -143,7 +143,7 @@ presence.on("UpdateData", async () => {
 				unlistedPathElement &&
 				unlistedBadgeElement &&
 				unlistedPathElement?.getAttribute("d") ===
-				unlistedBadgeElement?.getAttribute("d"),
+					unlistedBadgeElement?.getAttribute("d"),
 			videoId = resolver.getVideoID(),
 			presenceData: PresenceData = {
 				type: ActivityType.Watching,
@@ -161,22 +161,22 @@ presence.on("UpdateData", async () => {
 					unlistedVideo || logo === LogoMode.YouTubeLogo || pfp === ""
 						? YouTubeAssets.Logo
 						: logo === LogoMode.Thumbnail
-							? await getThumbnail(videoId)
-							: pfp,
+						? await getThumbnail(videoId)
+						: pfp,
 				smallImageKey: video.paused
 					? Assets.Pause
 					: video.loop
-						? Assets.RepeatOne
-						: isPlaylistLoop
-							? Assets.Repeat
-							: Assets.Play,
+					? Assets.RepeatOne
+					: isPlaylistLoop
+					? Assets.Repeat
+					: Assets.Play,
 				smallImageText: video.paused
 					? strings.pause
 					: video.loop
-						? "On loop"
-						: isPlaylistLoop
-							? "Playlist on loop"
-							: strings.play,
+					? "On loop"
+					: isPlaylistLoop
+					? "Playlist on loop"
+					: strings.play,
 				endTimestamp: adjustTimeError(
 					presence.getTimestampsfromMedia(video)[1],
 					0.75
@@ -304,10 +304,10 @@ presence.on("UpdateData", async () => {
 			case pathname.includes("/c"):
 			case pathname.includes("/user"): {
 				const tabSelected = document
-					.querySelector(
-						'[class="style-scope ytd-feed-filter-chip-bar-renderer iron-selected"]'
-					)
-					?.textContent.trim(),
+						.querySelector(
+							'[class="style-scope ytd-feed-filter-chip-bar-renderer iron-selected"]'
+						)
+						?.textContent.trim(),
 					documentTitle = document.title.substring(
 						0,
 						document.title.lastIndexOf(" - YouTube")
@@ -327,9 +327,11 @@ presence.on("UpdateData", async () => {
 					).textContent;
 					// Get channel name when viewing a channel
 				} else if (
-					document.querySelector("#text.ytd-channel-name")?.textContent !== ""
-					&&
-					documentTitle.includes(document.querySelector("#text.ytd-channel-name")?.textContent)
+					document.querySelector("#text.ytd-channel-name")?.textContent !==
+						"" &&
+					documentTitle.includes(
+						document.querySelector("#text.ytd-channel-name")?.textContent
+					)
 				)
 					user = document.querySelector("#text.ytd-channel-name").textContent;
 				// Get channel name from website's title
@@ -344,10 +346,14 @@ presence.on("UpdateData", async () => {
 					user = "null";
 
 				if (pathname.includes("/videos")) {
-					presenceData.details =
-						`${strings.browsingThrough} ${tabSelected} ${document.querySelector(
+					presenceData.details = `${
+						strings.browsingThrough
+					} ${tabSelected} ${document
+						.querySelector(
 							'[class="style-scope ytd-tabbed-page-header"] [aria-selected="true"]'
-						)?.textContent.trim().toLowerCase()}`;
+						)
+						?.textContent.trim()
+						.toLowerCase()}`;
 					presenceData.state = `${strings.ofChannel} ${user}`;
 				} else if (pathname.includes("/shorts")) {
 					presenceData.details = strings.browseShorts;
@@ -361,11 +367,11 @@ presence.on("UpdateData", async () => {
 					presenceData.largeImageKey =
 						logo === LogoMode.Thumbnail
 							? document
-								.querySelector('[id="post"]')
-								?.querySelectorAll("img")[1]?.src
+									.querySelector('[id="post"]')
+									?.querySelectorAll("img")[1]?.src
 							: logo === LogoMode.Channel
-								? document.querySelector('[id="post"]')?.querySelector("img")?.src
-								: YouTubeAssets.Logo;
+							? document.querySelector('[id="post"]')?.querySelector("img")?.src
+							: YouTubeAssets.Logo;
 				} else if (pathname.includes("/about")) {
 					presenceData.details = strings.readChannel;
 					presenceData.state = user;

--- a/websites/Y/YouTube/presence.ts
+++ b/websites/Y/YouTube/presence.ts
@@ -327,9 +327,9 @@ presence.on("UpdateData", async () => {
 					).textContent;
 					// Get channel name when viewing a channel
 				} else if (
-					documentTitle.includes(
-						document.querySelector("#text.ytd-channel-name")?.textContent
-					)
+					document.querySelector("#text.ytd-channel-name")?.textContent != ''
+					&&
+					documentTitle.includes(document.querySelector("#text.ytd-channel-name")?.textContent)
 				)
 					user = document.querySelector("#text.ytd-channel-name").textContent;
 				// Get channel name from website's title
@@ -344,14 +344,10 @@ presence.on("UpdateData", async () => {
 					user = "null";
 
 				if (pathname.includes("/videos")) {
-					presenceData.details = `${
-						strings.browsingThrough
-					} ${tabSelected} ${document
-						.querySelector(
-							'[class="style-scope ytd-c4-tabbed-header-renderer iron-selected"]'
-						)
-						?.textContent.trim()
-						.toLowerCase()}`;
+					presenceData.details =
+						`${strings.browsingThrough} ${tabSelected} ${document.querySelector(
+							'[class="style-scope ytd-tabbed-page-header"] [aria-selected="true"]'
+						)?.textContent.trim().toLowerCase()}`;
 					presenceData.state = `${strings.ofChannel} ${user}`;
 				} else if (pathname.includes("/shorts")) {
 					presenceData.details = strings.browseShorts;

--- a/websites/Y/YouTube/presence.ts
+++ b/websites/Y/YouTube/presence.ts
@@ -327,8 +327,7 @@ presence.on("UpdateData", async () => {
 					).textContent;
 					// Get channel name when viewing a channel
 				} else if (
-					document.querySelector("#text.ytd-channel-name")?.textContent !==
-						"" &&
+					!document.querySelector("#text.ytd-channel-name")?.textContent &&
 					documentTitle.includes(
 						document.querySelector("#text.ytd-channel-name")?.textContent
 					)

--- a/websites/Y/YouTube/presence.ts
+++ b/websites/Y/YouTube/presence.ts
@@ -327,7 +327,7 @@ presence.on("UpdateData", async () => {
 					).textContent;
 					// Get channel name when viewing a channel
 				} else if (
-					document.querySelector("#text.ytd-channel-name")?.textContent != ''
+					document.querySelector("#text.ytd-channel-name")?.textContent !== ""
 					&&
 					documentTitle.includes(document.querySelector("#text.ytd-channel-name")?.textContent)
 				)


### PR DESCRIPTION
## Description 
Came across instance where channel name and selected tabs were not showing up in Presence (`undefined` and `null` respectively)

Line 330: Adjusted an `if` statement that was causing channel name to be reported as `null` when an element on page was not found (`String.includes('')` is always true)

Line 349: Changed querystring to properly find selected tab of viewed content (Featured, Videos, ...) as it was returning `undefined`


## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![Screenshot 2024-05-08 19-58-46](https://github.com/PreMiD/Presences/assets/43938522/8b862f30-03a8-4394-885d-abb5312d30aa)

![Screenshot 2024-05-08 19-59-39](https://github.com/PreMiD/Presences/assets/43938522/4e0fd292-a2ac-4099-bee6-3054daba75fa)

<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

</details>
