### PR TITLE
feat(Simkl): add presence

### DIFF
--- a/websites/S/Simkl/metadata.json
+++ b/websites/S/Simkl/metadata.json
@@ -1,0 +1,26 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.11",
+	"apiVersion": 1,
+	"author": {
+		"id": "354233941550694400",
+		"name": "kuriel."
+	},
+	"service": "Simkl",
+	"description": {
+		"en": "Your All-in-One TV, Anime and Movie Tracking Platform"
+	},
+	"url": "simkl.com",
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/1m6HokC.png",
+	"thumbnail": "https://i.imgur.com/iqtPhbD.png",
+	"color": "#fabf2c",
+	"category": "socials",
+	"tags": [
+		"movie",
+		"anime",
+		"show",
+		"tv",
+		"tracking",
+		"tracker"
+	]
+}

--- a/websites/S/Simkl/metadata.json
+++ b/websites/S/Simkl/metadata.json
@@ -7,7 +7,7 @@
 	},
 	"service": "Simkl",
 	"description": {
-		"en": "Your All-in-One TV, Anime and Movie Tracking Platform"
+		"en": "Track what you watch. Discover new shows and movies. Receive episode notifications. Get personalized recommendations. Join Simkl for free."
 	},
 	"url": "simkl.com",
 	"version": "1.0.0",

