### PR TITLE
fix(AsuraScans): remake the presence to match asura website

### DIFF
--- a/websites/A/Asura Scans/metadata.json
+++ b/websites/A/Asura Scans/metadata.json
@@ -40,7 +40,6 @@
 		"manhua",
 		"manhwa"
 	],
-	"readLogs": true,
 	"settings": [
 		{
 			"id": "privacy",

--- a/websites/A/Asura Scans/metadata.json
+++ b/websites/A/Asura Scans/metadata.json
@@ -5,10 +5,17 @@
 		"name": "theusaf",
 		"id": "193714715631812608"
 	},
+	"contributors": [
+		{
+			"name": "rois2coeurs",
+			"id": "234647775621414912"
+		}
+	],
 	"service": "Asura Scans",
 	"description": {
 		"en": "Read Comics on Asura Scans.",
-		"vi_VN": "Đọc truyện tranh tại Asura Scans."
+		"vi_VN": "Đọc truyện tranh tại Asura Scans.",
+		"fr": "Lisez des bandes dessinées sur Asura Scans."
 	},
 	"url": [
 		"asurascans.com",
@@ -17,10 +24,11 @@
 		"asurascanstr.com",
 		"asura.nacm.xyz",
 		"asuracomics.com",
-		"asuratoon.com"
+		"asuratoon.com",
+		"asuracomic.net"
 	],
 	"regExp": "asura.*?[.].*?[/]",
-	"version": "1.2.11",
+	"version": "2.0.0",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/Asura%20Scans/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/Asura%20Scans/assets/thumbnail.png",
 	"color": "#6E3CAA",
@@ -31,5 +39,51 @@
 		"manga",
 		"manhua",
 		"manhwa"
+	],
+	"readLogs": true,
+	"settings": [
+		{
+			"id": "privacy",
+			"title": "Privacy Mode",
+			"icon": "fa-solid fa-user-secret",
+			"value": false
+		},
+		{
+			"id": "chapterNumber",
+			"title": "Display Current Chapter",
+			"icon": "fa-solid fa-book",
+			"value": true,
+			"if": {
+				"privacy": false
+			}
+		},
+		{
+			"id": "readingPercentage",
+			"title": "Display Reading %",
+			"icon": "fa-solid fa-percent",
+			"value": true,
+			"if": {
+				"privacy": false,
+				"chapterNumber": true
+			}
+		},
+		{
+			"id": "showCover",
+			"title": "Show Cover",
+			"icon": "fa-solid fa-images",
+			"value": true,
+			"if": {
+				"privacy": false
+			}
+		},
+		{
+			"id": "showButtons",
+			"title": "Show Buttons",
+			"icon": "fa-solid fa-compress-arrows-alt",
+			"value": true,
+			"if": {
+				"privacy": false
+			}
+		}
 	]
 }

