### PR TITLE
feat(Brave Search): add presence

### DIFF
--- a/websites/B/Brave Search/metadata.json
+++ b/websites/B/Brave Search/metadata.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.11",
+	"apiVersion": 1,
+	"author": {
+		"id": "354233941550694400",
+		"name": "kuriel."
+	},
+	"service": "Brave Search",
+	"description": {
+		"en": "The smarter way to search."
+	},
+	"url": "search.brave.com",
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/Oxx2bFw.png",
+	"thumbnail": "https://i.imgur.com/FdxJFrz.png",
+	"color": "#FB542B",
+	"category": "other",
+	"tags": [
+		"search"
+	]
+}

--- a/websites/B/Brave Search/metadata.json
+++ b/websites/B/Brave Search/metadata.json
@@ -17,5 +17,13 @@
 	"category": "other",
 	"tags": [
 		"search"
+	],
+	"settings": [
+		{
+			"id": "privacy",
+			"title": "Privacy Mode",
+			"icon": "fad fa-user-secret",
+			"value": false
+		}
 	]
 }

--- a/websites/B/Brave Search/metadata.json
+++ b/websites/B/Brave Search/metadata.json
@@ -7,7 +7,7 @@
 	},
 	"service": "Brave Search",
 	"description": {
-		"en": "The smarter way to search."
+		"en": "Search the Web. Privately. Truly useful results, AI-powered answers, & more. All from an independent index. No profiling, no bias, no Big Tech."
 	},
 	"url": "search.brave.com",
 	"version": "1.0.0",

--- a/websites/B/Brave Search/presence.ts
+++ b/websites/B/Brave Search/presence.ts
@@ -15,7 +15,7 @@ presence.on("UpdateData", async () => {
 			startTimestamp: browsingTimestamp,
 			details: "In Home",
 			state: privacy
-				? ""
+				? undefined
 				: document.querySelector<HTMLInputElement>("#searchbox")?.value,
 		};
 

--- a/websites/B/Brave Search/presence.ts
+++ b/websites/B/Brave Search/presence.ts
@@ -15,7 +15,8 @@ presence.on("UpdateData", async () => {
 			startTimestamp: browsingTimestamp,
 			details: "In Home",
 			state: privacy
-				? undefined
+				? // eslint-disable-next-line no-undefined
+				  undefined
 				: document.querySelector<HTMLInputElement>("#searchbox")?.value,
 		};
 

--- a/websites/B/Brave Search/presence.ts
+++ b/websites/B/Brave Search/presence.ts
@@ -9,11 +9,14 @@ const enum Assets {
 
 presence.on("UpdateData", async () => {
 	const { pathname } = document.location,
+		privacy = await presence.getSetting("privacy"),
 		presenceData: PresenceData = {
 			largeImageKey: Assets.Logo,
 			startTimestamp: browsingTimestamp,
 			details: "In Home",
-			state: document.querySelector<HTMLInputElement>("#searchbox")?.value,
+			state: privacy
+				? ""
+				: document.querySelector<HTMLInputElement>("#searchbox")?.value,
 		};
 
 	switch (pathname.split("/")[1]) {
@@ -23,30 +26,32 @@ presence.on("UpdateData", async () => {
 			break;
 		}
 		case "help": {
-			presenceData.details = "Viewing Help Page:";
-			presenceData.state = document
-				.querySelector(".post-title")
-				?.textContent?.trim();
+			if (!privacy) {
+				presenceData.details = "Viewing Help Page:";
+				presenceData.state = document
+					.querySelector(".post-title")
+					?.textContent?.trim();
+			} else presenceData.details = "Viewing Help Pages";
 			break;
 		}
 		case "search": {
-			presenceData.details = "Searching:";
+			presenceData.details = `Searching${!privacy ? ":" : "..."}`;
 			break;
 		}
 		case "images": {
-			presenceData.details = "Searching images:";
+			presenceData.details = `Searching images${!privacy ? ":" : "..."}`;
 			break;
 		}
 		case "news": {
-			presenceData.details = "Searching news:";
+			presenceData.details = `Searching news${!privacy ? ":" : "..."}`;
 			break;
 		}
 		case "videos": {
-			presenceData.details = "Searching videos:";
+			presenceData.details = `Searching videos${!privacy ? ":" : "..."}`;
 			break;
 		}
 		case "goggles": {
-			presenceData.details = "Searching goggles:";
+			presenceData.details = `Searching goggles${!privacy ? ":" : "..."}`;
 			break;
 		}
 		default: {

--- a/websites/B/Brave Search/presence.ts
+++ b/websites/B/Brave Search/presence.ts
@@ -1,0 +1,59 @@
+const presence = new Presence({
+		clientId: "1293341957141303307",
+	}),
+	browsingTimestamp = Math.floor(Date.now() / 1000);
+
+const enum Assets {
+	Logo = "https://i.imgur.com/Oxx2bFw.png",
+}
+
+presence.on("UpdateData", async () => {
+	const { pathname } = document.location,
+		presenceData: PresenceData = {
+			largeImageKey: Assets.Logo,
+			startTimestamp: browsingTimestamp,
+			details: "In Home",
+			state: document.querySelector<HTMLInputElement>("#searchbox")?.value,
+		};
+
+	switch (pathname.split("/")[1]) {
+		case "settings": {
+			presenceData.details = "Viewing Settings";
+			delete presenceData.state;
+			break;
+		}
+		case "help": {
+			presenceData.details = "Viewing Help Page:";
+			presenceData.state = document
+				.querySelector(".post-title")
+				?.textContent?.trim();
+			break;
+		}
+		case "search": {
+			presenceData.details = "Searching:";
+			break;
+		}
+		case "images": {
+			presenceData.details = "Searching images:";
+			break;
+		}
+		case "news": {
+			presenceData.details = "Searching news:";
+			break;
+		}
+		case "videos": {
+			presenceData.details = "Searching videos:";
+			break;
+		}
+		case "goggles": {
+			presenceData.details = "Searching goggles:";
+			break;
+		}
+		default: {
+			delete presenceData.state;
+			break;
+		}
+	}
+
+	presence.setActivity(presenceData);
+});


### PR DESCRIPTION
## Description 
Add presence for Brave Search. The presence shows what the user is searching on index, news, images, videos, or goggles and the help pages or settings. Solves #8437 

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![Discord_2vij8dR4nG](https://github.com/user-attachments/assets/b1be79b8-5efc-4846-b8b1-cf9711dfda72)

![Discord_blKjWDFpA8](https://github.com/user-attachments/assets/bdf65d04-1832-4793-b3e1-b0aaba5f090f)

![Discord_TGQ9oRehCk](https://github.com/user-attachments/assets/481cc0a9-768a-43b5-af1a-ba7c8a3d4737)

![Discord_TyvTKGAzAX](https://github.com/user-attachments/assets/ea8c006b-13fe-43bc-95d4-9ce9f91f8854)




</details>
