### PR TITLE
feat(Amazon Kindle): more URLs supported

### DIFF
--- a/websites/A/Amazon Kindle/metadata.json
+++ b/websites/A/Amazon Kindle/metadata.json
@@ -9,11 +9,9 @@
 	"description": {
 		"en": "Access and read millions of titles instantly and comfortably on your phone, tablet, or computer."
 	},
-	"url": [
-		"lesen.amazon.de",
-		"read.amazon.com"
-	],
-	"version": "1.0.7",
+	"url": "read.amazon.com",
+	"regExp": "(lire|read|leggi|leer|lesen|ler|lezen).amazon.[a-z]{2,3}([.][a-z]{2,3})?",
+	"version": "1.0.8",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/Amazon%20Kindle/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/Amazon%20Kindle/assets/thumbnail.jpg",
 	"color": "#FDEE00",


### PR DESCRIPTION
## Description 
Support for all (or almost all) Amazon Kindle URLs
Resolves #8755 
close #8825 (Add with this PR)

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

On [https://read.amazon.in/](https://read.amazon.in/) :
![image](https://github.com/user-attachments/assets/9c51edbb-27a8-4d00-b306-31055dfdcbc7)

On [https://lire.amazon.fr/](https://lire.amazon.fr/)
![image](https://github.com/user-attachments/assets/d1ef12a6-4c92-4a61-8c94-55ea595e9577)




</details>
