### PR TITLE
fix(chatgpt): fixed title not showing

### DIFF
--- a/websites/C/ChatGPT/metadata.json
+++ b/websites/C/ChatGPT/metadata.json
@@ -5,6 +5,12 @@
 		"id": "135058085386387457",
 		"name": "Extiriority"
 	},
+	"contributors": [
+		{
+			"name": "Kaktuswerk",
+			"id": "1167417152664522764"
+		}
+	],
 	"service": "ChatGPT",
 	"description": {
 		"en": "ChatGPT is a natural language processing tool driven by AI technology that allows you to have human-like conversations and much more with the chatbot. The language model can answer questions and assist you with tasks, such as composing emails, essays, and code."

--- a/websites/C/ChatGPT/presence.ts
+++ b/websites/C/ChatGPT/presence.ts
@@ -29,7 +29,7 @@ presence.on("UpdateData", async () => {
 
 	if (pathname.split("/")[1] === "c") {
 		presenceData.details = showTitle
-			? document.querySelector("li a button > svg")?.closest("li").textContent
+			? document.title
 			: "Talking with AI about something";
 		presenceData.state = isTalking
 			? "AI is responding..."

--- a/websites/C/ChatGPT/presence.ts
+++ b/websites/C/ChatGPT/presence.ts
@@ -28,9 +28,16 @@ presence.on("UpdateData", async () => {
 	}
 
 	if (pathname.split("/")[1] === "c") {
-		presenceData.details = showTitle
-			? document.title
-			: "Talking with AI about something";
+		// check if the document title is the default title. If so, get the chat title from the UI. Otherwise, get it from the document title
+		if (document.title === "ChatGPT" && showTitle) {
+			presenceData.details = document.querySelector(
+				`[href="/c/${pathname.split("/")[2]}"]`
+			)?.textContent;
+		} else {
+			presenceData.details = showTitle
+				? document.title
+				: "Talking with AI about something";
+		}
 		presenceData.state = isTalking
 			? "AI is responding..."
 			: `asked (${Number(


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
Now the chat title will be shown in the presence, if the setting is activated

![image](https://github.com/user-attachments/assets/0438a258-5c45-4285-8fa7-edfd97c0860a)

![image](https://github.com/user-attachments/assets/cdddefa4-402d-414c-ba43-a18ee229b0f2)

If deactivated, it will show this
![image](https://github.com/user-attachments/assets/96ab03b1-eebb-4a52-8c6c-9abb9aa73327)



</details>
