### PR TITLE
feat(Weverse): add presence 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
 		},
 		"cli": {
 			"name": "@pmd/cli",
-			"version": "1.3.4",
+			"version": "1.3.2",
 			"license": "MPL-2.0",
 			"dependencies": {
 				"@apollo/client": "^3.6.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
 		},
 		"cli": {
 			"name": "@pmd/cli",
-			"version": "1.3.2",
+			"version": "1.3.4",
 			"license": "MPL-2.0",
 			"dependencies": {
 				"@apollo/client": "^3.6.9",

--- a/websites/W/Weverse/metadata.json
+++ b/websites/W/Weverse/metadata.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.premid.app/metadata/1.10",
-	"apiVersion ": "1",
+	"apiVersion": 1,
 	"author": {
 		"id": "712745906876842025",
 		"name": "hanifhan1f"

--- a/websites/W/Weverse/metadata.json
+++ b/websites/W/Weverse/metadata.json
@@ -9,7 +9,7 @@
 		"en": "Displays the current live stream activity for a Weverse live page."
 	},
 	"url": "weverse.io",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"logo": "https://res.cloudinary.com/debvitdiw/image/upload/v1726211085/Presences/weverse.jpg",
 	"thumbnail": "https://res.cloudinary.com/debvitdiw/image/upload/v1726211170/Presences/thumbnail.png",
 	"color": "#08ccc9",

--- a/websites/W/Weverse/metadata.json
+++ b/websites/W/Weverse/metadata.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.10",
+	"author": {
+		"id": "712745906876842025",
+		"name": "hanifhan1f"
+	},
+	"service": "Weverse",
+	"description": {
+		"en": "Displays the current live stream activity for a Weverse live page."
+	},
+	"url": "weverse.io",
+	"version": "1.0.0",
+	"logo": "https://res.cloudinary.com/debvitdiw/image/upload/v1726211085/Presences/weverse.jpg",
+	"thumbnail": "https://res.cloudinary.com/debvitdiw/image/upload/v1726211170/Presences/thumbnail.png",
+	"color": "#08ccc9",
+	"category": "music",
+	"tags": [
+		"weverse",
+		"kpop",
+		"live",
+		"streaming",
+		"music"
+	]
+}

--- a/websites/W/Weverse/metadata.json
+++ b/websites/W/Weverse/metadata.json
@@ -9,7 +9,7 @@
 		"en": "Displays the current live stream activity for a Weverse live page."
 	},
 	"url": "weverse.io",
-	"version": "1.0.2",
+	"version": "1.0.4",
 	"logo": "https://res.cloudinary.com/debvitdiw/image/upload/v1726211085/Presences/weverse.jpg",
 	"thumbnail": "https://res.cloudinary.com/debvitdiw/image/upload/v1726211170/Presences/thumbnail.png",
 	"color": "#08ccc9",

--- a/websites/W/Weverse/metadata.json
+++ b/websites/W/Weverse/metadata.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.premid.app/metadata/1.10",
+	"$schema": "https://schemas.premid.app/metadata/1.11",
 	"apiVersion": 1,
 	"author": {
 		"id": "712745906876842025",

--- a/websites/W/Weverse/metadata.json
+++ b/websites/W/Weverse/metadata.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://schemas.premid.app/metadata/1.10",
+	"apiVersion ": "1",
 	"author": {
 		"id": "712745906876842025",
 		"name": "hanifhan1f"

--- a/websites/W/Weverse/metadata.json
+++ b/websites/W/Weverse/metadata.json
@@ -9,7 +9,7 @@
 		"en": "Displays the current live stream activity for a Weverse live page."
 	},
 	"url": "weverse.io",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"logo": "https://res.cloudinary.com/debvitdiw/image/upload/v1726211085/Presences/weverse.jpg",
 	"thumbnail": "https://res.cloudinary.com/debvitdiw/image/upload/v1726211170/Presences/thumbnail.png",
 	"color": "#08ccc9",

--- a/websites/W/Weverse/metadata.json
+++ b/websites/W/Weverse/metadata.json
@@ -7,7 +7,7 @@
 	},
 	"service": "Weverse",
 	"description": {
-		"en": "Displays the current live stream activity for a Weverse live page."
+		"en": "Enjoy every moment with artists on global fandom life platform Weverse."
 	},
 	"url": "weverse.io",
 	"version": "1.0.0",

--- a/websites/W/Weverse/metadata.json
+++ b/websites/W/Weverse/metadata.json
@@ -9,7 +9,7 @@
 		"en": "Displays the current live stream activity for a Weverse live page."
 	},
 	"url": "weverse.io",
