### PR TITLE
fix(Amazon Prime Video): amazon prime video regExp support japan amazon

### DIFF
--- a/websites/P/Prime Video/metadata.json
+++ b/websites/P/Prime Video/metadata.json
@@ -14,11 +14,12 @@
 	"description": {
 		"en": "Enjoy exclusive Amazon Originals as well as popular movies and TV shows. Watch anytime, anywhere. Start your free trial.",
 		"de": "Spielfilme und Serien online streamen, als Einzelabruf online leihen oder kaufen bei Prime Video, Amazons großer Video on Demand Online-Videothek.",
-		"nl": "Geniet van exclusieve Amazon Originals en populaire films en tv-programma's. Bekijk altijd en overal. Start uw gratis proefperiode."
+		"nl": "Geniet van exclusieve Amazon Originals en populaire films en tv-programma's. Bekijk altijd en overal. Start uw gratis proefperiode.",
+        "jp": "ここでしか見れない、先行や独占配信作品が続々追加！まずは30日間無料でお試し"
 	},
 	"url": "www.primevideo.com",
-	"regExp": "(([a-z0-9-]+[.])*amazon([.][a-z]+)+[/](-[/]([a-z0-9]+)[/])?(Prime-Video|Prime-Instant-Video|Amazon-Video|gp[/]video))|([a-z0-9-]+[.])*primevideo([.][a-z]+)+[/]",
-	"version": "2.1.23",
+	"regExp": "(([a-z0-9-]+[.])*amazon([.][a-z]+)+([/](-[/]([a-z0-9]+)[/])?(Prime-Video|Prime-Instant-Video|Amazon-Video|gp[/]video)?)?)|([a-z0-9-]+[.])*primevideo([.][a-z]+)+([/]?)?",
+	"version": "2.1.24",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/P/Prime%20Video/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/P/Prime%20Video/assets/thumbnail.jpg",
 	"color": "#FFFFFF",

--- a/websites/P/Prime Video/metadata.json
+++ b/websites/P/Prime Video/metadata.json
@@ -15,7 +15,7 @@
 		"en": "Enjoy exclusive Amazon Originals as well as popular movies and TV shows. Watch anytime, anywhere. Start your free trial.",
 		"de": "Spielfilme und Serien online streamen, als Einzelabruf online leihen oder kaufen bei Prime Video, Amazons großer Video on Demand Online-Videothek.",
 		"nl": "Geniet van exclusieve Amazon Originals en populaire films en tv-programma's. Bekijk altijd en overal. Start uw gratis proefperiode.",
-        "jp": "ここでしか見れない、先行や独占配信作品が続々追加！まずは30日間無料でお試し"
+		"ja_JP": "ここでしか見れない、先行や独占配信作品が続々追加！まずは30日間無料でお試し"
 	},
 	"url": "www.primevideo.com",
 	"regExp": "(([a-z0-9-]+[.])*amazon([.][a-z]+)+([/](-[/]([a-z0-9]+)[/])?(Prime-Video|Prime-Instant-Video|Amazon-Video|gp[/]video)?)?)|([a-z0-9-]+[.])*primevideo([.][a-z]+)+([/]?)?",


### PR DESCRIPTION
## Description 
This pull request updates the regular expression pattern for Prime Video URLs to include URLs without specific paths, such as https://www.amazon.co.jp. The updated regular expression ensures broader compatibility with various Amazon and Prime Video domains. Additionally, minor description updates for multiple languages are included.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
