### PR TITLE
fix(MangaDex): title image blocked by cdn

### DIFF
--- a/websites/M/MangaDex/metadata.json
+++ b/websites/M/MangaDex/metadata.json
@@ -29,7 +29,7 @@
 		"www.mangadex.org",
 		"mangadex.cc"
 	],
-	"version": "3.0.9",
+	"version": "3.0.10",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/M/MangaDex/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/M/MangaDex/assets/thumbnail.png",
 	"color": "#F18F1E",


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
This PR fixes a bug where a title's image get blocked by discord's cdn

Resolves #8530

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/user-attachments/assets/2bf5bf1e-4e7d-464c-9bf2-c4a92d71ee72)

![image](https://github.com/user-attachments/assets/3768e828-c17f-4a72-bb34-04fbd1b47a10)


</details>