--- a/websites/A/Asura Scans/presence.ts
+++ b/websites/A/Asura Scans/presence.ts
@@ -17,8 +17,7 @@ presence.on("UpdateData", async () => {
 	const { pathname, href } = window.location,
 		presenceData: PresenceData = {
 			startTimestamp: browsingTimestamp,
-			largeImageKey:
-				"https://cdn.rcd.gg/PreMiD/websites/A/Asura%20Scans/assets/logo.png",
+			largeImageKey: ASURA_SCANS_LOGO,
 			type: ActivityType.Watching,
 		},
 		[

--- a/websites/A/Asura Scans/presence.ts
+++ b/websites/A/Asura Scans/presence.ts
@@ -26,13 +26,13 @@ presence.on("UpdateData", async () => {
 			privacyMode,
 			displayChapter,
 			displayCover,
-			displayButtons
+			displayButtons,
 		] = await Promise.all([
 			presence.getSetting<boolean>("readingPercentage"),
 			presence.getSetting<boolean>("privacy"),
 			presence.getSetting<boolean>("chapterNumber"),
 			presence.getSetting<boolean>("showCover"),
-			presence.getSetting<boolean>("showButtons")
+			presence.getSetting<boolean>("showButtons"),
 		]);
 
 	if (privacyMode) {

--- a/websites/A/Asura Scans/presence.ts
+++ b/websites/A/Asura Scans/presence.ts
@@ -1,54 +1,88 @@
-const presence = new Presence({
-		clientId: "864304063804997702",
-	}),
-	browsingTimestamp = Math.floor(Date.now() / 1000);
+const presence = new Presence({ clientId: "864304063804997702" }),
+	browsingTimestamp = Math.floor(Date.now() / 1000),
+	ASURA_SCANS_LOGO =
+		"https://cdn.rcd.gg/PreMiD/websites/A/Asura%20Scans/assets/logo.png",
+	CHAPTER_PROGRESS_SELECTOR =
+		"body > div:nth-child(4) > div > div > div > div.py-8.-mx-5.md\\:mx-0.flex.flex-col.items-center.justify-center";
 
-presence.on("UpdateData", () => {
+class Comic {
+	title: string;
+	url: string;
+	image: string;
+}
+
+const comic = new Comic();
+
+presence.on("UpdateData", async () => {
 	const { pathname, href } = window.location,
 		presenceData: PresenceData = {
 			startTimestamp: browsingTimestamp,
 			largeImageKey:
 				"https://cdn.rcd.gg/PreMiD/websites/A/Asura%20Scans/assets/logo.png",
-		};
+			type: ActivityType.Watching,
+		},
+		displayPercentage = await presence.getSetting<boolean>("readingPercentage"),
+		privacyMode = await presence.getSetting<boolean>("privacy"),
+		displayChapter = await presence.getSetting<boolean>("chapterNumber"),
+		displayCover = await presence.getSetting<boolean>("showCover"),
+		displayButtons = await presence.getSetting<boolean>("showButtons");
 
-	if (/^\/(page\/\d+\/?)?$/.test(pathname))
-		presenceData.details = "Viewing Home Page";
-	else if (/^\/manga\/?$/.test(pathname))
-		presenceData.details = "Viewing Comic List";
-	else if (/^\/manga\/[0-9a-z-]+\/?$/i.test(pathname)) {
-		presenceData.details = "Viewing Comic Page";
-		presenceData.state =
-			document.querySelector<HTMLHeadingElement>(".entry-title").textContent;
-		presenceData.buttons = [
-			{
-				label: "Visit Comic Page",
-				url: href,
-			},
-		];
-	} else if (
-		/\/[a-z-\d]+(chapter|ch|bolum)[a-z-\d]*-[0-9]+\/?$/i.test(pathname)
-	) {
-		const progress =
-			(document.documentElement.scrollTop /
-				(document.querySelector<HTMLDivElement>("#readerarea").scrollHeight -
-					window.innerHeight)) *
-			100;
-		presenceData.details = "Reading Comic";
-		presenceData.state = `${
-			document.querySelector<HTMLHeadingElement>(".entry-title").textContent
-		} - ${(progress > 100 ? 100 : progress).toFixed(1)}%`;
-		presenceData.buttons = [
-			{
-				label: "Visit Comic Page",
-				url: document.querySelector<HTMLAnchorElement>(".allc > a").href,
-			},
-			{
-				label: "Visit Chapter",
-				url: href,
-			},
-		];
+	if (privacyMode) {
+		presenceData.details = "Browsing Asura Scans";
+		presence.setActivity(presenceData);
+		return;
+	}
+
+	if (onComicOrChapterPage(pathname) && isNewComic(href, comic)) {
+		comic.url = href.split("/chapter")[0];
+		comic.title = document.title
+			.split("Chapter")[0]
+			.trim()
+			.split(" - ")[0]
+			.trim();
+		if (displayCover) comic.image = await getComicImage(comic.url);
+		else comic.image = ASURA_SCANS_LOGO;
+	}
+
+	if (onChapterPage(pathname)) {
+		presenceData.details = comic.title;
+		presenceData.largeImageKey = comic.image;
+		if (displayButtons) {
+			presenceData.buttons = [
+				{
+					label: "Visit Comic Page",
+					url: comic.url,
+				},
+			];
+		}
+		if (displayChapter) {
+			presenceData.state = `Chapter ${getChapterNumber()} ${
+				displayPercentage ? `- ${getChapterProgress()}%` : ""
+			}`;
+			if (displayButtons) {
+				presenceData.buttons.push({
+					label: "Visit Chapter",
+					url: href,
+				});
+			}
+		}
+	} else if (onComicHomePage(pathname)) {
+		presenceData.details = "Viewing Comic Home Page";
+		presenceData.largeImageKey = comic.image;
+		presenceData.state = comic.title;
+		if (displayButtons) {
+			presenceData.buttons = [
+				{
+					label: "Visit Comic Page",
+					url: comic.url,
+				},
+			];
+		}
 	} else if (pathname.startsWith("/bookmark"))
 		presenceData.details = "Viewing Bookmarks";
+	else if (pathname.startsWith("/series"))
+		presenceData.details = "Viewing Comic List";
+	else if (pathname === "/") presenceData.details = "Viewing Home Page";
 	else {
 		presenceData.details = "Browsing Asura Scans";
 		presenceData.state = document.title;
@@ -57,3 +91,39 @@ presence.on("UpdateData", () => {
 	if (presenceData.details) presence.setActivity(presenceData);
 	else presence.setActivity();
 });
+
+function onComicOrChapterPage(path: string) {
+	return /\/series\/[a-z-\d]+.*$/i.test(path);
+}
+
+function onComicHomePage(path: string) {
+	return /\/series\/[a-z-\d]+$/i.test(path);
+}
+
+function onChapterPage(path: string) {
+	return /\/series\/[a-z-\d]+\/chapter\/[0-9]+$/i.test(path);
+}
+
+function isNewComic(path: string, comic: Comic) {
+	return comic.url !== path.split("/chapter")[0];
+}
+
+function getChapterNumber() {
+	return document.title.split("Chapter")[1].split("-")[0].trim();
+}
+
+function getChapterProgress() {
+	const progress =
+		(document.documentElement.scrollTop /
+			(document.querySelector(CHAPTER_PROGRESS_SELECTOR).scrollHeight -
+				window.innerHeight)) *
+		100;
+	return progress > 100 ? 100 : progress.toFixed(1);
+}
+
+async function getComicImage(comicHomePageURL: string): Promise<string> {
+	const res = await (await fetch(comicHomePageURL)).text();
+	return new DOMParser()
+		.parseFromString(res, "text/html")
+		.querySelector<HTMLMetaElement>("head > meta[property='og:image']").content;
+}

--- a/websites/A/Asura Scans/presence.ts
+++ b/websites/A/Asura Scans/presence.ts
@@ -21,11 +21,19 @@ presence.on("UpdateData", async () => {
 				"https://cdn.rcd.gg/PreMiD/websites/A/Asura%20Scans/assets/logo.png",
 			type: ActivityType.Watching,
 		},
-		displayPercentage = await presence.getSetting<boolean>("readingPercentage"),
-		privacyMode = await presence.getSetting<boolean>("privacy"),
-		displayChapter = await presence.getSetting<boolean>("chapterNumber"),
-		displayCover = await presence.getSetting<boolean>("showCover"),
-		displayButtons = await presence.getSetting<boolean>("showButtons");
+		[
+			displayPercentage,
+			privacyMode,
+			displayChapter,
+			displayCover,
+			displayButtons
+		] = await Promise.all([
+			presence.getSetting<boolean>("readingPercentage"),
+			presence.getSetting<boolean>("privacy"),
+			presence.getSetting<boolean>("chapterNumber"),
+			presence.getSetting<boolean>("showCover"),
+			presence.getSetting<boolean>("showButtons")
+		]);
 
 	if (privacyMode) {
 		presenceData.details = "Browsing Asura Scans";


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
- Added the new URL.
- Fixed regex for URL to accommodate Asura Scans' new paths.
- Added fetching for comic covers.
- Fixed the progress calculation issue.
- Fixed the issue with retrieving the comic title.
- Fixed the issue with retrieving the current chapter.
- Added settings to the presence:
  - Privacy Mode: Only displays that the user is on Asura Scans.
  - Display Current Chapter.
  - Display Reading Percentage.
  - Show Cover.
  - Show Buttons.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/user-attachments/assets/27ee4f69-d672-4017-8eff-864f40e23bb4)
![image](https://github.com/user-attachments/assets/611a27a5-1067-4a96-905d-13686f63e42a)
![image](https://github.com/user-attachments/assets/a3d4bb04-ad61-456e-8bf0-91b3a920ec8c)
![image](https://github.com/user-attachments/assets/a2fa84e9-77e2-4001-93b6-732e1514c07d)



</details>
