### PR TITLE
fix(Youtube): do not set timestamps when there is no video

### DIFF
--- a/websites/Y/YouTube/metadata.json
+++ b/websites/Y/YouTube/metadata.json
@@ -75,7 +75,7 @@
 		"*://www.youtube.com/*",
 		"*://studio.youtube.com/*"
 	],
-	"version": "5.13.0",
+	"version": "5.13.1",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/thumbnail.jpg",
 	"color": "#E40813",

--- a/websites/Y/YouTube/presence.ts
+++ b/websites/Y/YouTube/presence.ts
@@ -177,14 +177,12 @@ presence.on("UpdateData", async () => {
 					: isPlaylistLoop
 					? "Playlist on loop"
 					: strings.play,
-				endTimestamp: adjustTimeError(
-					presence.getTimestampsfromMedia(video)[1],
-					0.75
-				),
-				startTimestamp: adjustTimeError(
-					presence.getTimestampsfromMedia(video)[0],
-					0.75
-				),
+				endTimestamp: !video?.paused
+					? adjustTimeError(presence.getTimestampsfromMedia(video)[1], 0.75)
+					: -1,
+				startTimestamp: !video?.paused
+					? adjustTimeError(presence.getTimestampsfromMedia(video)[0], 0.75)
+					: -1,
 			};
 
 		if (vidState.includes("{0}")) delete presenceData.state;


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
- Don't add timestamps when the video is paused.
## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img src="https://github.com/user-attachments/assets/a0c8354a-086e-41c0-9eca-0661b3d4a3e0">



</details>
