### PR TITLE
fix(AnimeUnity): show correctly on smartphone

### DIFF
--- a/websites/A/AnimeUnity/metadata.json
+++ b/websites/A/AnimeUnity/metadata.json
@@ -10,7 +10,7 @@
 		"it": "AnimeUnity è un sito di streaming & download di anime ita/sub ita con un archivio molto vasto e streaming veloce"
 	},
 	"url": "animeunity.to",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeUnity/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeUnity/assets/thumbnail.png",
 	"color": "#ffffff",

--- a/websites/A/AnimeUnity/presence.ts
+++ b/websites/A/AnimeUnity/presence.ts
@@ -67,9 +67,9 @@ presence.on("UpdateData", async () => {
 				document.querySelectorAll(".name")[i].textContent
 			}\n`;
 		}
-		presenceData.details = `Viewing top-anime: ${
-			document.querySelector(".nav-link.active").textContent
-		}`;
+		presenceData.details = `Viewing top-anime: ${document
+			.querySelector(".nav-link.active")
+			.textContent.replace(/\n\s+/g, "")}`;
 		presenceData.state = top3;
 	} else if (pathname.startsWith("/anime")) {
 		delete presenceData.startTimestamp;
@@ -77,11 +77,10 @@ presence.on("UpdateData", async () => {
 		presenceData.smallImageText = paused ? strings.paused : strings.play;
 
 		presenceData.details = document.querySelector(".title").textContent;
-		presenceData.state = `Episode ${
-			document
-				.querySelector(".episode.episode-item.active.seen")
-				.querySelector("a").textContent
-		}`;
+		presenceData.state = `Episode ${document
+			.querySelector(".episode.episode-item.active.seen")
+			.querySelector("a")
+			.textContent.replace(/\n\s+/g, "")}`;
 		presenceData.largeImageKey = cover
 			? (presenceData.largeImageKey =
 					document.querySelector<HTMLImageElement>(".cover")?.src ??


### PR DESCRIPTION
## Description 
When presence gets the episode number, the episode has unnecessary spaces. It can be noticed using a smartphone

same thing with the “Tutto” category in top anime

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

BEFORE:
![image](https://github.com/user-attachments/assets/ec90b7a0-5c0e-47b1-b0ee-467021925fb1)
![image](https://github.com/user-attachments/assets/251a5680-77dc-4d90-be67-a88ad2acb1e0)

AFTER:
![image](https://github.com/user-attachments/assets/1de1a553-97f8-41d6-af81-771761c84070)
![image](https://github.com/user-attachments/assets/3265fb63-9798-4be0-bd82-e74cda92907d)

</details>
