### PR TITLE
fix(Discord): update serverChannel selector

### DIFF
--- a/websites/D/Discord/metadata.json
+++ b/websites/D/Discord/metadata.json
@@ -23,7 +23,7 @@
 	},
 	"url": "discord.com",
 	"regExp": "([a-z0-9-]+[.])*(discord[.]com|discord[.]gg|discordapp[.]com|discordmerch[.]com|discordstatus[.]com)[/]",
-	"version": "3.0.32",
+	"version": "3.0.33",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/D/Discord/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/D/Discord/assets/thumbnail.png",
 	"color": "#7289DA",

--- a/websites/D/Discord/presence.ts
+++ b/websites/D/Discord/presence.ts
@@ -162,7 +162,7 @@ presence.on("UpdateData", async () => {
 					document
 						.querySelectorAll("title")[0]
 						?.textContent.split("| #")[1]
-						.split("|")[0] || "Undefined"
+						?.split("|")[0] || "Undefined"
 				}`,
 				serverServerName =
 					document.querySelectorAll("title")[0]?.textContent.split("|")[2] ||


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
This PR fixes the bug where if you navigated to a dm channel, the console would be flooded with `cannot read properties of undefined`
fixes  #8372 

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/PreMiD/Presences/assets/142719764/3c9b5a7d-896d-49ba-94ce-1f4ab28909c7)

![image](https://github.com/PreMiD/Presences/assets/142719764/46405bee-193c-4490-905d-2a386a003a18)

</details>
