### PR TITLE
fix(BeatLeader): use API instead of dataURI

### DIFF
--- a/websites/B/BeatLeader/iframe.ts
+++ b/websites/B/BeatLeader/iframe.ts
@@ -1,27 +1,51 @@
-const iframe = new iFrame();
-function blobToDataURL(blob: Blob, callback: (dataurl: string) => void) {
-	const reader = new FileReader();
-	reader.onload = function (e) {
-		callback(e.target.result.toString());
-	};
-	reader.readAsDataURL(blob);
+const iframe = new iFrame(),
+	coverCache: Record<string, string | null> = {};
+
+async function getCover(songId: string): Promise<string> {
+	const coverImage = coverCache[songId];
+
+	if (typeof coverImage !== "undefined") return coverImage;
+
+	coverCache[songId] = null;
+
+	try {
+		const response = await fetch(
+			`https://api.beatleader.xyz/leaderboard/${songId}?count=0`
+		);
+		if (!response.ok) throw new Error(`Response status: ${response.status}`);
+
+		const json = await response.json();
+
+		coverCache[songId] = json.song.coverImage;
+
+		return json.song.coverImage;
+	} catch (error) {
+		presence.error(error.message);
+	}
 }
 
-if (document.location.href.includes("https://replay.beatleader.xyz")) {
+if (document.location.href.includes("https://replay.beatleader.")) {
 	iframe.on("UpdateData", async () => {
-		const blob = await fetch(
-			document.querySelector<HTMLImageElement>("#songImage").src
-		).then(response => response.blob());
-		blobToDataURL(blob, function (dataurl: string) {
-			iframe.send({
-				name: document.querySelector("#songName")?.textContent,
-				subName: document.querySelector("#songSubName")?.textContent,
-				currentTime: document.querySelector("#songProgress")?.textContent,
-				playing: Boolean(document.querySelector(".btn.pause")),
-				duration: document.querySelector("#songDuration")?.textContent,
-				playerName: document.querySelector("#playerName")?.textContent,
-				cover: dataurl,
-			});
+		let coverURL = document.querySelector<HTMLImageElement>("#songImage").src;
+
+		if (coverURL.startsWith("blob:")) {
+			coverURL = await getCover(
+				document
+					.querySelector<HTMLAnchorElement>("#songLink")
+					.href.split("/")[5]
+			);
+
+			if (coverURL === null) return;
+		}
+
+		iframe.send({
+			name: document.querySelector("#songName")?.textContent,
+			subName: document.querySelector("#songSubName")?.textContent,
+			currentTime: document.querySelector("#songProgress")?.textContent,
+			playing: Boolean(document.querySelector(".btn.pause")),
+			duration: document.querySelector("#songDuration")?.textContent,
+			playerName: document.querySelector("#playerName")?.textContent,
+			cover: coverURL,
 		});
 	});
 }

--- a/websites/B/BeatLeader/presence.ts
+++ b/websites/B/BeatLeader/presence.ts
@@ -551,7 +551,7 @@ presence.on("UpdateData", async () => {
 		if (
 			document
 				.querySelector<HTMLIFrameElement>("iframe")
-				?.src.includes("replay.beatleader.xyz") &&
+				?.src.includes("replay.beatleader.") &&
 			replay.name
 		) {
 			presenceData.largeImageKey = cover ? replay.cover : Assets.Replay;


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
For the iframe changed to the API to get a URL to the cover image instead of sending around sometimes fairly big dataURIs

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![Discord_ekfTmUbK7M](https://github.com/user-attachments/assets/48dcafae-d3f0-443e-83bf-5271f19ed4d2)


</details>
