### PR TITLE
Update metadata.json for 3388 (new domain)

### DIFF
--- a/websites/0-9/3388/metadata.json
+++ b/websites/0-9/3388/metadata.json
@@ -10,7 +10,9 @@
 	},
 	"url": [
 		"3388.to",
-		"www.3388.to"
+		"www.3388.to",
+		"www.8833.to",
+		"8833.to"
 	],
 	"version": "1.0.6",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/0-9/3388/assets/logo.png",


### PR DESCRIPTION
## Description 
Domain update for the 3388 presence, added the new one as the old one got taken down.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots

Old domain (or rather what it redirects to now):
![image](https://github.com/PreMiD/Presences/assets/55195336/f44f1c1b-94d7-401f-99d1-dfb3ed1136db)