### PR TITLE
feat(Apple Music): add listening setting

### DIFF
--- a/websites/A/Apple Music/metadata.json
+++ b/websites/A/Apple Music/metadata.json
@@ -27,7 +27,7 @@
 		"music.apple.com",
 		"beta.music.apple.com"
 	],
-	"version": "1.5.14",
+	"version": "1.5.15",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/Apple%20Music/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/Apple%20Music/assets/thumbnail.png",
 	"color": "#FA273F",
@@ -50,6 +50,13 @@
 			"title": "Show cover",
 			"icon": "fad fa-images",
 			"value": true
+		},
+		{
+			"id": "listening",
+			"title": "Enable listening",
+			"icon": "fad fa-ear",
+			"value": true
+
 		}
 	]
 }

--- a/websites/A/Apple Music/presence.ts
+++ b/websites/A/Apple Music/presence.ts
@@ -37,6 +37,7 @@ presence.on("UpdateData", async () => {
 
 		presenceData.details = navigator.mediaSession.metadata.title;
 		presenceData.state = navigator.mediaSession.metadata.artist;
+		presenceData.type = ActivityType.Listening;
 
 		presenceData.smallImageKey = paused ? Assets.Pause : Assets.Play;
 		presenceData.smallImageText = paused

--- a/websites/A/Apple Music/presence.ts
+++ b/websites/A/Apple Music/presence.ts
@@ -11,9 +11,10 @@ presence.on("UpdateData", async () => {
 			largeImageKey:
 				"https://cdn.rcd.gg/PreMiD/websites/A/Apple%20Music/assets/logo.png",
 		},
-		[timestamps, cover] = await Promise.all([
+		[timestamps, cover, listening] = await Promise.all([
 			presence.getSetting<boolean>("timestamps"),
 			presence.getSetting<boolean>("cover"),
+			presence.getSetting<boolean>("listening")
 		]),
 		audio = document.querySelector<HTMLAudioElement>(
 			"audio#apple-music-player"
@@ -37,7 +38,6 @@ presence.on("UpdateData", async () => {
 
 		presenceData.details = navigator.mediaSession.metadata.title;
 		presenceData.state = navigator.mediaSession.metadata.artist;
-		presenceData.type = ActivityType.Listening;
 
 		presenceData.smallImageKey = paused ? Assets.Pause : Assets.Play;
 		presenceData.smallImageText = paused
@@ -62,6 +62,11 @@ presence.on("UpdateData", async () => {
 			delete presenceData.startTimestamp;
 			delete presenceData.endTimestamp;
 		}
+
+		if (listening) {
+			presenceData.type = ActivityType.Listening;
+		}
+		
 		presence.setActivity(presenceData);
 	} else if (+presence.getExtensionVersion() < 224) presence.setActivity();
 	else presence.clearActivity();

--- a/websites/A/Apple Music/presence.ts
+++ b/websites/A/Apple Music/presence.ts
@@ -63,9 +63,8 @@ presence.on("UpdateData", async () => {
 			delete presenceData.endTimestamp;
 		}
 
-		if (listening) {
+		if (listening) 
 			presenceData.type = ActivityType.Listening;
-		}
 		
 		presence.setActivity(presenceData);
 	} else if (+presence.getExtensionVersion() < 224) presence.setActivity();

--- a/websites/A/Apple Music/presence.ts
+++ b/websites/A/Apple Music/presence.ts
@@ -14,7 +14,7 @@ presence.on("UpdateData", async () => {
 		[timestamps, cover, listening] = await Promise.all([
 			presence.getSetting<boolean>("timestamps"),
 			presence.getSetting<boolean>("cover"),
-			presence.getSetting<boolean>("listening")
+			presence.getSetting<boolean>("listening"),
 		]),
 		audio = document.querySelector<HTMLAudioElement>(
 			"audio#apple-music-player"
@@ -63,9 +63,8 @@ presence.on("UpdateData", async () => {
 			delete presenceData.endTimestamp;
 		}
 
-		if (listening) 
-			presenceData.type = ActivityType.Listening;
-		
+		if (listening) presenceData.type = ActivityType.Listening;
+
 		presence.setActivity(presenceData);
 	} else if (+presence.getExtensionVersion() < 224) presence.setActivity();
 	else presence.clearActivity();


### PR DESCRIPTION
## Description 
Changes the Apple Music presence from `Playing` to `Listening` with a setting to change between the two.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
-  [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
Proof showing the creation/modification is working as expected </summary>
![image](https://github.com/PreMiD/Presences/assets/40673120/c9b1a355-b0a1-4fe4-b286-ccd08dd6d852)
![image](https://github.com/PreMiD/Presences/assets/40673120/0593ed37-7b80-4f5b-92ba-41520e2d5533)
![image](https://github.com/PreMiD/Presences/assets/40673120/3161ec5e-7150-4670-87b7-48089358de82)