### PR TITLE
now largeImageKey is properly set

### DIFF
--- a/websites/M/MangaDex/presence.ts
+++ b/websites/M/MangaDex/presence.ts
@@ -71,7 +71,7 @@ presence.on("UpdateData", async () => {
 				.querySelector("head > title")
 				.textContent.replace(` - ${title} - MangaDex`, "")}`;
 			presenceData.largeImageKey = await getCoverImage(
-				document.querySelector<HTMLLinkElement>("span > a").href.split("/")[4]
+				href.split("/")[4]
 			);
 			presenceData.smallImageKey = Assets.Reading;
 			presenceData.buttons = [{ label: "Read Chapter", url: href }];


### PR DESCRIPTION
For some reason the modified line of code throws an error, it's trying to get the id of the current manga (mangadex) and then use it as the argument of a function, instead of directly retrieving the id from the href variable