### PR TITLE
fix(Codewars): show states aside from browsing

### DIFF
--- a/websites/C/Codewars/metadata.json
+++ b/websites/C/Codewars/metadata.json
@@ -11,7 +11,7 @@
 		"vi_VN": "Codewars là nơi các nhà phát triển làm chủ lập trình qua các thử thách. Luyện tập trong võ đường và phát huy tối đa khả năng của bạn."
 	},
 	"url": "www.codewars.com",
-	"version": "1.0.21",
+	"version": "1.1.0",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/C/Codewars/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/C/Codewars/assets/thumbnail.png",
 	"color": "#9c1414",

--- a/websites/C/Codewars/presence.ts
+++ b/websites/C/Codewars/presence.ts
@@ -1,98 +1,110 @@
 const presence = new Presence({
-		clientId: "821106305241972746",
-	}),
-	timebrowsed = Math.floor(Date.now() / 1000);
+    clientId: "821106305241972746",
+  }),
+  timebrowsed = Math.floor(Date.now() / 1000);
 
 presence.on("UpdateData", async () => {
-	const pages = document.location.pathname.split("/").filter(p => p),
-		presenceData: PresenceData = {
-			largeImageKey: "https://cdn.rcd.gg/PreMiD/websites/C/Codewars/assets/logo.png",
-			startTimestamp: timebrowsed,
-			details: "Browsing...",
-		},
-		displayStats = await presence.getSetting<boolean>("statsdisplay");
-	switch (pages[0]) {
-		case "dashboard": {
-			presenceData.details = "Viewing Dashboard";
-			if (displayStats) {
-				presenceData.state = `${
-					document.querySelector(".ml-10px").textContent
-				} Honor`;
-			}
-			break;
-		}
-		case "topics": {
-			if (pages[1]) {
-				presenceData.details = "Viewing Topic";
-				presenceData.state = "Topic: " + pages[1];
-			} else presenceData.details = "Viewing Forum";
-			break;
-		}
-		case "kumite": {
-			presenceData.details = "Viewing kumite";
-			break;
-		}
-		case "subscription": {
-			presenceData.details = "Viewing Codewars Red";
-			break;
-		}
-		default:
-			if (pages[0] === "users" && pages[1] === "leaderboard")
-				presenceData.details = "Viewing Leaderboard";
-			else if (pages[0] === "kata") {
-				if (pages[2] && pages[2].startsWith("my-languages")) {
-					let search = (document.querySelectorAll('[name="q"]')[0] as HTMLInputElement).getAttribute("value") || "All Katas";
-					let difficultyFilter = (document.querySelectorAll('[Label="Difficulty"]')[0] as HTMLInputElement).getAttribute("value");
-					if (difficultyFilter) {
-						difficultyFilter = difficultyFilter.split(",").map((x: string) => {
-							return x.replace(/-/g, "").trim() + " kyu";
-						}).join(", ");
-					}
-					else difficultyFilter = "Any kyu";
-					presenceData.details = "Searching Katas";
-					presenceData.state = `${search} | ${difficultyFilter}`;
-				} else {
-					presenceData.details = `Solving Kata | ${
-						document.querySelectorAll(".w-full>div>div>div>span")[0].textContent
-					}`;
-					presenceData.state =
-						document.querySelector(".items-center > h4").textContent;
-				}
-			} else if (pages[0] === "users" && pages[1] === "edit")
-				presenceData.details = "Editing Account";
-			else if (pages[0] === "trainer" && pages[1] === "setup") {
-				presenceData.details = "Editing Trainer Setup";
-				presenceData.state = `${
-					Array.from(document.querySelectorAll(".icon-list > li > .is-active"))
-						.length
-				} Languages selected`;
-			} else if (
-				pages[0] === "users" &&
-				pages[1] !== "leaderboard" &&
-				pages[1] !== "edit"
-			) {
-				let urls = Array.from(document.getElementsByTagName("img")).map(e => e.src);
-				let avatar = urls.find(e => e.includes("avatar"));
-				let avatar2 = urls.find(e => e.includes("avatar") && e !== avatar);
-				if (!avatar2) {
-					presenceData.details = "Viewing own profile";
-					if (displayStats) {
-						presenceData.state = `${
-							document.querySelector(".ml-10px").textContent
-						} Honor | ${document.querySelector(".small-hex").textContent}`;
-					}
-				} else {
-					presenceData.details = "Viewing profile of";
-					if (displayStats) {
-						presenceData.state = `${pages[1]} | 
+  const pages = document.location.pathname.split("/").filter((p) => p),
+    presenceData: PresenceData = {
+      largeImageKey:
+        "https://cdn.rcd.gg/PreMiD/websites/C/Codewars/assets/logo.png",
+      startTimestamp: timebrowsed,
+      details: "Browsing...",
+    },
+    displayStats = await presence.getSetting<boolean>("statsdisplay");
+  switch (pages[0]) {
+    case "dashboard": {
+      presenceData.details = "Viewing Dashboard";
+      if (displayStats) {
+        presenceData.state = `${
+          document.querySelector(".ml-10px").textContent
+        } Honor`;
+      }
+      break;
+    }
+    case "topics": {
+      if (pages[1]) {
+        presenceData.details = "Viewing Topic";
+        presenceData.state = "Topic: " + pages[1];
+      } else presenceData.details = "Viewing Forum";
+      break;
+    }
+    case "kumite": {
+      presenceData.details = "Viewing kumite";
+      break;
+    }
+    case "subscription": {
+      presenceData.details = "Viewing Codewars Red";
+      break;
+    }
+    default:
+      if (pages[0] === "users" && pages[1] === "leaderboard")
+        presenceData.details = "Viewing Leaderboard";
+      else if (pages[0] === "kata") {
+        if (pages[2] && pages[2].startsWith("my-languages")) {
+          let search =
+            (
+              document.querySelectorAll('[name="q"]')[0] as HTMLInputElement
+            ).getAttribute("value") || "All Katas";
+          let difficultyFilter = (
+            document.querySelectorAll(
+              '[Label="Difficulty"]',
+            )[0] as HTMLInputElement
+          ).getAttribute("value");
+          if (difficultyFilter) {
+            difficultyFilter = difficultyFilter
+              .split(",")
+              .map((x: string) => {
+                return x.replace(/-/g, "").trim() + " kyu";
+              })
+              .join(", ");
+          } else difficultyFilter = "Any kyu";
+          presenceData.details = "Searching Katas";
+          presenceData.state = `${search} | ${difficultyFilter}`;
+        } else {
+          presenceData.details = `Solving Kata | ${
+            document.querySelectorAll(".w-full>div>div>div>span")[0].textContent
+          }`;
+          presenceData.state =
+            document.querySelector(".items-center > h4").textContent;
+        }
+      } else if (pages[0] === "users" && pages[1] === "edit")
+        presenceData.details = "Editing Account";
+      else if (pages[0] === "trainer" && pages[1] === "setup") {
+        presenceData.details = "Editing Trainer Setup";
+        presenceData.state = `${
+          Array.from(document.querySelectorAll(".icon-list > li > .is-active"))
+            .length
+        } Languages selected`;
+      } else if (
+        pages[0] === "users" &&
+        pages[1] !== "leaderboard" &&
+        pages[1] !== "edit"
+      ) {
+        let urls = Array.from(document.getElementsByTagName("img")).map(
+          (e) => e.src,
+        );
+        let avatar = urls.find((e) => e.includes("avatar"));
+        let avatar2 = urls.find((e) => e.includes("avatar") && e !== avatar);
+        if (!avatar2) {
+          presenceData.details = "Viewing own profile";
+          if (displayStats) {
+            presenceData.state = `${
+              document.querySelector(".ml-10px").textContent
+            } Honor | ${document.querySelector(".small-hex").textContent}`;
+          }
+        } else {
+          presenceData.details = "Viewing profile of";
+          if (displayStats) {
+            presenceData.state = `${pages[1]} | 
 						${Array.from(document.querySelector(".stat-box").children)
-							.find(e => e.textContent.startsWith("Clan:"))
-							.textContent.slice("Clan:".length)}`;
-					}
-				}
-			}
-	}
+              .find((e) => e.textContent.startsWith("Clan:"))
+              .textContent.slice("Clan:".length)}`;
+          }
+        }
+      }
+  }
 
-	if (!presenceData.details) presence.setActivity();
-	else presence.setActivity(presenceData);
+  if (!presenceData.details) presence.setActivity();
+  else presence.setActivity(presenceData);
 });

