### PR TITLE
fix(niconico): `/watch/` information was not available.

### DIFF
--- a/websites/N/niconico/metadata.json
+++ b/websites/N/niconico/metadata.json
@@ -19,7 +19,7 @@
 		"live.nicovideo.jp",
 		"seiga.nicovideo.jp"
 	],
-	"version": "1.3.25",
+	"version": "1.3.26",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/N/niconico/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/N/niconico/assets/thumbnail.jpg",
 	"color": "#272727",

--- a/websites/N/niconico/presence.ts
+++ b/websites/N/niconico/presence.ts
@@ -53,39 +53,36 @@ function getTimesec(
 presence.on("UpdateData", async () => {
 	switch (location.hostname) {
 		case "www.nicovideo.jp": {
-			if (
-				location.pathname.startsWith("/watch/") &&
-				document.querySelector(".VideoPlayer video")
-			) {
-				const ownerElement =
-					document.querySelector(".ChannelInfo-pageLink") ||
-					document.querySelector(".VideoOwnerInfo-pageLink") ||
-					null;
-				let owner;
-				if (ownerElement) {
-					[, owner] = ownerElement.textContent.match(/(.+) さん$/) || [
-						ownerElement.textContent,
-					];
-				} else owner = "Deleted User";
-
-				const isPlaying = !!document.querySelector(".PlayerPauseButton"),
+			if (location.pathname.startsWith("/watch/")) {
+				const startTimeStamp = document
+						.querySelector(
+							'div[data-styling-id=":r4:"]  span.white-space_nowrap'
+						)
+						.textContent.split(":")
+						.map(e => parseInt(e))
+						.reverse()
+						.reduce((acc, cur, i) => acc + cur * Math.pow(60, i), 0),
+					ownerElement = document.querySelector(
+						'a[data-anchor-area="video_information"]:not(:has(div))'
+					),
+					imageElement = document.querySelector('meta[property="og:image"]'),
+					isPlaying = !!document.querySelector(
+						'#tooltip\\:\\:r5\\:\\:trigger  > svg > path[fill-rule="evenodd"]'
+					),
 					presenceData: PresenceData = {
-						details: document.querySelector(".VideoTitle").textContent,
-						state: `${owner} - ${location.pathname.match(/..\d+$/)[0]}`,
-						largeImageKey:
-							"https://cdn.rcd.gg/PreMiD/websites/N/niconico/assets/logo.png",
+						details: document.querySelector("main h1").textContent,
+						state: `${
+							ownerElement ? ownerElement.textContent : "Deleted User"
+						} - ${location.pathname.match(/..\d+$/)[0]}`,
+						largeImageKey: imageElement
+							? imageElement.attributes.getNamedItem("content").value
+							: "https://cdn.rcd.gg/PreMiD/websites/N/niconico/assets/logo.png",
 						smallImageKey: isPlaying ? Assets.Play : Assets.Pause,
 						smallImageText: isPlaying
 							? (await strings).play
 							: (await strings).pause,
-						startTimestamp:
-							Math.floor(Date.now() / 1000) -
-							Math.floor(
-								document.querySelector<HTMLVideoElement>(".VideoPlayer video")
-									.currentTime
-							),
+						startTimestamp: Math.floor(Date.now() / 1000) - startTimeStamp,
 					};
-
 				presence.setActivity(presenceData);
 			}
 			break;


### PR DESCRIPTION
## Description 
In early August, [ニコニコ動画(niconico)](https://www.nicovideo.jp/) released a major update.

ref: https://blog.nicovideo.jp/niconews/226054.html

With this update, the existing `presence` can no longer retrieve `/watch/` browsing status.
Therefore, these have been fixed in this PR.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

|before|after|
|--|--|
|not available|![Screenshot 2024-09-11 012003](https://github.com/user-attachments/assets/df047b25-42cd-4099-8b29-d7d645546453)|

</details>