--- a/websites/S/Simkl/presence.ts
+++ b/websites/S/Simkl/presence.ts
@@ -4,7 +4,7 @@ const presence = new Presence({
 	browsingTimestamp = Math.floor(Date.now() / 1000);
 
 const enum Assets {
-Logo =  "https://i.imgur.com/1m6HokC.png",
+	Logo = "https://i.imgur.com/1m6HokC.png",
 }
 function textContent(tags: string) {
 	return document.querySelector(tags)?.textContent?.trim();
@@ -18,7 +18,7 @@ presence.on("UpdateData", async () => {
 	const { pathname, search } = document.location,
 		path = pathname.split("/"),
 		presenceData: PresenceData = {
-		largeImageKey: Assets.Logo,
+			largeImageKey: Assets.Logo,
 			startTimestamp: browsingTimestamp,
 		};
 
@@ -68,9 +68,7 @@ presence.on("UpdateData", async () => {
 						presenceData.details = `Reading a ${textContent(
 							"#global_div > div.SimklHeaderBgShaddow > div > div > div.SimklTVReviewHeaderBottom > table > tbody > tr > td > table > tbody > tr > td:nth-child(2) > table > tbody > tr:nth-child(1) > td"
 						)}`;
-						presenceData.state = textContent(
-							"span.ajLinkInside"
-						);
+						presenceData.state = textContent("span.ajLinkInside");
 						presenceData.largeImageKey = getImage(".SimklTVReviewPoster");
 					} else if (path[4]) {
 						presenceData.state = `on ${textContent(

--- a/websites/S/Simkl/presence.ts
+++ b/websites/S/Simkl/presence.ts
@@ -3,6 +3,9 @@ const presence = new Presence({
 	}),
 	browsingTimestamp = Math.floor(Date.now() / 1000);
 
+const enum Assets {
+Logo =  "https://i.imgur.com/1m6HokC.png",
+}
 function textContent(tags: string) {
 	return document.querySelector(tags)?.textContent?.trim();
 }

--- a/websites/S/Simkl/presence.ts
+++ b/websites/S/Simkl/presence.ts
@@ -1,0 +1,378 @@
+const presence = new Presence({
+		clientId: "1290874564582051855",
+	}),
+	strings = presence.getStrings({
+		play: "presence.playback.playing",
+		pause: "presence.playback.paused",
+	}),
+	browsingTimestamp = Math.floor(Date.now() / 1000);
+
+function textContent(tags: string) {
+	return document.querySelector(tags)?.textContent?.trim();
+}
+
+function getImage(tags: string) {
+	return document.querySelector<HTMLImageElement>(tags)?.src;
+}
+
+presence.on("UpdateData", async () => {
+	const { pathname, search } = document.location,
+		path = pathname.split("/"),
+		presenceData: PresenceData = {
+			startTimestamp: browsingTimestamp,
+		};
+
+	switch (path[1]) {
+		case "tv": {
+			presenceData.details = "Exploring TV Shows";
+			if (path[2]) {
+				switch (path[2]) {
+					case "calendar": {
+						presenceData.details = "Viewing TV Shows Calendar";
+						break;
+					}
+					case "discover": {
+						presenceData.details = "Discovering TV Shows";
+						break;
+					}
+					case "today": {
+						presenceData.details = "Viewing Today's TV Shows Calendar";
+						break;
+					}
+					case "movies": {
+						presenceData.details = "Viewing Animes Movies";
+						break;
+					}
+					case "best-shows": {
+						presenceData.details = "Viewing Best TV Shows";
+						break;
+					}
+					case "premieres": {
+						presenceData.details = "Viewing Premieres TV Shows";
+						break;
+					}
+				}
+				if (path[3]) {
+					presenceData.details = textContent("h1.headDetail");
+					presenceData.largeImageKey = getImage("#detailPosterImg");
+					if (path[4] && path[4].startsWith("countdown")) {
+						presenceData.details = textContent(".heading").replace(
+							"Countdown",
+							""
+						);
+						presenceData.state = textContent(".simkltvcountdownsubtitle");
+						presenceData.largeImageKey = getImage(
+							".simkltvcountdowninfoleftiage"
+						);
+					} else if (path[4] && path[4].startsWith("review")) {
+						presenceData.details = `Reading a ${textContent(
+							"#global_div > div.SimklHeaderBgShaddow > div > div > div.SimklTVReviewHeaderBottom > table > tbody > tr > td > table > tbody > tr > td:nth-child(2) > table > tbody > tr:nth-child(1) > td"
+						)}`;
+						presenceData.state = textContent(
+							"#global_div > div.SimklHeaderBgShaddow > div > div > div.SimklTVReviewHeaderBottom > table > tbody > tr > td > table > tbody > tr > td:nth-child(2) > table > tbody > tr:nth-child(2) > td"
+						);
+						presenceData.largeImageKey = getImage(".SimklTVReviewPoster");
+					} else if (path[4]) {
+						presenceData.state = `on ${textContent(
+							".SimklTVAboutTabsActive"
+						)} tab`;
+					} else if (path[5] && path[5].startsWith("episode-")) {
+						presenceData.details = textContent(
+							"td.SimklTVDetailEpisodeDescTitle > h1"
+						)
+							.replace("Watch", "")
+							.replace("Online", "");
+						presenceData.largeImageKey = getImage(".SimklTVDetailEpisodeImage");
+						delete presenceData.state;
+					}
+				}
+			}
+			break;
+		}
+		case "anime": {
+			presenceData.details = "Exploring Animes";
+			if (path[2]) {
+				switch (path[2]) {
+					case "calendar": {
+						presenceData.details = "Viewing Animes Calendar";
+						break;
+					}
+					case "discover": {
+						presenceData.details = "Discovering Animes";
+						break;
+					}
+					case "today": {
+						presenceData.details = "Viewing Today's Animes Calendar";
+						break;
+					}
+					case "movies": {
+						presenceData.details = "Viewing Animes Movies";
+						break;
+					}
+					case "best-anime": {
+						presenceData.details = "Viewing Best Animes";
+						break;
+					}
+					case "premieres": {
+						presenceData.details = "Viewing Premieres Animes";
+						break;
+					}
+				}
+				if (path[3]) {
+					presenceData.details = textContent("h1.headDetail");
+					presenceData.largeImageKey = getImage("#detailPosterImg");
+					presenceData.state = `on ${textContent(
+						".SimklTVAboutTabsActive"
+					)} tab`;
+					if (path[4] && path[4].startsWith("episode-")) {
+						presenceData.details = textContent(
+							"td.SimklTVDetailEpisodeDescTitle > h1"
+						)
+							.replace("Watch", "")
+							.replace("Online", "");
+						presenceData.largeImageKey = getImage(".SimklTVDetailEpisodeImage");
+						delete presenceData.state;
+					} else if (path[4] && path[4].startsWith("review")) {
+						presenceData.details = `Reading a ${textContent(
+							"#global_div > div.SimklHeaderBgShaddow > div > div > div.SimklTVReviewHeaderBottom > table > tbody > tr > td > table > tbody > tr > td:nth-child(2) > table > tbody > tr:nth-child(1) > td"
+						)}`;
+						presenceData.state = textContent(
+							"#global_div > div.SimklHeaderBgShaddow > div > div > div.SimklTVReviewHeaderBottom > table > tbody > tr > td > table > tbody > tr > td:nth-child(2) > table > tbody > tr:nth-child(2) > td"
+						);
+						presenceData.largeImageKey = getImage(".SimklTVReviewPoster");
+					} else if (path[4] && path[4].startsWith("countdown")) {
+						presenceData.details = textContent(".heading").replace(
+							"Countdown",
+							""
+						);
+						presenceData.state = textContent(".simkltvcountdownsubtitle");
+						presenceData.largeImageKey = getImage(
+							".simkltvcountdowninfoleftiage"
+						);
+					}
+				}
+			}
+			break;
+		}
+		case "movies": {
+			presenceData.details = "Exploring Movies";
+			if (path[2]) {
+				switch (path[2]) {
+					case "theaters": {
+						presenceData.details = "Viewing Movies In Theathers";
+						break;
+					}
+					case "discover": {
+						presenceData.details = "Discovering Movies";
+						break;
+					}
+					case "new": {
+						presenceData.details = "Viewing New Movies";
+						break;
+					}
+					case "dvd-releases": {
+						presenceData.details = "Viewing Movies DVDs Releases";
+						break;
+					}
+					case "best-movies": {
+						presenceData.details = "Viewing Best Movies";
+						break;
+					}
+				}
+				if (path[3] && path[2] !== "new") {
+					presenceData.details = textContent("h1.headDetail");
+					presenceData.largeImageKey = getImage("#detailPosterImg");
+					presenceData.state = `on ${textContent(
+						".SimklTVAboutTabsActive"
+					)} tab`;
+					if (path[4] && path[4].startsWith("review")) {
+						presenceData.details = `Reading a ${textContent(
+							"#global_div > div.SimklHeaderBgShaddow > div > div > div.SimklTVReviewHeaderBottom > table > tbody > tr > td > table > tbody > tr > td:nth-child(2) > table > tbody > tr:nth-child(1) > td"
+						)}`;
+						presenceData.state = textContent(
+							"#global_div > div.SimklHeaderBgShaddow > div > div > div.SimklTVReviewHeaderBottom > table > tbody > tr > td > table > tbody > tr > td:nth-child(2) > table > tbody > tr:nth-child(2) > td"
+						);
+						presenceData.largeImageKey = getImage(".SimklTVReviewPoster");
+					}
+				}
+			}
+			break;
+		}
+		case "lists": {
+			presenceData.details = "Discovering Lists";
+			switch (path[2]) {
+				case "random": {
+					presenceData.details = "Viewing Random Lists";
+					break;
+				}
+				case "official": {
+					presenceData.details = "Viewing Official Lists";
+					break;
+				}
+				case "discover": {
+					presenceData.details = "Discovering new Lists";
+					break;
+				}
+				case "tags": {
+					presenceData.details = "Viewing tags of Lists";
+					break;
+				}
+				case "most-followed": {
+					presenceData.details = "Viewing Most Followed Lists";
+					break;
+				}
+				case "most-liked": {
+					presenceData.details = "Viewing Most Liked Lists";
+					break;
+				}
+			}
+			break;
+		}
+		case "apps": {
+			presenceData.details = "On Apps Page";
+			break;
+		}
+		case "vip": {
+			presenceData.details = "On VIP's Page";
+			break;
+		}
+		case "search": {
+			presenceData.details = "Searching for";
+			presenceData.state = decodeURIComponent(search.split("=")[2]);
+			break;
+		}
+		case "settings": {
+			presenceData.details = "Managing profile settings";
+			break;
+		}
+		default: {
+			if (path[2]) {
+				switch (path[2]) {
+					case "dashboard": {
+						presenceData.details = `On ${textContent(
+							".simklprofileheadcontentnametext"
+						)}'s profile`;
+						presenceData.largeImageKey = getImage(
+							".simklprofileheadcontentavatarimg"
+						);
+						break;
+					}
+					case "tv": {
+						presenceData.details = "Viewing TV Shows List";
+						presenceData.state = `On ${textContent(
+							".simklprofileheadcontentnametext"
+						)}'s profile`;
+						presenceData.largeImageKey = getImage(
+							".simklprofileheadcontentavatarimg"
+						);
+						break;
+					}
+					case "anime": {
+						presenceData.details = "Viewing Animes List";
+						presenceData.state = `On ${textContent(
+							".simklprofileheadcontentnametext"
+						)}'s profile`;
+						presenceData.largeImageKey = getImage(
+							".simklprofileheadcontentavatarimg"
+						);
+						break;
+					}
+					case "movies": {
+						presenceData.details = "Viewing Movies List";
+						presenceData.state = `On ${textContent(
+							".simklprofileheadcontentnametext"
+						)}'s profile`;
+						presenceData.largeImageKey = getImage(
+							".simklprofileheadcontentavatarimg"
+						);
+						break;
+					}
+					case "recommendations": {
+						presenceData.details = "Viewing recommendations page";
+						presenceData.state = `On ${textContent(
+							".simklprofileheadcontentnametext"
+						)}'s profile`;
+						presenceData.largeImageKey = getImage(
+							".simklprofileheadcontentavatarimg"
+						);
+						break;
+					}
+					case "lists": {
+						presenceData.details = "Viewing lists page";
+						presenceData.state = `On ${textContent(
+							".simklprofileheadcontentnametext"
+						)}'s profile`;
+						presenceData.largeImageKey = getImage(
+							".simklprofileheadcontentavatarimg"
+						);
+						break;
+					}
+					case "tags": {
+						presenceData.details = "Viewing tags page";
+						presenceData.state = `On ${textContent(
+							".simklprofileheadcontentnametext"
+						)}'s profile`;
+						presenceData.largeImageKey = getImage(
+							".simklprofileheadcontentavatarimg"
+						);
+						break;
+					}
+					case "reviews": {
+						presenceData.details = "Viewing reviews page";
+						presenceData.state = `On ${textContent(
+							".simklprofileheadcontentnametext"
+						)}'s profile`;
+						presenceData.largeImageKey = getImage(
+							".simklprofileheadcontentavatarimg"
+						);
+						break;
+					}
+					case "stats": {
+						presenceData.details = "Viewing stats page";
+						presenceData.state = `On ${textContent(
+							".simklprofileheadcontentnametext"
+						)}'s profile`;
+						presenceData.largeImageKey = getImage(
+							".simklprofileheadcontentavatarimg"
+						);
+						break;
+					}
+					case "following": {
+						presenceData.details = "Viewing following";
+						presenceData.state = `Of ${textContent(
+							".simklprofileheadcontentnametext"
+						)}'s profile`;
+						presenceData.largeImageKey = getImage(
+							".simklprofileheadcontentavatarimg"
+						);
+						break;
+					}
+					case "followers": {
+						presenceData.details = "Viewing followers";
+						presenceData.state = `Of ${textContent(
+							".simklprofileheadcontentnametext"
+						)}'s profile`;
+						presenceData.largeImageKey = getImage(
+							".simklprofileheadcontentavatarimg"
+						);
+						break;
+					}
+					case "friends": {
+						presenceData.details = "On Friends Page";
+						break;
+					}
+					case "list": {
+						presenceData.details = "On List:";
+						presenceData.state = textContent(
+							"#global_div > list-wrap > list > list-bottom > list-bottom-left > list-bottom-left-content > list-bottom-left-content-left > list-bottom-left-content-left-title > h1"
+						);
+						break;
+					}
+				}
+			} else presenceData.details = "Exploring the website";
+			break;
+		}
+	}
+
+	presence.setActivity(presenceData);
+});

