### PR TITLE
fix(Stremio): series info can be null

### DIFF
--- a/websites/S/Stremio/metadata.json
+++ b/websites/S/Stremio/metadata.json
@@ -22,7 +22,7 @@
 		"web.strem.io",
 		"web.stremio.com"
 	],
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/S/Stremio/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/S/Stremio/assets/thumbnail.jpg",
 	"color": "#8A5AAB",

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -334,12 +334,12 @@ presence.on("UpdateData", async () => {
 						if (playerState.metaItem.type.toLowerCase() === "ready") {
 							const {
 								metaItem: { content },
-								seriesInfo: { season, episode },
+								seriesInfo,
 							} = playerState;
 							({ title } = playerState);
 							metaUrl = `${window.location.origin}/#/detail/${content.type}/${content.id}`;
 							if (content.type === "series")
-								metaUrl += `/${content.id}:${season}:${episode}`;
+								metaUrl += `/${content.id}:${seriesInfo.season}:${seriesInfo.episode}`;
 							presenceData.largeImageKey = content.logo ?? Assets.Logo;
 						}
 					}


### PR DESCRIPTION
## Description 
Fixes a bug in the Stremio presence where the extracted 'series info' can be null (this is the case when a movie is selected for instance), causing the object destructure to fail and thus halting the execution of the rest of the presence code due to an error being thrown.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots

*Not applicable*

Resolves #8488 