--- a/websites/C/Codewars/presence.ts
+++ b/websites/C/Codewars/presence.ts
@@ -25,7 +25,7 @@ presence.on("UpdateData", async () => {
     case "topics": {
       if (pages[1]) {
         presenceData.details = "Viewing Topic";
-        presenceData.state = "Topic: " + pages[1];
+        presenceData.state = `Topic: ${pages[1]}`;
       } else presenceData.details = "Viewing Forum";
       break;
     }
@@ -42,7 +42,7 @@ presence.on("UpdateData", async () => {
         presenceData.details = "Viewing Leaderboard";
       else if (pages[0] === "kata") {
         if (pages[2] && pages[2].startsWith("my-languages")) {
-          let search =
+          const search =
             (
               document.querySelectorAll('[name="q"]')[0] as HTMLInputElement
             ).getAttribute("value") || "All Katas";
@@ -55,7 +55,7 @@ presence.on("UpdateData", async () => {
             difficultyFilter = difficultyFilter
               .split(",")
               .map((x: string) => {
-                return x.replace(/-/g, "").trim() + " kyu";
+                return `${x.replace(/-/g, "").trim()} kyu`;
               })
               .join(", ");
           } else difficultyFilter = "Any kyu";
@@ -81,11 +81,11 @@ presence.on("UpdateData", async () => {
         pages[1] !== "leaderboard" &&
         pages[1] !== "edit"
       ) {
-        let urls = Array.from(document.getElementsByTagName("img")).map(
+        const urls = Array.from(document.querySelectorAll("img")).map(
           (e) => e.src,
-        );
-        let avatar = urls.find((e) => e.includes("avatar"));
-        let avatar2 = urls.find((e) => e.includes("avatar") && e !== avatar);
+        ),
+	  avatar = urls.find((e) => e.includes("avatar")),
+	  avatar2 = urls.find((e) => e.includes("avatar") && e !== avatar);
         if (!avatar2) {
           presenceData.details = "Viewing own profile";
           if (displayStats) {

--- a/websites/C/Codewars/presence.ts
+++ b/websites/C/Codewars/presence.ts
@@ -46,11 +46,9 @@ presence.on("UpdateData", async () => {
 						(
 							document.querySelectorAll('[name="q"]')[0] as HTMLInputElement
 						).getAttribute("value") || "All Katas";
-					let difficultyFilter = (
-						document.querySelector<HTMLInputElement>(
-							'[Label="Difficulty"]'
-						)
-					).getAttribute("value");
+					let difficultyFilter = document
+						.querySelector<HTMLInputElement>('[Label="Difficulty"]')
+						.getAttribute("value");
 					if (difficultyFilter) {
 						difficultyFilter = difficultyFilter
 							.split(",")
@@ -100,9 +98,9 @@ presence.on("UpdateData", async () => {
 					presenceData.details = "Viewing profile of";
 					if (displayStats) {
 						presenceData.state = `${pages[1]} | 
-						${Array.from(document.querySelector(".stat-box").children)
-							.find(e => e.textContent.startsWith("Clan:"))
-							.textContent.slice("Clan:".length)}`;
+					${Array.from(document.querySelector(".stat-box").children)
+						.find(e => e.textContent.startsWith("Clan:"))
+						.textContent.slice("Clan:".length)}`;
 					}
 				}
 			}

--- a/websites/C/Codewars/presence.ts
+++ b/websites/C/Codewars/presence.ts
@@ -4,15 +4,13 @@ const presence = new Presence({
 	timebrowsed = Math.floor(Date.now() / 1000);
 
 presence.on("UpdateData", async () => {
-	const [pages, state] = document.location.pathname.split("/").filter(p => p),
+	const pages = document.location.pathname.split("/").filter(p => p),
 		presenceData: PresenceData = {
-			largeImageKey:
-				"https://cdn.rcd.gg/PreMiD/websites/C/Codewars/assets/logo.png",
+			largeImageKey: "https://cdn.rcd.gg/PreMiD/websites/C/Codewars/assets/logo.png",
 			startTimestamp: timebrowsed,
-			details: "Browsing ...",
+			details: "Browsing...",
 		},
 		displayStats = await presence.getSetting<boolean>("statsdisplay");
-
 	switch (pages[0]) {
 		case "dashboard": {
 			presenceData.details = "Viewing Dashboard";
@@ -21,15 +19,13 @@ presence.on("UpdateData", async () => {
 					document.querySelector(".ml-10px").textContent
 				} Honor`;
 			}
-
 			break;
 		}
 		case "topics": {
 			if (pages[1]) {
 				presenceData.details = "Viewing Topic";
-				presenceData.state = state;
+				presenceData.state = "Topic: " + pages[1];
 			} else presenceData.details = "Viewing Forum";
-
 			break;
 		}
 		case "kumite": {
@@ -44,12 +40,20 @@ presence.on("UpdateData", async () => {
 			if (pages[0] === "users" && pages[1] === "leaderboard")
 				presenceData.details = "Viewing Leaderboard";
 			else if (pages[0] === "kata") {
-				if (pages[2]) {
+				if (pages[2] && pages[2].startsWith("my-languages")) {
+					let search = (document.querySelectorAll('[name="q"]')[0] as HTMLInputElement).getAttribute("value") || "All Katas";
+					let difficultyFilter = (document.querySelectorAll('[Label="Difficulty"]')[0] as HTMLInputElement).getAttribute("value");
+					if (difficultyFilter) {
+						difficultyFilter = difficultyFilter.split(",").map((x: string) => {
+							return x.replace(/-/g, "").trim() + " kyu";
+						}).join(", ");
+					}
+					else difficultyFilter = "Any kyu";
 					presenceData.details = "Searching Katas";
-					presenceData.state = `${document.querySelector(".ml-0").textContent}`;
+					presenceData.state = `${search} | ${difficultyFilter}`;
 				} else {
 					presenceData.details = `Solving Kata | ${
-						document.querySelector(".inner-small-hex > span").textContent
+						document.querySelectorAll(".w-full>div>div>div>span")[0].textContent
 					}`;
 					presenceData.state =
 						document.querySelector(".items-center > h4").textContent;
@@ -67,22 +71,22 @@ presence.on("UpdateData", async () => {
 				pages[1] !== "leaderboard" &&
 				pages[1] !== "edit"
 			) {
-				if (Array.from(document.querySelectorAll(".h-full")).length > 6) {
-					presenceData.details = "Viewing own Profile";
+				let urls = Array.from(document.getElementsByTagName("img")).map(e => e.src);
+				let avatar = urls.find(e => e.includes("avatar"));
+				let avatar2 = urls.find(e => e.includes("avatar") && e !== avatar);
+				if (!avatar2) {
+					presenceData.details = "Viewing own profile";
 					if (displayStats) {
 						presenceData.state = `${
 							document.querySelector(".ml-10px").textContent
 						} Honor | ${document.querySelector(".small-hex").textContent}`;
 					}
 				} else {
-					presenceData.details = "Viewing Profile from";
+					presenceData.details = "Viewing profile of";
 					if (displayStats) {
-						presenceData.state = `${document
-							.querySelector(".stat")
-							.textContent.slice("Name:".length)} | ${Array.from(
-							document.querySelector(".stat-box").children
-						)
-							.find(e => e.textContent.startsWith("<b>Clan:</b>"))
+						presenceData.state = `${pages[1]} | 
+						${Array.from(document.querySelector(".stat-box").children)
+							.find(e => e.textContent.startsWith("Clan:"))
 							.textContent.slice("Clan:".length)}`;
 					}
 				}

--- a/websites/C/Codewars/presence.ts
+++ b/websites/C/Codewars/presence.ts
@@ -47,9 +47,9 @@ presence.on("UpdateData", async () => {
 							document.querySelectorAll('[name="q"]')[0] as HTMLInputElement
 						).getAttribute("value") || "All Katas";
 					let difficultyFilter = (
-						document.querySelectorAll(
+						document.querySelector<HTMLInputElement>(
 							'[Label="Difficulty"]'
-						)[0] as HTMLInputElement
+						)
 					).getAttribute("value");
 					if (difficultyFilter) {
 						difficultyFilter = difficultyFilter

--- a/websites/C/Codewars/presence.ts
+++ b/websites/C/Codewars/presence.ts
@@ -48,7 +48,7 @@ presence.on("UpdateData", async () => {
             ).getAttribute("value") || "All Katas";
           let difficultyFilter = (
             document.querySelectorAll(
-              '[Label="Difficulty"]',
+              '[Label="Difficulty"]'
             )[0] as HTMLInputElement
           ).getAttribute("value");
           if (difficultyFilter) {
@@ -82,9 +82,15 @@ presence.on("UpdateData", async () => {
         pages[1] !== "edit"
       ) {
         const urls = Array.from(document.querySelectorAll("img")).map(
-          (e) => e.src,
+          (e) => e.src
         );
-        if (!urls.find((e) => e.includes("avatar") && e !== urls.find((e) => e.includes("avatar")))) {
+        if (
+          !urls.find(
+            (e) =>
+              e.includes("avatar") &&
+              e !== urls.find((e) => e.includes("avatar"))
+          )
+        ) {
           presenceData.details = "Viewing own profile";
           if (displayStats) {
             presenceData.state = `${

--- a/websites/C/Codewars/presence.ts
+++ b/websites/C/Codewars/presence.ts
@@ -48,7 +48,7 @@ presence.on("UpdateData", async () => {
             ).getAttribute("value") || "All Katas";
           let difficultyFilter = (
             document.querySelectorAll(
-              '[Label="Difficulty"]'
+              '[Label="Difficulty"]',
             )[0] as HTMLInputElement
           ).getAttribute("value");
           if (difficultyFilter) {
@@ -82,13 +82,13 @@ presence.on("UpdateData", async () => {
         pages[1] !== "edit"
       ) {
         const urls = Array.from(document.querySelectorAll("img")).map(
-          (e) => e.src
+          (e) => e.src,
         );
         if (
           !urls.find(
             (e) =>
               e.includes("avatar") &&
-              e !== urls.find((e) => e.includes("avatar"))
+              e !== urls.find((e) => e.includes("avatar")),
           )
         ) {
           presenceData.details = "Viewing own profile";

--- a/websites/C/Codewars/presence.ts
+++ b/websites/C/Codewars/presence.ts
@@ -63,7 +63,7 @@ presence.on("UpdateData", async () => {
 					presenceData.state = `${search} | ${difficultyFilter}`;
 				} else {
 					presenceData.details = `Solving Kata | ${
-						document.querySelectorAll(".w-full>div>div>div>span")[0].textContent
+						document.querySelector(".w-full>div>div>div>span").textContent
 					}`;
 					presenceData.state =
 						document.querySelector(".items-center > h4").textContent;

--- a/websites/C/Codewars/presence.ts
+++ b/websites/C/Codewars/presence.ts
@@ -83,10 +83,8 @@ presence.on("UpdateData", async () => {
       ) {
         const urls = Array.from(document.querySelectorAll("img")).map(
           (e) => e.src,
-        ),
-	  avatar = urls.find((e) => e.includes("avatar")),
-	  avatar2 = urls.find((e) => e.includes("avatar") && e !== avatar);
-        if (!avatar2) {
+        );
+        if (!urls.find((e) => e.includes("avatar") && e !== urls.find((e) => e.includes("avatar")))) {
           presenceData.details = "Viewing own profile";
           if (displayStats) {
             presenceData.state = `${

--- a/websites/C/Codewars/presence.ts
+++ b/websites/C/Codewars/presence.ts
@@ -1,114 +1,113 @@
 const presence = new Presence({
-    clientId: "821106305241972746",
-  }),
-  timebrowsed = Math.floor(Date.now() / 1000);
+		clientId: "821106305241972746",
+	}),
+	timebrowsed = Math.floor(Date.now() / 1000);
 
 presence.on("UpdateData", async () => {
-  const pages = document.location.pathname.split("/").filter((p) => p),
-    presenceData: PresenceData = {
-      largeImageKey:
-        "https://cdn.rcd.gg/PreMiD/websites/C/Codewars/assets/logo.png",
-      startTimestamp: timebrowsed,
-      details: "Browsing...",
-    },
-    displayStats = await presence.getSetting<boolean>("statsdisplay");
-  switch (pages[0]) {
-    case "dashboard": {
-      presenceData.details = "Viewing Dashboard";
-      if (displayStats) {
-        presenceData.state = `${
-          document.querySelector(".ml-10px").textContent
-        } Honor`;
-      }
-      break;
-    }
-    case "topics": {
-      if (pages[1]) {
-        presenceData.details = "Viewing Topic";
-        presenceData.state = `Topic: ${pages[1]}`;
-      } else presenceData.details = "Viewing Forum";
-      break;
-    }
-    case "kumite": {
-      presenceData.details = "Viewing kumite";
-      break;
-    }
-    case "subscription": {
-      presenceData.details = "Viewing Codewars Red";
-      break;
-    }
-    default:
-      if (pages[0] === "users" && pages[1] === "leaderboard")
-        presenceData.details = "Viewing Leaderboard";
-      else if (pages[0] === "kata") {
-        if (pages[2] && pages[2].startsWith("my-languages")) {
-          const search =
-            (
-              document.querySelectorAll('[name="q"]')[0] as HTMLInputElement
-            ).getAttribute("value") || "All Katas";
-          let difficultyFilter = (
-            document.querySelectorAll(
-              '[Label="Difficulty"]',
-            )[0] as HTMLInputElement
-          ).getAttribute("value");
-          if (difficultyFilter) {
-            difficultyFilter = difficultyFilter
-              .split(",")
-              .map((x: string) => {
-                return `${x.replace(/-/g, "").trim()} kyu`;
-              })
-              .join(", ");
-          } else difficultyFilter = "Any kyu";
-          presenceData.details = "Searching Katas";
-          presenceData.state = `${search} | ${difficultyFilter}`;
-        } else {
-          presenceData.details = `Solving Kata | ${
-            document.querySelectorAll(".w-full>div>div>div>span")[0].textContent
-          }`;
-          presenceData.state =
-            document.querySelector(".items-center > h4").textContent;
-        }
-      } else if (pages[0] === "users" && pages[1] === "edit")
-        presenceData.details = "Editing Account";
-      else if (pages[0] === "trainer" && pages[1] === "setup") {
-        presenceData.details = "Editing Trainer Setup";
-        presenceData.state = `${
-          Array.from(document.querySelectorAll(".icon-list > li > .is-active"))
-            .length
-        } Languages selected`;
-      } else if (
-        pages[0] === "users" &&
-        pages[1] !== "leaderboard" &&
-        pages[1] !== "edit"
-      ) {
-        const urls = Array.from(document.querySelectorAll("img")).map(
-          (e) => e.src,
-        );
-        if (
-          !urls.find(
-            (e) =>
-              e.includes("avatar") &&
-              e !== urls.find((e) => e.includes("avatar")),
-          )
-        ) {
-          presenceData.details = "Viewing own profile";
-          if (displayStats) {
-            presenceData.state = `${
-              document.querySelector(".ml-10px").textContent
-            } Honor | ${document.querySelector(".small-hex").textContent}`;
-          }
-        } else {
-          presenceData.details = "Viewing profile of";
-          if (displayStats) {
-            presenceData.state = `${pages[1]} | 
+	const pages = document.location.pathname.split("/").filter(p => p),
+		presenceData: PresenceData = {
+			largeImageKey:
+				"https://cdn.rcd.gg/PreMiD/websites/C/Codewars/assets/logo.png",
+			startTimestamp: timebrowsed,
+			details: "Browsing...",
+		},
+		displayStats = await presence.getSetting<boolean>("statsdisplay");
+	switch (pages[0]) {
+		case "dashboard": {
+			presenceData.details = "Viewing Dashboard";
+			if (displayStats) {
+				presenceData.state = `${
+					document.querySelector(".ml-10px").textContent
+				} Honor`;
+			}
+			break;
+		}
+		case "topics": {
+			if (pages[1]) {
+				presenceData.details = "Viewing Topic";
+				presenceData.state = `Topic: ${pages[1]}`;
+			} else presenceData.details = "Viewing Forum";
+			break;
+		}
+		case "kumite": {
+			presenceData.details = "Viewing kumite";
+			break;
+		}
+		case "subscription": {
+			presenceData.details = "Viewing Codewars Red";
+			break;
+		}
+		default:
+			if (pages[0] === "users" && pages[1] === "leaderboard")
+				presenceData.details = "Viewing Leaderboard";
+			else if (pages[0] === "kata") {
+				if (pages[2] && pages[2].startsWith("my-languages")) {
+					const search =
+						(
+							document.querySelectorAll('[name="q"]')[0] as HTMLInputElement
+						).getAttribute("value") || "All Katas";
+					let difficultyFilter = (
+						document.querySelectorAll(
+							'[Label="Difficulty"]'
+						)[0] as HTMLInputElement
+					).getAttribute("value");
+					if (difficultyFilter) {
+						difficultyFilter = difficultyFilter
+							.split(",")
+							.map((x: string) => {
+								return `${x.replace(/-/g, "").trim()} kyu`;
+							})
+							.join(", ");
+					} else difficultyFilter = "Any kyu";
+					presenceData.details = "Searching Katas";
+					presenceData.state = `${search} | ${difficultyFilter}`;
+				} else {
+					presenceData.details = `Solving Kata | ${
+						document.querySelectorAll(".w-full>div>div>div>span")[0].textContent
+					}`;
+					presenceData.state =
+						document.querySelector(".items-center > h4").textContent;
+				}
+			} else if (pages[0] === "users" && pages[1] === "edit")
+				presenceData.details = "Editing Account";
+			else if (pages[0] === "trainer" && pages[1] === "setup") {
+				presenceData.details = "Editing Trainer Setup";
+				presenceData.state = `${
+					Array.from(document.querySelectorAll(".icon-list > li > .is-active"))
+						.length
+				} Languages selected`;
+			} else if (
+				pages[0] === "users" &&
+				pages[1] !== "leaderboard" &&
+				pages[1] !== "edit"
+			) {
+				const urls = Array.from(document.querySelectorAll("img")).map(
+					e => e.src
+				);
+				if (
+					!urls.find(
+						e =>
+							e.includes("avatar") && e !== urls.find(e => e.includes("avatar"))
+					)
+				) {
+					presenceData.details = "Viewing own profile";
+					if (displayStats) {
+						presenceData.state = `${
+							document.querySelector(".ml-10px").textContent
+						} Honor | ${document.querySelector(".small-hex").textContent}`;
+					}
+				} else {
+					presenceData.details = "Viewing profile of";
+					if (displayStats) {
+						presenceData.state = `${pages[1]} | 
 						${Array.from(document.querySelector(".stat-box").children)
-              .find((e) => e.textContent.startsWith("Clan:"))
-              .textContent.slice("Clan:".length)}`;
-          }
-        }
-      }
-  }
+							.find(e => e.textContent.startsWith("Clan:"))
+							.textContent.slice("Clan:".length)}`;
+					}
+				}
+			}
+	}
 
-  if (!presenceData.details) presence.setActivity();
-  else presence.setActivity(presenceData);
+	if (!presenceData.details) presence.setActivity();
+	else presence.setActivity(presenceData);
 });


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
- Fixed a major issue that prevented anything besides "Browsing..." from being displayed in the description
- Added a small feature that shows the difficulty of the kata being searched for

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![331835104-6074af89-05de-4148-97e5-95dc8700750f](https://github.com/PreMiD/Presences/assets/69062894/d82b23c5-1d6b-47e0-ba99-45534b987e94)

![331835088-7d102463-96c4-40ca-9e88-ce33c9b9a7c8](https://github.com/PreMiD/Presences/assets/69062894/947616c0-6186-4ce1-8e81-87c34d172fb2)


</details>
