### PR TITLE
fix(BeatLeader): fix broken regexp

### DIFF
--- a/websites/B/BeatLeader/metadata.json
+++ b/websites/B/BeatLeader/metadata.json
@@ -14,14 +14,14 @@
 		"replay.beatleader.xyz",
 		"royale.beatleader.xyz"
 	],
-	"regExp": ".+\\.beatleader\\.(?:xyz)|(?:net)",
+	"regExp": "beatleader\\.xyz|beatleader\\.net",
 	"matches": [
 		"*://beatleader.xyz/*",
 		"*://beatleader.net/*",
 		"*://*.beatleader.xyz/*",
 		"*://*.beatleader.net/*"
 	],
-	"version": "1.8.7",
+	"version": "1.8.8",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/thumbnail.png",
 	"color": "#c81c9f",


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

Hopefully makes the RegExp of the BeatLeader presence not inject into every website that ends in .net

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![Discord_QMr6suTae4](https://github.com/PreMiD/Presences/assets/44418429/5c9f91e3-0b42-4a7c-88df-e09df3978750)

</details>
