### PR TITLE
Fix for ChatGPT domain update

### DIFF
--- a/websites/C/ChatGPT/metadata.json
+++ b/websites/C/ChatGPT/metadata.json
@@ -8,7 +8,7 @@
 	"description": {
 		"en": "ChatGPT is a natural language processing tool driven by AI technology that allows you to have human-like conversations and much more with the chatbot. The language model can answer questions and assist you with tasks, such as composing emails, essays, and code."
 	},
-	"url": "chat.openai.com",
+	"url": "chatgpt.com",
 	"version": "1.0.6",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/C/ChatGPT/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/C/ChatGPT/assets/thumbnail.png",


### PR DESCRIPTION
## Description 
I have updated the URL in the metadata to `chatgpt.com` to match with ChatGPTs new domain.
