### PR TITLE
fix(ChatGPT): change url

### DIFF
--- a/websites/C/ChatGPT/metadata.json
+++ b/websites/C/ChatGPT/metadata.json
@@ -8,8 +8,8 @@
 	"description": {
 		"en": "ChatGPT is a natural language processing tool driven by AI technology that allows you to have human-like conversations and much more with the chatbot. The language model can answer questions and assist you with tasks, such as composing emails, essays, and code."
 	},
-	"url": "chat.openai.com",
-	"version": "1.0.6",
+	"url": "chatgpt.com",
+	"version": "1.0.7",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/C/ChatGPT/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/C/ChatGPT/assets/thumbnail.png",
 	"color": "#75AC9D",


### PR DESCRIPTION
Increased version number from 1.0.6 to 1.0.7 as this is a minor change that doesn't affect the functionality of the presence
Changed URL to `chatgpt.com` following ChatGPTs new domain from `chat.openai.com`