### PR TITLE
feat(Cisco Networking Academy): add Legacy URL

### DIFF
--- a/websites/C/Cisco Networking Academy/metadata.json
+++ b/websites/C/Cisco Networking Academy/metadata.json
@@ -4,13 +4,25 @@
 		"name": "YJJcoolcool",
 		"id": "300929818231308288"
 	},
+	"contributors": [
+		{
+			"name": "Atom Skully",
+			"id": "671037171611729920"
+		}
+	],
 	"service": "Cisco Networking Academy",
 	"description": {
 		"en": "Cisco Networking Academy is a global IT and cybersecurity education platform.",
 		"vi_VN": "Cisco Networking Academy là nền tảng giáo dục an ninh mạng và IT toàn cầu."
 	},
-	"url": "www.netacad.com",
-	"version": "1.0.18",
+	"url": [
+		"www.netacad.com",
+		"legacy.netacad.com"
+	],
+	"matches": [
+		"*://*.netacad.com/*"
+	],
+	"version": "1.0.19",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/C/Cisco%20Networking%20Academy/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/C/Cisco%20Networking%20Academy/assets/thumbnail.png",
 	"color": "#005073",


### PR DESCRIPTION
## Description 
Fix issue #8695 with legacy url added to metadata.json

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://github.com/user-attachments/assets/78a5cdc7-07c4-4a66-afc8-29508699e638)

![image](https://github.com/user-attachments/assets/10d1b06b-a6ac-4ca5-b133-7b97be060598)




</details>