-	"version": "1.0.4",
+	"version": "1.0.0",
 	"logo": "https://res.cloudinary.com/debvitdiw/image/upload/v1726211085/Presences/weverse.jpg",
 	"thumbnail": "https://res.cloudinary.com/debvitdiw/image/upload/v1726211170/Presences/thumbnail.png",
 	"color": "#08ccc9",

--- a/websites/W/Weverse/metadata.json
+++ b/websites/W/Weverse/metadata.json
@@ -11,7 +11,7 @@
 	},
 	"url": "weverse.io",
 	"version": "1.0.0",
-	"logo": "https://res.cloudinary.com/debvitdiw/image/upload/v1726211085/Presences/weverse.jpg",
+	"logo": "https://res.cloudinary.com/debvitdiw/image/upload/v1727852958/Presences/WeverseLogo.png",
 	"thumbnail": "https://res.cloudinary.com/debvitdiw/image/upload/v1726211170/Presences/thumbnail.png",
 	"color": "#08ccc9",
 	"category": "music",

--- a/websites/W/Weverse/presence.ts
+++ b/websites/W/Weverse/presence.ts
@@ -6,19 +6,19 @@ class Weverse extends Presence {
 	getArtistName(): string {
 		return (
 			document
-				.querySelector(".LiveArtistProfileView_name_item__8W66y")
+				.querySelector("[class*=LiveArtistProfileView_name_item]")
 				?.textContent?.trim() ?? "Unknown Artist"
 		);
 	}
 
 	getStreamTitle(): string {
-		const titleElement = document.querySelector("h2.TitleView_title__SSnHb");
+		const titleElement = document.querySelector("h2[class*=TitleView_title]");
 		if (titleElement) {
 			const titleTextNodes = Array.from(titleElement.childNodes).filter(
 				node =>
 					!(
 						node instanceof HTMLElement &&
-						node.matches(".LiveBadgeView_badge__o2vFt")
+						node.matches("[class*=LiveBadgeView_badge]")
 					)
 			);
 
@@ -34,42 +34,42 @@ class Weverse extends Presence {
 
 	getThumbnailUrl(): string | undefined {
 		return document.querySelector<HTMLImageElement>(
-			".ProfileThumbnailView_thumbnail_wrap__ZgeTf img"
+			"[class*=ProfileThumbnailView_thumbnail_wrap] img"
 		)?.src;
 	}
 
 	getCommunityName(): string {
 		return (
 			document
-				.querySelector(".HeaderCommunityDropdownWrapperView_name__FZXsx")
+				.querySelector("[class*=HeaderCommunityDropdownWrapperView_name]")
 				?.textContent?.trim() ?? "Unknown Community"
 		);
 	}
 
 	getCommunityImageUrl(): string | undefined {
 		return document.querySelector<HTMLImageElement>(
-			".CommunityAsideWelcomeView_thumbnail__5MVun"
+			"[class*=CommunityAsideWelcomeView_thumbnail] img"
 		)?.src;
 	}
 
 	getArtistPageName(): string {
 		return (
 			document
-				.querySelector(".HeaderCommunityDropdownWrapperView_name__FZXsx")
+				.querySelector("[class*=HeaderCommunityDropdownWrapperView_name]")
 				?.textContent?.trim() ?? "Unknown Artist"
 		);
 	}
 
 	getMomentThumbnailUrl(): string | undefined {
 		return document.querySelector<HTMLImageElement>(
-			".ProfileThumbnailView_thumbnail_wrap__ZgeTf img"
+			"a[class*=PostHeaderView_thumbnail_wrap] img"
 		)?.src;
 	}
 
 	getMomentNickname(): string {
 		return (
 			document
-				.querySelector(".PostHeaderView_nickname__6Cb7X")
+				.querySelector("[class*=PostHeaderView_nickname]")
 				?.textContent?.trim() ?? "Unknown User"
 		);
 	}
@@ -91,7 +91,7 @@ presence.on("UpdateData", async () => {
 		presenceData.state = presence.getArtistName();
 
 		const video = document.querySelector("video");
-		if (document.querySelector(".LiveBadgeView_-replay__nNx34") !== null) {
+		if (document.querySelector("[class*=LiveBadgeView_-replay]") !== null) {
 			presenceData.smallImageKey = Assets.Play;
 			presenceData.smallImageText = "Replay";
 			presenceData.buttons = [

--- a/websites/W/Weverse/presence.ts
+++ b/websites/W/Weverse/presence.ts
@@ -1,0 +1,189 @@
+class Weverse extends Presence {
+	constructor(options: PresenceOptions) {
+		super(options);
+	}
+
+	getArtistName(): string {
+		return (
+			document
+				.querySelector(".LiveArtistProfileView_name_item__8W66y")
+				?.textContent?.trim() ?? "Unknown Artist"
+		);
+	}
+
+	getStreamTitle(): string {
+		const titleElement = document.querySelector("h2.TitleView_title__SSnHb");
+		if (titleElement) {
+			const titleTextNodes = Array.from(titleElement.childNodes).filter(
+				node =>
+					!(
+						node instanceof HTMLElement &&
+						node.matches(".LiveBadgeView_badge__o2vFt")
+					)
+			);
+
+			return (
+				titleTextNodes
+					.map(node => node.textContent)
+					.join("")
+					.trim() || "Unknown Title"
+			);
+		}
+		return "Unknown Title";
+	}
+
+	getThumbnailUrl(): string | undefined {
+		return document.querySelector<HTMLImageElement>(
+			".ProfileThumbnailView_thumbnail_wrap__ZgeTf img"
+		)?.src;
+	}
+
+	getCommunityName(): string {
+		return (
+			document
+				.querySelector(".HeaderCommunityDropdownWrapperView_name__FZXsx")
+				?.textContent?.trim() ?? "Unknown Community"
+		);
+	}
+
+	getCommunityImageUrl(): string | undefined {
+		return document.querySelector<HTMLImageElement>(
+			".CommunityAsideWelcomeView_thumbnail__5MVun"
+		)?.src;
+	}
+
+	getArtistPageName(): string {
+		return (
+			document
+				.querySelector(".HeaderCommunityDropdownWrapperView_name__FZXsx")
+				?.textContent?.trim() ?? "Unknown Artist"
+		);
+	}
+
+	getMomentThumbnailUrl(): string | undefined {
+		return document.querySelector<HTMLImageElement>(
+			".ProfileThumbnailView_thumbnail_wrap__ZgeTf img"
+		)?.src;
+	}
+
+	getMomentNickname(): string {
+		return (
+			document
+				.querySelector(".PostHeaderView_nickname__6Cb7X")
+				?.textContent?.trim() ?? "Unknown User"
+		);
+	}
+}
+
+const presence = new Weverse({
+	clientId: "1284048129414402109",
+});
+
+presence.on("UpdateData", async () => {
+	const presenceData: PresenceData = {
+		largeImageKey:
+			"https://res.cloudinary.com/debvitdiw/image/upload/v1726211085/Presences/weverse.jpg",
+	};
+
+	if (document.location.pathname.includes("/live/")) {
+		const thumbnailUrl = presence.getThumbnailUrl();
+		presenceData.details = presence.getStreamTitle();
+		presenceData.state = presence.getArtistName();
+
+		const video = document.querySelector("video");
+		if (document.querySelector(".LiveBadgeView_-replay__nNx34") !== null) {
+			presenceData.smallImageKey = Assets.Play;
+			presenceData.smallImageText = "Replay";
+			presenceData.buttons = [
+				{
+					label: `Watch ${presence.getArtistName()} Replay`,
+					url: document.location.href,
+				},
+			];
+		} else if (video) {
+			if (video.paused) {
+				presenceData.smallImageKey = Assets.Play;
+				presenceData.smallImageText = "Paused";
+			} else {
+				presenceData.smallImageKey = Assets.Live;
+				presenceData.smallImageText = "Live";
+			}
+			presenceData.buttons = [
+				{
+					label: `Visit ${presence.getArtistName()} Live`,
+					url: document.location.href,
+				},
+			];
+		} else {
+			presenceData.smallImageKey = Assets.Play;
+			presenceData.smallImageText = "Playing";
+			presenceData.buttons = [
+				{
+					label: `Watch ${presence.getArtistName()} Replay`,
+					url: document.location.href,
+				},
+			];
+		}
+
+		if (thumbnailUrl) presenceData.largeImageKey = thumbnailUrl;
+	} else if (document.location.pathname === "/") {
+		presenceData.details = "Browsing Weverse";
+		presenceData.state = "On Homepage";
+	} else if (document.location.pathname.includes("/feed")) {
+		presenceData.details = "Viewing Community Feed";
+		presenceData.state = presence.getCommunityName();
+
+		const communityImageUrl = presence.getCommunityImageUrl();
+		if (communityImageUrl) presenceData.largeImageKey = communityImageUrl;
+
+		presenceData.buttons = [
+			{
+				label: `Visit ${presence.getCommunityName()} Feed`,
+				url: document.location.href,
+			},
+		];
+	} else if (document.location.pathname.includes("/artist")) {
+		presenceData.details = "Viewing Artist";
+		presenceData.state = presence.getArtistPageName();
+
+		presenceData.buttons = [
+			{
+				label: `Visit ${presence.getArtistPageName()} Artist`,
+				url: document.location.href,
+			},
+		];
+	} else if (document.location.pathname.includes("/moment")) {
+		presenceData.details = "Viewing Moment";
+		presenceData.state = presence.getMomentNickname();
+
+		const momentThumbnailUrl = presence.getMomentThumbnailUrl();
+		if (momentThumbnailUrl) presenceData.largeImageKey = momentThumbnailUrl;
+
+		presenceData.buttons = [
+			{
+				label: `Visit ${presence.getMomentNickname()} Moment`,
+				url: document.location.href,
+			},
+		];
+	} else if (document.location.pathname.includes("/media")) {
+		presenceData.details = "Viewing Media";
+		presenceData.state = presence.getCommunityName();
+
+		presenceData.buttons = [
+			{
+				label: `Visit ${presence.getCommunityName()} Media`,
+				url: document.location.href,
+			},
+		];
+	} else {
+		presenceData.details = "Browsing Weverse";
+		presenceData.buttons = [
+			{
+				label: "Go to Weverse",
+				url: "https://weverse.io",
+			},
+		];
+	}
+
+	presence.setActivity(presenceData);
+});

--- a/websites/W/Weverse/presence.ts
+++ b/websites/W/Weverse/presence.ts
@@ -82,7 +82,7 @@ const presence = new Weverse({
 presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
 		largeImageKey:
-			"https://res.cloudinary.com/debvitdiw/image/upload/v1726211085/Presences/weverse.jpg",
+			"https://res.cloudinary.com/debvitdiw/image/upload/v1727852958/Presences/WeverseLogo.png",
 	};
 
 	if (document.location.pathname.includes("/live/")) {
@@ -173,14 +173,6 @@ presence.on("UpdateData", async () => {
 			{
 				label: `Visit ${presence.getCommunityName()} Media`,
 				url: document.location.href,
-			},
-		];
-	} else {
-		presenceData.details = "Browsing Weverse";
-		presenceData.buttons = [
-			{
-				label: "Go to Weverse",
-				url: "https://weverse.io",
 			},
 		];
 	}


### PR DESCRIPTION
## Description 
Add presence for Weverse Kpop. The presence displays real-time updates about Kpop artists, including their current activities and recent posts on the platform.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
  
![Screenshot 1](https://res.cloudinary.com/debvitdiw/image/upload/v1727792206/general/hveneyc33mxktf36gwut.png)
![Screenshot 2](https://res.cloudinary.com/debvitdiw/image/upload/v1727792206/general/elidyom8emrgys9tcqoc.png)

</details>
