### PR TITLE
feat(multiplayerpiano.net): add presence

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -1,30 +1,15 @@
 ## Description 
-Added a presence for [multiplayerpiano.net](multiplayerpiano.net), a website used for playing piano in custom lobbies with other people. \
-There are settings for both showing the name of the room and for showing a button that allows other users to join the room.\
-The presence keeps track of the user's status on the website in order to determine whether they're active or AFK.
+<!-- A clear and detailed description of the changes, referencing issues if applicable -->
 
 ## Acknowledgements
-- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
-- [X] I linted the code by running `yarn format`
-- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)
+- [ ] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
+- [ ] I linted the code by running `yarn format`
+- [ ] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)
 
 ## Screenshots
 <details>
 <summary> Proof showing the creation/modification is working as expected </summary>
-
-### Description and settings: 
-![](https://cdn.discordapp.com/attachments/587336926533648409/1240290676609126400/image.png?ex=66460634&is=6644b4b4&hm=4393ef5a3003bd4f4b42d28d20b82ff7118db45e62007a1f165a118f3f6a601e&)
-
-### Not AFK, Both settings enabled:
-![](https://cdn.discordapp.com/attachments/587336926533648409/1240280544705773611/image.png?ex=6645fcc5&is=6644ab45&hm=cadb911657ec15f4bbd76bbe55676b9bdd73ae76df30fa130a9593e55fcf9931&)
-
-### AFK, Both settings enabled:
-![](https://cdn.discordapp.com/attachments/587336926533648409/1240281895783239700/image.png?ex=6645fe07&is=6644ac87&hm=c4f6d12ce57b40b8e35ef98a0f72220240fdd853d6ffa982a32fd736223e25ed&)
-
-### Not AFK, Both settings disabled:
-![](https://cdn.discordapp.com/attachments/587336926533648409/1240286964591235094/image.png?ex=664602bf&is=6644b13f&hm=db356f34ab384d59307352598947426816fb3d2cbe4871f3fd354d23dd2336b8&)
-
-### AFK, Both settings disabled
-![](https://cdn.discordapp.com/attachments/587336926533648409/1240288203836227707/image.png?ex=664603e7&is=6644b267&hm=71fb98d5cd333714e8e6703db8df181bd04d1bcb861fb36f46739842b0f41d86&)
-
-</details>
+<!-- 
+    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
+    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -1,19 +1,30 @@
 ## Description 
-<!-- A clear and detailed description of the changes, referencing issues if applicable -->
+Added a presence for [multiplayerpiano.net](multiplayerpiano.net), a website used for playing piano in custom lobbies with other people. \
+There are settings for both showing the name of the room and for showing a button that allows other users to join the room.\
+The presence keeps track of the user's status on the website in order to determine whether they're active or AFK.
 
 ## Acknowledgements
-- [ ] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
-- [ ] I linted the code by running `yarn format`
-- [ ] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)
+- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
+- [X] I linted the code by running `yarn format`
+- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)
 
 ## Screenshots
 <details>
 <summary> Proof showing the creation/modification is working as expected </summary>
-<!-- 
-    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
-    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
--->
 
+### Description and settings: 
+![](https://cdn.discordapp.com/attachments/587336926533648409/1240290676609126400/image.png?ex=66460634&is=6644b4b4&hm=4393ef5a3003bd4f4b42d28d20b82ff7118db45e62007a1f165a118f3f6a601e&)
 
+### Not AFK, Both settings enabled:
+![](https://cdn.discordapp.com/attachments/587336926533648409/1240280544705773611/image.png?ex=6645fcc5&is=6644ab45&hm=cadb911657ec15f4bbd76bbe55676b9bdd73ae76df30fa130a9593e55fcf9931&)
+
+### AFK, Both settings enabled:
+![](https://cdn.discordapp.com/attachments/587336926533648409/1240281895783239700/image.png?ex=6645fe07&is=6644ac87&hm=c4f6d12ce57b40b8e35ef98a0f72220240fdd853d6ffa982a32fd736223e25ed&)
+
+### Not AFK, Both settings disabled:
+![](https://cdn.discordapp.com/attachments/587336926533648409/1240286964591235094/image.png?ex=664602bf&is=6644b13f&hm=db356f34ab384d59307352598947426816fb3d2cbe4871f3fd354d23dd2336b8&)
+
+### AFK, Both settings disabled
+![](https://cdn.discordapp.com/attachments/587336926533648409/1240288203836227707/image.png?ex=664603e7&is=6644b267&hm=71fb98d5cd333714e8e6703db8df181bd04d1bcb861fb36f46739842b0f41d86&)
 
 </details>

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -1,30 +1,19 @@
 ## Description 
-Added a presence for [multiplayerpiano.net](multiplayerpiano.net), a website used for playing piano in custom lobbies with other people. \
-There are settings for both showing the name of the room and for showing a button that allows other users to join the room.\
-The presence keeps track of the user's status on the website in order to determine whether they're active or AFK.
+<!-- A clear and detailed description of the changes, referencing issues if applicable -->
 
 ## Acknowledgements
-- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
-- [X] I linted the code by running `yarn format`
-- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)
+- [ ] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
+- [ ] I linted the code by running `yarn format`
+- [ ] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)
 
 ## Screenshots
 <details>
 <summary> Proof showing the creation/modification is working as expected </summary>
+<!-- 
+    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
+    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
+-->
 
-### Description and settings: 
-![](https://cdn.discordapp.com/attachments/587336926533648409/1240290676609126400/image.png?ex=66460634&is=6644b4b4&hm=4393ef5a3003bd4f4b42d28d20b82ff7118db45e62007a1f165a118f3f6a601e&)
 
-### Not AFK, Both settings enabled:
-![](https://cdn.discordapp.com/attachments/587336926533648409/1240280544705773611/image.png?ex=6645fcc5&is=6644ab45&hm=cadb911657ec15f4bbd76bbe55676b9bdd73ae76df30fa130a9593e55fcf9931&)
-
-### AFK, Both settings enabled:
-![](https://cdn.discordapp.com/attachments/587336926533648409/1240281895783239700/image.png?ex=6645fe07&is=6644ac87&hm=c4f6d12ce57b40b8e35ef98a0f72220240fdd853d6ffa982a32fd736223e25ed&)
-
-### Not AFK, Both settings disabled:
-![](https://cdn.discordapp.com/attachments/587336926533648409/1240286964591235094/image.png?ex=664602bf&is=6644b13f&hm=db356f34ab384d59307352598947426816fb3d2cbe4871f3fd354d23dd2336b8&)
-
-### AFK, Both settings disabled
-![](https://cdn.discordapp.com/attachments/587336926533648409/1240288203836227707/image.png?ex=664603e7&is=6644b267&hm=71fb98d5cd333714e8e6703db8df181bd04d1bcb861fb36f46739842b0f41d86&)
 
 </details>

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -13,3 +13,7 @@
     Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
     Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
 -->
+
+
+
+</details>

--- a/websites/M/MultiplayerPiano.net/metadata.json
+++ b/websites/M/MultiplayerPiano.net/metadata.json
@@ -10,7 +10,7 @@
 	},
 	"url": "multiplayerpiano.net",
 	"version": "1.0.0",
-	"logo": "https://cdn.discordapp.com/icons/813217128529264710/911b06d8a1a9af24fac16b843165cc0f.png",
+	"logo": "https://cdn.discordapp.com/attachments/587336926533648409/1240591699034767380/mpp2.png?ex=66471e8e&is=6645cd0e&hm=b288e175fe293d96c41c4041773d370a231a52a4cdd818eaa88342731a6762f9&",
 	"thumbnail": "https://multiplayerpiano.com/wp-content/uploads/2023/10/ae9cdbc0dcf1f870/multiplayer-piano-bot.jpeg",
 	"color": "#2f207a",
 	"category": "music",

--- a/websites/M/MultiplayerPiano.net/metadata.json
+++ b/websites/M/MultiplayerPiano.net/metadata.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.premid.app/metadata/1.9",
+	"$schema": "https://schemas.premid.app/metadata/1.10",
 	"author": {
 		"id": "224864947480297472",
 		"name": "antokek"

--- a/websites/M/MultiplayerPiano.net/metadata.json
+++ b/websites/M/MultiplayerPiano.net/metadata.json
@@ -1,0 +1,36 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.9",
+	"author": {
+		"id": "224864947480297472",
+		"name": "antokek"
+	},
+	"service": "MultiplayerPiano.net",
+	"description": {
+		"en": "An online website used for playing piano with friends. It supports input from both MIDI keyboards and QWERTY keyboards."
+	},
+	"url": "multiplayerpiano.net",
+	"version": "1.0.0",
+	"logo": "https://cdn.discordapp.com/icons/813217128529264710/911b06d8a1a9af24fac16b843165cc0f.png",
+	"thumbnail": "https://multiplayerpiano.com/wp-content/uploads/2023/10/ae9cdbc0dcf1f870/multiplayer-piano-bot.jpeg",
+	"color": "#2f207a",
+	"category": "music",
+	"tags": [
+		"music",
+		"piano",
+		"game"
+	],
+
+	"settings": [
+		{
+			"id": "showRoomName",
+			"title": "Show room name",
+			"value": true
+		},
+		{
+			"id": "showJoinButton",
+			"title": "Show join room button",
+			"value": true
+		}
+
+	]
+}

--- a/websites/M/MultiplayerPiano.net/metadata.json
+++ b/websites/M/MultiplayerPiano.net/metadata.json
@@ -6,7 +6,7 @@
 	},
 	"service": "MultiplayerPiano.net",
 	"description": {
-		"en": "An online website used for playing piano with friends. It supports input from both MIDI keyboards and QWERTY keyboards."
+		"en": "An online piano you can play alone or with others in real-time. MIDI support, 88 keys, velocity sensitive. You can show off your skill or chat while listening to others play."
 	},
 	"url": "multiplayerpiano.net",
 	"version": "1.0.0",

--- a/websites/M/MultiplayerPiano.net/metadata.json
+++ b/websites/M/MultiplayerPiano.net/metadata.json
@@ -10,7 +10,7 @@
 	},
 	"url": "multiplayerpiano.net",
 	"version": "1.0.0",
-	"logo": "https://cdn.discordapp.com/attachments/587336926533648409/1240591699034767380/mpp2.png?ex=66471e8e&is=6645cd0e&hm=b288e175fe293d96c41c4041773d370a231a52a4cdd818eaa88342731a6762f9&",
+	"logo": "https://www.virtualdrumming.com/icons-piano/icons-512.png",
 	"thumbnail": "https://multiplayerpiano.com/wp-content/uploads/2023/10/ae9cdbc0dcf1f870/multiplayer-piano-bot.jpeg",
 	"color": "#2f207a",
 	"category": "music",

--- a/websites/M/MultiplayerPiano.net/presence.ts
+++ b/websites/M/MultiplayerPiano.net/presence.ts
@@ -44,7 +44,7 @@ const {href} = document.location;
 		presenceData.buttons = [
 			{
 				label: "Join Room",
-				url: `https://multiplayerpiano.net/?c=${getRoomName()}`,
+				url: href,
 			},
 		];
 	}

--- a/websites/M/MultiplayerPiano.net/presence.ts
+++ b/websites/M/MultiplayerPiano.net/presence.ts
@@ -33,6 +33,7 @@ const presenceData: PresenceData = {
 };
 
 presence.on("UpdateData", async () => {
+const {href} = document.location;
 	if (getAFK()) presenceData.details = "Currently AFK";
 	else presenceData.details = "Playing piano";
 

--- a/websites/M/MultiplayerPiano.net/presence.ts
+++ b/websites/M/MultiplayerPiano.net/presence.ts
@@ -17,10 +17,7 @@ async function getShowRoomName(): Promise<boolean> {
 }
 
 function getRoomName(): string {
-    const url = document.location.href;
-    const regex = /[?&]c=([^&#]*)/;
-    const matches = url.match(regex);
-    return matches ? matches[1] : "lobby";
+    return document.location.href.match(/[?&]c=([^&#]*)/) ? document.location.href.match(/[?&]c=([^&#]*)/)[1] : "lobby";
 }
 
 function getAFK(): boolean {
@@ -34,20 +31,15 @@ const presenceData: PresenceData = {
 };
 
 presence.on("UpdateData", async () => {
-    const showRoomName = await getShowRoomName();
-    const showJoinButton = await getShowJoinButton();
-    const roomName = getRoomName();
-    const isAFK = getAFK();
+    let showRoomName = await getShowRoomName();
+    let showJoinButton = await getShowJoinButton();
+    let roomName = getRoomName();
+    let isAFK = getAFK();
 
-    if (isAFK) {
-        presenceData.details = "Currently AFK";
-    } else {
-        presenceData.details = "Playing piano";
-    }
-
-    if (showRoomName) {
-        presenceData.state = `in room "${roomName}"`;
-    }
+    if (isAFK) presenceData.details = "Currently AFK";
+    else presenceData.details = "Playing piano";
+    
+    if (showRoomName) presenceData.state = `in room "${roomName}"`;
 
     if (showJoinButton) {
         presenceData.buttons = [{

--- a/websites/M/MultiplayerPiano.net/presence.ts
+++ b/websites/M/MultiplayerPiano.net/presence.ts
@@ -21,8 +21,7 @@ function getRoomName(): string {
 }
 
 function getAFK(): boolean {
-    const afkElement = document.querySelector('.name.me [id^="afktag-"]');
-    return afkElement !== null;
+    return document.querySelector('.name.me [id^="afktag-"]') !== null;
 }
 
 const presenceData: PresenceData = {

--- a/websites/M/MultiplayerPiano.net/presence.ts
+++ b/websites/M/MultiplayerPiano.net/presence.ts
@@ -7,8 +7,9 @@ const enum Assets {
 }
 
 async function getShowJoinButton(): Promise<boolean> {
-	const joinButtonSetting =
-		await presence.getSetting<boolean>("showJoinButton");
+	const joinButtonSetting = await presence.getSetting<boolean>(
+		"showJoinButton"
+	);
 	return joinButtonSetting;
 }
 

--- a/websites/M/MultiplayerPiano.net/presence.ts
+++ b/websites/M/MultiplayerPiano.net/presence.ts
@@ -1,5 +1,5 @@
 const presence = new Presence({
-    clientId: "1240257888514080830",
+	clientId: "1240257888514080830",
 });
 
 const enum Assets { // Other default assets can be found at index.d.ts
@@ -7,41 +7,46 @@ const enum Assets { // Other default assets can be found at index.d.ts
 }
 
 async function getShowJoinButton(): Promise<boolean> {
-    const joinButtonSetting = await presence.getSetting<boolean>("showJoinButton");
-    return joinButtonSetting;
+	const joinButtonSetting =
+		await presence.getSetting<boolean>("showJoinButton");
+	return joinButtonSetting;
 }
 
 async function getShowRoomName(): Promise<boolean> {
-    const roomNameSetting = await presence.getSetting<boolean>("showRoomName");
-    return roomNameSetting;
+	const roomNameSetting = await presence.getSetting<boolean>("showRoomName");
+	return roomNameSetting;
 }
 
 function getRoomName(): string {
-    return document.location.href.match(/[?&]c=([^&#]*)/) ? document.location.href.match(/[?&]c=([^&#]*)/)[1] : "lobby";
+	return document.location.href.match(/[?&]c=([^&#]*)/)
+		? document.location.href.match(/[?&]c=([^&#]*)/)[1]
+		: "lobby";
 }
 
 function getAFK(): boolean {
-    return document.querySelector('.name.me [id^="afktag-"]') !== null;
+	return document.querySelector('.name.me [id^="afktag-"]') !== null;
 }
 
 const presenceData: PresenceData = {
-    largeImageKey: Assets.Logo,
-    startTimestamp: Math.floor(Date.now() / 1000),
+	largeImageKey: Assets.Logo,
+	startTimestamp: Math.floor(Date.now() / 1000),
 };
 
 presence.on("UpdateData", async () => {
+	if (getAFK()) presenceData.details = "Currently AFK";
+	else presenceData.details = "Playing piano";
 
-    if (getAFK()) presenceData.details = "Currently AFK";
-    else presenceData.details = "Playing piano";
-    
-    if (await getShowRoomName()) presenceData.state = `in room "${getRoomName()}"`;
+	if (await getShowRoomName())
+		presenceData.state = `in room "${getRoomName()}"`;
 
-    if (await getShowJoinButton()) {
-        presenceData.buttons = [{
-            label: "Join Room",
-            url: `https://multiplayerpiano.net/?c=${getRoomName()}`
-        }];
-    }
+	if (await getShowJoinButton()) {
+		presenceData.buttons = [
+			{
+				label: "Join Room",
+				url: `https://multiplayerpiano.net/?c=${getRoomName()}`,
+			},
+		];
+	}
 
-    presence.setActivity(presenceData);
+	presence.setActivity(presenceData);
 });

--- a/websites/M/MultiplayerPiano.net/presence.ts
+++ b/websites/M/MultiplayerPiano.net/presence.ts
@@ -7,9 +7,8 @@ const enum Assets { // Other default assets can be found at index.d.ts
 }
 
 async function getShowJoinButton(): Promise<boolean> {
-	const joinButtonSetting = await presence.getSetting<boolean>(
-		"showJoinButton"
-	);
+	const joinButtonSetting =
+		await presence.getSetting<boolean>("showJoinButton");
 	return joinButtonSetting;
 }
 
@@ -19,9 +18,11 @@ async function getShowRoomName(): Promise<boolean> {
 }
 
 function getRoomName(): string {
-	return document.location.href.match(/[?&]c=([^&#]*)/)
-		? document.location.href.match(/[?&]c=([^&#]*)/)[1]
-		: "lobby";
+	return decodeURIComponent(
+		document.location.href.match(/[?&]c=([^&#]*)/)
+			? document.location.href.match(/[?&]c=([^&#]*)/)[1]
+			: "lobby"
+	);
 }
 
 function getAFK(): boolean {

--- a/websites/M/MultiplayerPiano.net/presence.ts
+++ b/websites/M/MultiplayerPiano.net/presence.ts
@@ -1,34 +1,26 @@
 const presence = new Presence({
-		clientId: "1240257888514080830",
-	}),
-	strings = presence.getStrings({
-		play: "presence.playback.playing",
-		pause: "presence.playback.paused",
-	}),
-	browsingTimestamp = Math.floor(Date.now() / 1000);
+    clientId: "1240257888514080830",
+});
 
 const enum Assets { // Other default assets can be found at index.d.ts
-	Logo = "logo",
+	Logo = "https://cdn.discordapp.com/attachments/587336926533648409/1240591699034767380/mpp2.png?ex=66471e8e&is=6645cd0e&hm=b288e175fe293d96c41c4041773d370a231a52a4cdd818eaa88342731a6762f9&",
 }
 
 async function getShowJoinButton(): Promise<boolean> {
     const joinButtonSetting = await presence.getSetting<boolean>("showJoinButton");
     return joinButtonSetting;
 }
+
 async function getShowRoomName(): Promise<boolean> {
     const roomNameSetting = await presence.getSetting<boolean>("showRoomName");
     return roomNameSetting;
 }
-async function getShowStatus(): Promise<boolean> {
-    const roomNameSetting = await presence.getSetting<boolean>("showStatus");
-    return roomNameSetting;
-}
 
 function getRoomName(): string {
-	const url = window.location.href;
-	const regex = /[?&]c=([^&#]*)/;
-	const matches = url.match(regex)
-	return matches ? matches[1] : "lobby"
+    const url = document.location.href;
+    const regex = /[?&]c=([^&#]*)/;
+    const matches = url.match(regex);
+    return matches ? matches[1] : "lobby";
 }
 
 function getAFK(): boolean {
@@ -37,34 +29,32 @@ function getAFK(): boolean {
 }
 
 const presenceData: PresenceData = {
-	largeImageKey: Assets.Logo,
-	startTimestamp: browsingTimestamp,
-}
+    largeImageKey: Assets.Logo,
+    startTimestamp: Math.floor(Date.now() / 1000),
+};
 
 presence.on("UpdateData", async () => {
-	const showRoomName = await getShowRoomName();
-	const showJoinButton = await getShowJoinButton();
+    const showRoomName = await getShowRoomName();
+    const showJoinButton = await getShowJoinButton();
     const roomName = getRoomName();
-	const isAFK = getAFK();
+    const isAFK = getAFK();
 
-    const presenceData: PresenceData = {
-        largeImageKey: Assets.Logo,
-        startTimestamp: browsingTimestamp,
-    };
+    if (isAFK) {
+        presenceData.details = "Currently AFK";
+    } else {
+        presenceData.details = "Playing piano";
+    }
 
-	if (isAFK) presenceData.details = "Currently AFK"
-	else presenceData.details = "Playing piano";
+    if (showRoomName) {
+        presenceData.state = `in room "${roomName}"`;
+    }
 
-	if (showRoomName) {
-		presenceData.state = "in room \"" + roomName + "\""
-	}
-    
-	if (showJoinButton) {
+    if (showJoinButton) {
         presenceData.buttons = [{
             label: "Join Room",
             url: `https://multiplayerpiano.net/?c=${roomName}`
         }];
     }
 
-	presence.setActivity(presenceData);
+    presence.setActivity(presenceData);
 });

--- a/websites/M/MultiplayerPiano.net/presence.ts
+++ b/websites/M/MultiplayerPiano.net/presence.ts
@@ -7,8 +7,9 @@ const enum Assets { // Other default assets can be found at index.d.ts
 }
 
 async function getShowJoinButton(): Promise<boolean> {
-	const joinButtonSetting =
-		await presence.getSetting<boolean>("showJoinButton");
+	const joinButtonSetting = await presence.getSetting<boolean>(
+		"showJoinButton"
+	);
 	return joinButtonSetting;
 }
 
@@ -33,7 +34,7 @@ const presenceData: PresenceData = {
 };
 
 presence.on("UpdateData", async () => {
-const {href} = document.location;
+	const { href } = document.location;
 	if (getAFK()) presenceData.details = "Currently AFK";
 	else presenceData.details = "Playing piano";
 

--- a/websites/M/MultiplayerPiano.net/presence.ts
+++ b/websites/M/MultiplayerPiano.net/presence.ts
@@ -1,0 +1,70 @@
+const presence = new Presence({
+		clientId: "1240257888514080830",
+	}),
+	strings = presence.getStrings({
+		play: "presence.playback.playing",
+		pause: "presence.playback.paused",
+	}),
+	browsingTimestamp = Math.floor(Date.now() / 1000);
+
+const enum Assets { // Other default assets can be found at index.d.ts
+	Logo = "logo",
+}
+
+async function getShowJoinButton(): Promise<boolean> {
+    const joinButtonSetting = await presence.getSetting<boolean>("showJoinButton");
+    return joinButtonSetting;
+}
+async function getShowRoomName(): Promise<boolean> {
+    const roomNameSetting = await presence.getSetting<boolean>("showRoomName");
+    return roomNameSetting;
+}
+async function getShowStatus(): Promise<boolean> {
+    const roomNameSetting = await presence.getSetting<boolean>("showStatus");
+    return roomNameSetting;
+}
+
+function getRoomName(): string {
+	const url = window.location.href;
+	const regex = /[?&]c=([^&#]*)/;
+	const matches = url.match(regex)
+	return matches ? matches[1] : "lobby"
+}
+
+function getAFK(): boolean {
+    const afkElement = document.querySelector('.name.me [id^="afktag-"]');
+    return afkElement !== null;
+}
+
+const presenceData: PresenceData = {
+	largeImageKey: Assets.Logo,
+	startTimestamp: browsingTimestamp,
+}
+
+presence.on("UpdateData", async () => {
+	const showRoomName = await getShowRoomName();
+	const showJoinButton = await getShowJoinButton();
+    const roomName = getRoomName();
+	const isAFK = getAFK();
+
+    const presenceData: PresenceData = {
+        largeImageKey: Assets.Logo,
+        startTimestamp: browsingTimestamp,
+    };
+
+	if (isAFK) presenceData.details = "Currently AFK"
+	else presenceData.details = "Playing piano";
+
+	if (showRoomName) {
+		presenceData.state = "in room \"" + roomName + "\""
+	}
+    
+	if (showJoinButton) {
+        presenceData.buttons = [{
+            label: "Join Room",
+            url: `https://multiplayerpiano.net/?c=${roomName}`
+        }];
+    }
+
+	presence.setActivity(presenceData);
+});

--- a/websites/M/MultiplayerPiano.net/presence.ts
+++ b/websites/M/MultiplayerPiano.net/presence.ts
@@ -3,7 +3,7 @@ const presence = new Presence({
 });
 
 const enum Assets { // Other default assets can be found at index.d.ts
-	Logo = "https://cdn.discordapp.com/attachments/587336926533648409/1240591699034767380/mpp2.png?ex=66471e8e&is=6645cd0e&hm=b288e175fe293d96c41c4041773d370a231a52a4cdd818eaa88342731a6762f9&",
+	Logo = "https://www.virtualdrumming.com/icons-piano/icons-512.png",
 }
 
 async function getShowJoinButton(): Promise<boolean> {

--- a/websites/M/MultiplayerPiano.net/presence.ts
+++ b/websites/M/MultiplayerPiano.net/presence.ts
@@ -2,7 +2,7 @@ const presence = new Presence({
 	clientId: "1240257888514080830",
 });
 
-const enum Assets { // Other default assets can be found at index.d.ts
+const enum Assets {
 	Logo = "https://www.virtualdrumming.com/icons-piano/icons-512.png",
 }
 

--- a/websites/M/MultiplayerPiano.net/presence.ts
+++ b/websites/M/MultiplayerPiano.net/presence.ts
@@ -31,20 +31,16 @@ const presenceData: PresenceData = {
 };
 
 presence.on("UpdateData", async () => {
-    let showRoomName = await getShowRoomName();
-    let showJoinButton = await getShowJoinButton();
-    let roomName = getRoomName();
-    let isAFK = getAFK();
 
-    if (isAFK) presenceData.details = "Currently AFK";
+    if (getAFK()) presenceData.details = "Currently AFK";
     else presenceData.details = "Playing piano";
     
-    if (showRoomName) presenceData.state = `in room "${roomName}"`;
+    if (await getShowRoomName()) presenceData.state = `in room "${getRoomName()}"`;
 
-    if (showJoinButton) {
+    if (await getShowJoinButton()) {
         presenceData.buttons = [{
             label: "Join Room",
-            url: `https://multiplayerpiano.net/?c=${roomName}`
+            url: `https://multiplayerpiano.net/?c=${getRoomName()}`
         }];
     }
 


### PR DESCRIPTION
## Description 
Added a presence for [multiplayerpiano.net](multiplayerpiano.net), a website used for playing piano in custom lobbies with other people. \
There are settings for both showing the name of the room and for showing a button that allows other users to join the room.\
The presence keeps track of the user's status on the website in order to determine whether they're active or AFK.

## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

### Description and settings: 
![](https://cdn.discordapp.com/attachments/587336926533648409/1240290676609126400/image.png?ex=66460634&is=6644b4b4&hm=4393ef5a3003bd4f4b42d28d20b82ff7118db45e62007a1f165a118f3f6a601e&)

### Not AFK, Both settings enabled:
![](https://cdn.discordapp.com/attachments/587336926533648409/1240280544705773611/image.png?ex=6645fcc5&is=6644ab45&hm=cadb911657ec15f4bbd76bbe55676b9bdd73ae76df30fa130a9593e55fcf9931&)

### AFK, Both settings enabled:
![](https://cdn.discordapp.com/attachments/587336926533648409/1240281895783239700/image.png?ex=6645fe07&is=6644ac87&hm=c4f6d12ce57b40b8e35ef98a0f72220240fdd853d6ffa982a32fd736223e25ed&)

### Not AFK, Both settings disabled:
![](https://cdn.discordapp.com/attachments/587336926533648409/1240286964591235094/image.png?ex=664602bf&is=6644b13f&hm=db356f34ab384d59307352598947426816fb3d2cbe4871f3fd354d23dd2336b8&)

### AFK, Both settings disabled
![](https://cdn.discordapp.com/attachments/587336926533648409/1240288203836227707/image.png?ex=664603e7&is=6644b267&hm=71fb98d5cd333714e8e6703db8df181bd04d1bcb861fb36f46739842b0f41d86&)

</details>
