### PR TITLE
fix(Songsterr): fix search tab not showing and make details title-case

### DIFF
--- a/websites/S/Songsterr/metadata.json
+++ b/websites/S/Songsterr/metadata.json
@@ -14,7 +14,7 @@
 		"www.songsterr.com",
 		"songsterr.com"
 	],
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/S/Songsterr/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/S/Songsterr/assets/thumbnail.png",
 	"color": "#138CF6",

--- a/websites/S/Songsterr/presence.ts
+++ b/websites/S/Songsterr/presence.ts
@@ -27,9 +27,9 @@ presence.on("UpdateData", async () => {
 			presenceData.details = obj[pathname.split("/").at(-1)];
 		else {
 			presenceData.details = `Searching tabs for ${
-				(<HTMLInputElement>(
-					document.querySelector("div.Bt4t5 > div.Ccm27v > div > input")
-				))?.value
+				document.querySelector<HTMLInputElement>(
+					"#search-wrap > div > div > div > input"
+				)?.value
 			}`;
 		}
 	} else {

--- a/websites/S/Songsterr/presence.ts
+++ b/websites/S/Songsterr/presence.ts
@@ -1,5 +1,5 @@
 const presence = new Presence({
-		clientId: "1074706064609656852",
+		clientId: "1112463096368353300",
 	}),
 	browsingTimestamp = Math.floor(Date.now() / 1000);
 
@@ -11,25 +11,28 @@ presence.on("UpdateData", async () => {
 		},
 		{ pathname } = document.location,
 		{ role } = document.querySelector("#apptab"),
-		searchvar = (<HTMLInputElement>(
-			document.querySelector("#sticky-list-header > div.Ccm27v > div > input")
-		))?.value,
 		obj: { [key: string]: string } = {
 			plus: "Viewing Plans",
-			mytabs: "Checking submitted tabs",
+			mytabs: "Checking Submitted Tabs",
 			submit: "Submitting Tabs",
 			help: "Reading FAQ",
-			howtoreadtab: "Learning how to read a tab",
+			howtoreadtab: "Learning How To Read A Tab",
 			account: "Viewing Account Settings",
 			favorites: "Viewing Favorite Tabs",
 			payment: "Buying Songsterr Plus",
 		};
 
-	if (role === "complementary")
-		presenceData.details = obj[pathname.split("/").at(-1)];
-	else if (typeof searchvar !== "undefined")
-		presenceData.details = `Searching tabs for ${searchvar}`;
-	else {
+	if (role === "complementary") {
+		if (pathname.split("/").at(-1) in obj)
+			presenceData.details = obj[pathname.split("/").at(-1)];
+		else {
+			presenceData.details = `Searching tabs for ${
+				(<HTMLInputElement>(
+					document.querySelector("div.Bt4t5 > div.Ccm27v > div > input")
+				))?.value
+			}`;
+		}
+	} else {
 		presenceData.state = `Author: ${
 			document.querySelector('[aria-label="artist"]').textContent
 		}`;


### PR DESCRIPTION
## Description 
Presence was not working as expected in the previous version as "#sticky-list-header" is no more a thing. Also, since complementary role is also available when doing a search, the condition was blocking details to change accordingly for search. Rewritten the problematic part. Also made details title-case as it is more consistent and aesthetic.

## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://github.com/PreMiD/Presences/assets/34231577/b7cc09b5-1c78-4caa-af02-cd4fb15e0a17)

![image](https://github.com/PreMiD/Presences/assets/34231577/26aa2595-10b4-461f-8636-865ded856ae3)



</details>
