### PR TITLE
fix(Miruro): update timestamp calculation

### DIFF
--- a/websites/M/Miruro/metadata.json
+++ b/websites/M/Miruro/metadata.json
@@ -10,8 +10,8 @@
 		"en": "Miruro · Watch Free Anime Online · Stream Subbed & Dubbed Anime in HD"
 	},
 	"url": [
-		"miruro.tv",
-		"miruro.online"
+		"www.miruro.tv",
+		"www.miruro.online"
 	],
 	"version": "1.0.2",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/M/Miruro/assets/logo.png",

--- a/websites/M/Miruro/metadata.json
+++ b/websites/M/Miruro/metadata.json
@@ -13,7 +13,7 @@
 		"miruro.tv",
 		"miruro.online"
 	],
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/M/Miruro/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/M/Miruro/assets/thumbnail.png",
 	"color": "#e0a10a",

--- a/websites/M/Miruro/presence.ts
+++ b/websites/M/Miruro/presence.ts
@@ -52,8 +52,12 @@ presence.on("UpdateData", async () => {
 
 		if (video) {
 			if (!video.paused) {
-				[presenceData.startTimestamp, presenceData.endTimestamp] =
-					presence.getTimestampsfromMedia(video);
+				const { currentTime, duration } = video,
+					currentTimeStamp = Math.floor(Date.now() / 1000);
+				presenceData.startTimestamp =
+					currentTimeStamp - Math.floor(currentTime);
+				presenceData.endTimestamp =
+					currentTimeStamp + Math.floor(duration - currentTime);
 				presenceData.smallImageKey = Assets.Play;
 				presenceData.smallImageText = "Now Watching";
 			} else {

--- a/websites/M/Miruro/presence.ts
+++ b/websites/M/Miruro/presence.ts
@@ -52,12 +52,8 @@ presence.on("UpdateData", async () => {
 
 		if (video) {
 			if (!video.paused) {
-				const { currentTime, duration } = video,
-					currentTimeStamp = Math.floor(Date.now() / 1000);
-				presenceData.startTimestamp =
-					currentTimeStamp - Math.floor(currentTime);
-				presenceData.endTimestamp =
-					currentTimeStamp + Math.floor(duration - currentTime);
+				[presenceData.startTimestamp, presenceData.endTimestamp] =
+					presence.getTimestampsfromMedia(video);
 				presenceData.smallImageKey = Assets.Play;
 				presenceData.smallImageText = "Now Watching";
 			} else {


### PR DESCRIPTION
## Description 
Changes: Update timestamp logic to correctly set startTimestamp and endTimestamp while the video is playing. This ensures accurate display of the total video duration and current progress.
Issue: The current use of getTimestampsfromMedia causes inaccuracies in the progress bar.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![Screenshot 2024-09-30 1](https://github.com/user-attachments/assets/04218d0f-e6c7-4793-b67a-a57f1f0ee95e)
![Screenshot 2024-09-30 2](https://github.com/user-attachments/assets/37f2683b-a3c4-4196-a921-a2fe9a18801e)



</details>
