### PR TITLE
fix(Prime Video): fix durations

### DIFF
--- a/websites/P/Prime Video/metadata.json
+++ b/websites/P/Prime Video/metadata.json
@@ -20,7 +20,7 @@
 	},
 	"url": "www.primevideo.com",
 	"regExp": "(([a-z0-9-]+[.])*amazon([.][a-z]+)+([/](-[/]([a-z0-9]+)[/])?(Prime-Video|Prime-Instant-Video|Amazon-Video|gp[/]video)?)?)|([a-z0-9-]+[.])*primevideo([.][a-z]+)+([/]?)?",
-	"version": "2.1.28",
+	"version": "2.1.29",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/P/Prime%20Video/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/P/Prime%20Video/assets/thumbnail.jpg",
 	"color": "#FFFFFF",

--- a/websites/P/Prime Video/presence.ts
+++ b/websites/P/Prime Video/presence.ts
@@ -49,7 +49,7 @@ presence.on("UpdateData", async () => {
 			)
 				presenceData.state = subtitle.textContent;
 
-			if (video.paused || document.querySelector("button[aria-label=Play]")) {
+			if (video.paused) {
 				presenceData.smallImageKey = Assets.Pause;
 				presenceData.smallImageText = (await strings).paused;
 				delete presenceData.startTimestamp;
@@ -72,11 +72,10 @@ presence.on("UpdateData", async () => {
 			}
 		} else if (video && !video.className.includes("tst")) {
 			if (title2 !== "") presenceData.details = title2;
-			if (video.paused || document.querySelector("button[aria-label=Play]")) {
+			if (video.paused) {
 				presenceData.smallImageKey = Assets.Pause;
 				presenceData.smallImageText = (await strings).paused;
 				delete presenceData.startTimestamp;
-				delete presenceData.endTimestamp;
 			} else {
 				const [unformattedCurrentTime, unformattedDuration] = document
 						.querySelector(".atvwebplayersdk-timeindicator-text")

--- a/websites/P/Prime Video/presence.ts
+++ b/websites/P/Prime Video/presence.ts
@@ -55,18 +55,15 @@ presence.on("UpdateData", async () => {
 				delete presenceData.startTimestamp;
 			} else {
 				const [unformattedCurrentTime, unformattedDuration] = document
-						.querySelector(".atvwebplayersdk-timeindicator-text")
-						.textContent.trim()
-						.split(" / "),
-					[startTimestamp, endTimestamp] = presence.getTimestamps(
-						timeToSeconds(unformattedCurrentTime),
-						timeToSeconds(unformattedDuration) +
-							timeToSeconds(unformattedCurrentTime)
+					.querySelector(".atvwebplayersdk-timeindicator-text")
+					.textContent.trim()
+					.split(" / ");
+				[presenceData.startTimestamp, presenceData.endTimestamp] =
+					presence.getTimestamps(
+						presence.timestampFromFormat(unformattedCurrentTime),
+						presence.timestampFromFormat(unformattedDuration) +
+							presence.timestampFromFormat(unformattedCurrentTime)
 					);
-				[presenceData.startTimestamp, presenceData.endTimestamp] = [
-					startTimestamp,
-					endTimestamp,
-				];
 				presenceData.smallImageKey = Assets.Play;
 				presenceData.smallImageText = (await strings).playing;
 			}
@@ -78,18 +75,15 @@ presence.on("UpdateData", async () => {
 				delete presenceData.startTimestamp;
 			} else {
 				const [unformattedCurrentTime, unformattedDuration] = document
-						.querySelector(".atvwebplayersdk-timeindicator-text")
-						.textContent.trim()
-						.split(" / "),
-					[startTimestamp, endTimestamp] = presence.getTimestamps(
-						timeToSeconds(unformattedCurrentTime),
-						timeToSeconds(unformattedDuration) +
-							timeToSeconds(unformattedCurrentTime)
+					.querySelector(".atvwebplayersdk-timeindicator-text")
+					.textContent.trim()
+					.split(" / ");
+				[presenceData.startTimestamp, presenceData.endTimestamp] =
+					presence.getTimestamps(
+						presence.timestampFromFormat(unformattedCurrentTime),
+						presence.timestampFromFormat(unformattedDuration) +
+							presence.timestampFromFormat(unformattedCurrentTime)
 					);
-				[presenceData.startTimestamp, presenceData.endTimestamp] = [
-					startTimestamp,
-					endTimestamp,
-				];
 				presenceData.smallImageKey = Assets.Play;
 				presenceData.smallImageText = (await strings).playing;
 			}
@@ -123,11 +117,3 @@ presence.on("UpdateData", async () => {
 	if (presenceData.details) presence.setActivity(presenceData);
 	else presence.setActivity();
 });
-function timeToSeconds(timeStr: string) {
-	const timeParts = timeStr.split(":").map(Number).reverse();
-	let seconds = 0;
-	if (timeParts.length >= 1) seconds += timeParts[0];
-	if (timeParts.length >= 2) seconds += timeParts[1] * 60;
-	if (timeParts.length === 3) seconds += timeParts[2] * 3600;
-	return seconds;
-}

--- a/websites/P/Prime Video/presence.ts
+++ b/websites/P/Prime Video/presence.ts
@@ -49,15 +49,20 @@ presence.on("UpdateData", async () => {
 			)
 				presenceData.state = subtitle.textContent;
 
-			if (video.paused) {
+			if (video.paused || document.querySelector("button[aria-label=Play]")) {
 				presenceData.smallImageKey = Assets.Pause;
 				presenceData.smallImageText = (await strings).paused;
 				delete presenceData.startTimestamp;
 			} else {
-				const [startTimestamp, endTimestamp] = presence.getTimestamps(
-					video.currentTime,
-					video.duration
-				);
+				const [unformattedCurrentTime, unformattedDuration] = document
+						.querySelector(".atvwebplayersdk-timeindicator-text")
+						.textContent.trim()
+						.split(" / "),
+					[startTimestamp, endTimestamp] = presence.getTimestamps(
+						timeToSeconds(unformattedCurrentTime),
+						timeToSeconds(unformattedDuration) +
+							timeToSeconds(unformattedCurrentTime)
+					);
 				[presenceData.startTimestamp, presenceData.endTimestamp] = [
 					startTimestamp,
 					endTimestamp,
@@ -67,15 +72,21 @@ presence.on("UpdateData", async () => {
 			}
 		} else if (video && !video.className.includes("tst")) {
 			if (title2 !== "") presenceData.details = title2;
-			if (video.paused) {
+			if (video.paused || document.querySelector("button[aria-label=Play]")) {
 				presenceData.smallImageKey = Assets.Pause;
 				presenceData.smallImageText = (await strings).paused;
 				delete presenceData.startTimestamp;
+				delete presenceData.endTimestamp;
 			} else {
-				const [startTimestamp, endTimestamp] = presence.getTimestamps(
-					video.currentTime,
-					video.duration
-				);
+				const [unformattedCurrentTime, unformattedDuration] = document
+						.querySelector(".atvwebplayersdk-timeindicator-text")
+						.textContent.trim()
+						.split(" / "),
+					[startTimestamp, endTimestamp] = presence.getTimestamps(
+						timeToSeconds(unformattedCurrentTime),
+						timeToSeconds(unformattedDuration) +
+							timeToSeconds(unformattedCurrentTime)
+					);
 				[presenceData.startTimestamp, presenceData.endTimestamp] = [
 					startTimestamp,
 					endTimestamp,
@@ -113,3 +124,11 @@ presence.on("UpdateData", async () => {
 	if (presenceData.details) presence.setActivity(presenceData);
 	else presence.setActivity();
 });
+function timeToSeconds(timeStr: string) {
+	const timeParts = timeStr.split(":").map(Number).reverse();
+	let seconds = 0;
+	if (timeParts.length >= 1) seconds += timeParts[0];
+	if (timeParts.length >= 2) seconds += timeParts[1] * 60;
+	if (timeParts.length === 3) seconds += timeParts[2] * 3600;
+	return seconds;
+}


### PR DESCRIPTION
## Description 
I noticed that the currentTime and duration of what I was watching in Prime Video was actually of a short segment, and not of the full video itself. I fixed that by getting the current time and duration from the html.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img src="https://github.com/user-attachments/assets/40251987-4e25-435a-b47e-939ef9340f58" />
</details>
