### PR TITLE
fix(RadioGarden): update broken selector

### DIFF
--- a/websites/R/Radio Garden/metadata.json
+++ b/websites/R/Radio Garden/metadata.json
@@ -10,7 +10,7 @@
 		"nl": "Door verre stemmen dichtbij te brengen, verbindt radio mensen en plaatsen. Met Radio Garden kunnen luisteraars afstemmen op live-radio over de hele wereld."
 	},
 	"url": "radio.garden",
-	"version": "3.1.2",
+	"version": "3.1.3",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/R/Radio%20Garden/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/R/Radio%20Garden/assets/thumbnail.png",
 	"color": "#0DF675",

--- a/websites/R/Radio Garden/presence.ts
+++ b/websites/R/Radio Garden/presence.ts
@@ -12,7 +12,9 @@ presence.on("UpdateData", async () => {
 				.querySelector('[class*="_channel_"]')
 				?.querySelector('[class*="_title_"]')?.textContent ?? "Unknown Radio"; // which radio we're tuning right now
 		state =
-			document.querySelector('[class*="_subtitle_"]')?.textContent ??
+			document
+				.querySelector('[class*="_channel_"]')
+				?.querySelector('[class*="_subtitle_"]')?.textContent ??
 			"Unknown State/Country"; // the state where the radio serves
 
 		const presenceData: PresenceData = {


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
This PR fixes a bug, where if you navigated to the `All Stations` menu, the extension would grab the "All Stations" string, instead of the current country.

reproduction note: you can reproduce the bug by navigating to the  [/channels/](http://radio.garden/visit/damascus/8ElQnK3h/channels) route
## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/PreMiD/Presences/assets/142719764/cffe29d7-fa26-4335-91e1-202b590ebf03)
![image](https://github.com/PreMiD/Presences/assets/142719764/1f222acb-1364-4c37-aca5-a94bf9c175a9)



</details>
