### PR TITLE
fix(YTPLR): fix iframe has already been declared

### DIFF
--- a/websites/Y/YTPLR/iframe.ts
+++ b/websites/Y/YTPLR/iframe.ts
@@ -1,10 +1,10 @@
-const iframe = new iFrame();
-iframe.on("UpdateData", async () => {
+const ytplr_iframe = new iFrame();
+ytplr_iframe.on("UpdateData", async () => {
 	const videoElement: HTMLVideoElement =
 		document.querySelector(".video-stream");
 	if (!videoElement) return;
 
-	iframe.send({
+	ytplr_iframe.send({
 		title: document.querySelector<HTMLAnchorElement>("div.ytp-title-text > a")
 			.textContent,
 		duration: videoElement.duration,

--- a/websites/Y/YTPLR/iframe.ts
+++ b/websites/Y/YTPLR/iframe.ts
@@ -1,10 +1,10 @@
-const ytplr_iframe = new iFrame();
-ytplr_iframe.on("UpdateData", async () => {
+const ytplrIframe = new iFrame();
+ytplrIframe.on("UpdateData", async () => {
 	const videoElement: HTMLVideoElement =
 		document.querySelector(".video-stream");
 	if (!videoElement) return;
 
-	ytplr_iframe.send({
+	ytplrIframe.send({
 		title: document.querySelector<HTMLAnchorElement>("div.ytp-title-text > a")
 			.textContent,
 		duration: videoElement.duration,

--- a/websites/Y/YTPLR/metadata.json
+++ b/websites/Y/YTPLR/metadata.json
@@ -13,7 +13,7 @@
 		"en": "Shuffles a YouTube Playlist in random order"
 	},
 	"url": "youtube-playlist-randomizer.bitbucket.io",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YTPLR/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YTPLR/assets/thumbnail.png",
 	"color": "#ff6d70",


### PR DESCRIPTION
## Description 
This PR fixes an Error only present on PreMiD 2.6.12 (and likely older Versions?) that is not present on either Alpha or Beta Versions of PreMiD 2.7.x

Said Error being `Uncaught SyntaxError: Identifier 'iframe' has already been declared (at iframe.js:1:1)`

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Error Screenshot </summary>

![image](https://github.com/user-attachments/assets/dfa4c83f-6533-4576-8c4c-eafe1d8f8177)

</details>
