### PR TITLE
fix(Stremio): resolve player state promise before submitting the event

### DIFF
--- a/websites/S/Stremio/metadata.json
+++ b/websites/S/Stremio/metadata.json
@@ -22,7 +22,7 @@
 		"web.strem.io",
 		"web.stremio.com"
 	],
-	"version": "2.0.4",
+	"version": "2.0.5",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/S/Stremio/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/S/Stremio/assets/thumbnail.jpg",
 	"color": "#8A5AAB",

--- a/websites/S/Stremio/presence.ts
+++ b/websites/S/Stremio/presence.ts
@@ -43,10 +43,17 @@ function _eval(js: string): Promise<any> {
 			script.id = eventName;
 			script.appendChild(
 				document.createTextNode(`
-			 var core = window.services.core;
-			 var pmdEvent = new CustomEvent("${eventName}", {detail: ${js}});
-			 window.dispatchEvent(pmdEvent);
-			 `)
+				var core = window.services.core;
+				var result = ${js};
+				
+				if (result instanceof Promise) {
+					result.then((awaitedResult) => {
+						window.dispatchEvent(new CustomEvent("${eventName}", { detail: awaitedResult }));
+					});
+				} else {
+					window.dispatchEvent(new CustomEvent("${eventName}", { detail: result }));
+				}				
+			`)
 			);
 
 			document.head.appendChild(script);
@@ -331,7 +338,7 @@ presence.on("UpdateData", async () => {
 						const playerState = await _eval(
 							"core.transport.getState('player')"
 						);
-						if (playerState.metaItem.type.toLowerCase() === "ready") {
+						if (playerState?.metaItem?.type?.toLowerCase() === "ready") {
 							const {
 								metaItem: { content },
 								seriesInfo,


### PR DESCRIPTION
## Description 
There's an issue with Chromium-based browsers (such as Chrome and Microsoft Edge) in particular where the received player state is always `null`. On Firefox this issue does not occur. I'm not 100% sure of the exact cause of the discrepancy between the two browsers, but it seems like Chromium has trouble resolving promises that were dispatched by the `CustomEvent` event. So, to address this issue we have to resolve the promise first before dispatching the event.

I also added a check to gracefully handle cases where the `metaItem` field is still `undefined`, which may happen to users with slow network speeds.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots

*Not applicable*