--- a/websites/S/Simkl/presence.ts
+++ b/websites/S/Simkl/presence.ts
@@ -18,6 +18,7 @@ presence.on("UpdateData", async () => {
 	const { pathname, search } = document.location,
 		path = pathname.split("/"),
 		presenceData: PresenceData = {
+		largeImageKey: Assets.Logo,
 			startTimestamp: browsingTimestamp,
 		};
 

--- a/websites/S/Simkl/presence.ts
+++ b/websites/S/Simkl/presence.ts
@@ -1,10 +1,6 @@
 const presence = new Presence({
 		clientId: "1290874564582051855",
 	}),
-	strings = presence.getStrings({
-		play: "presence.playback.playing",
-		pause: "presence.playback.paused",
-	}),
 	browsingTimestamp = Math.floor(Date.now() / 1000);
 
 function textContent(tags: string) {

--- a/websites/S/Simkl/presence.ts
+++ b/websites/S/Simkl/presence.ts
@@ -133,7 +133,9 @@ presence.on("UpdateData", async () => {
 						presenceData.largeImageKey = getImage(".SimklTVDetailEpisodeImage");
 						delete presenceData.state;
 					} else if (path[4] && path[4].startsWith("review")) {
-						presenceData.details = `Reading a review of ${textContent("span.ajLinkInside")}`;
+						presenceData.details = `Reading a review of ${textContent(
+							"span.ajLinkInside"
+						)}`;
 						presenceData.state = textContent(
 							".SimklTVReviewHeaderBottom > table > tbody > tr > td > table > tbody > tr > td:nth-child(2) > table > tbody > tr:nth-child(2) > td"
 						);

--- a/websites/S/Simkl/presence.ts
+++ b/websites/S/Simkl/presence.ts
@@ -11,7 +11,7 @@ function textContent(tags: string) {
 }
 
 function getImage(tags: string) {
-	return document.querySelector<HTMLImageElement>(tags)?.src;
+	return document.querySelector<HTMLImageElement>(tags)?.src ?? Assets.Logo;
 }
 
 presence.on("UpdateData", async () => {

--- a/websites/S/Simkl/presence.ts
+++ b/websites/S/Simkl/presence.ts
@@ -65,10 +65,12 @@ presence.on("UpdateData", async () => {
 							".simkltvcountdowninfoleftiage"
 						);
 					} else if (path[4] && path[4].startsWith("review")) {
-						presenceData.details = `Reading a ${textContent(
-							"#global_div > div.SimklHeaderBgShaddow > div > div > div.SimklTVReviewHeaderBottom > table > tbody > tr > td > table > tbody > tr > td:nth-child(2) > table > tbody > tr:nth-child(1) > td"
+						presenceData.details = `Reading a review of ${textContent(
+							"span.ajLinkInside"
 						)}`;
-						presenceData.state = textContent("span.ajLinkInside");
+						presenceData.state = textContent(
+							".SimklTVReviewHeaderBottom > table > tbody > tr > td > table > tbody > tr > td:nth-child(2) > table > tbody > tr:nth-child(2) > td"
+						);
 						presenceData.largeImageKey = getImage(".SimklTVReviewPoster");
 					} else if (path[4]) {
 						presenceData.state = `on ${textContent(
@@ -131,11 +133,9 @@ presence.on("UpdateData", async () => {
 						presenceData.largeImageKey = getImage(".SimklTVDetailEpisodeImage");
 						delete presenceData.state;
 					} else if (path[4] && path[4].startsWith("review")) {
-						presenceData.details = `Reading a ${textContent(
-							"#global_div > div.SimklHeaderBgShaddow > div > div > div.SimklTVReviewHeaderBottom > table > tbody > tr > td > table > tbody > tr > td:nth-child(2) > table > tbody > tr:nth-child(1) > td"
-						)}`;
+						presenceData.details = `Reading a review of ${textContent("span.ajLinkInside")}`;
 						presenceData.state = textContent(
-							"#global_div > div.SimklHeaderBgShaddow > div > div > div.SimklTVReviewHeaderBottom > table > tbody > tr > td > table > tbody > tr > td:nth-child(2) > table > tbody > tr:nth-child(2) > td"
+							".SimklTVReviewHeaderBottom > table > tbody > tr > td > table > tbody > tr > td:nth-child(2) > table > tbody > tr:nth-child(2) > td"
 						);
 						presenceData.largeImageKey = getImage(".SimklTVReviewPoster");
 					} else if (path[4] && path[4].startsWith("countdown")) {
@@ -184,11 +184,11 @@ presence.on("UpdateData", async () => {
 						".SimklTVAboutTabsActive"
 					)} tab`;
 					if (path[4] && path[4].startsWith("review")) {
-						presenceData.details = `Reading a ${textContent(
-							"#global_div > div.SimklHeaderBgShaddow > div > div > div.SimklTVReviewHeaderBottom > table > tbody > tr > td > table > tbody > tr > td:nth-child(2) > table > tbody > tr:nth-child(1) > td"
+						presenceData.details = `Reading a review of ${textContent(
+							"span.ajLinkInside"
 						)}`;
 						presenceData.state = textContent(
-							"#global_div > div.SimklHeaderBgShaddow > div > div > div.SimklTVReviewHeaderBottom > table > tbody > tr > td > table > tbody > tr > td:nth-child(2) > table > tbody > tr:nth-child(2) > td"
+							".SimklTVReviewHeaderBottom > table > tbody > tr > td > table > tbody > tr > td:nth-child(2) > table > tbody > tr:nth-child(2) > td"
 						);
 						presenceData.largeImageKey = getImage(".SimklTVReviewPoster");
 					}
@@ -362,7 +362,7 @@ presence.on("UpdateData", async () => {
 					case "list": {
 						presenceData.details = "On List:";
 						presenceData.state = textContent(
-							"#global_div > list-wrap > list > list-bottom > list-bottom-left > list-bottom-left-content > list-bottom-left-content-left > list-bottom-left-content-left-title > h1"
+							"list-bottom-left-content-left-title > h1"
 						);
 						break;
 					}

--- a/websites/S/Simkl/presence.ts
+++ b/websites/S/Simkl/presence.ts
@@ -69,7 +69,7 @@ presence.on("UpdateData", async () => {
 							"#global_div > div.SimklHeaderBgShaddow > div > div > div.SimklTVReviewHeaderBottom > table > tbody > tr > td > table > tbody > tr > td:nth-child(2) > table > tbody > tr:nth-child(1) > td"
 						)}`;
 						presenceData.state = textContent(
-							"#global_div > div.SimklHeaderBgShaddow > div > div > div.SimklTVReviewHeaderBottom > table > tbody > tr > td > table > tbody > tr > td:nth-child(2) > table > tbody > tr:nth-child(2) > td"
+							"span.ajLinkInside"
 						);
 						presenceData.largeImageKey = getImage(".SimklTVReviewPoster");
 					} else if (path[4]) {


### PR DESCRIPTION
## Description 
Add presence for Simkl. The presence shows what movies, lists, profiles, anime, and TV shows users are currently viewing and searching for information about.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://github.com/user-attachments/assets/b95ad637-5aec-4794-8518-16ee166b74b5)
![image](https://github.com/user-attachments/assets/acd4150b-14c8-4155-a1cd-885179f67ae1)
![image](https://github.com/user-attachments/assets/5b8a295a-79d4-4bbe-96df-9f4095a0fc1e)
![image](https://github.com/user-attachments/assets/fe28fc07-26d7-4906-a292-a13332ca392a)
![image](https://github.com/user-attachments/assets/a48c8e7f-b866-4207-ad44-8be5b769d62b)
![image](https://github.com/user-attachments/assets/7a9db847-27db-48d0-824f-cb9e29531475)


</details>
