### PR TITLE
fix(Youtube Music): remove old if check for showBrowsing

### DIFF
--- a/websites/Y/YouTube Music/metadata.json
+++ b/websites/Y/YouTube Music/metadata.json
@@ -20,7 +20,7 @@
 		"vi_VN": "Một dịch vụ phát nhạc với các album, đĩa đơn, video, bản remix, và các tiết mục trực tiếp chính thức và hơn nữa cho Android, iOS và máy tính. Tất cả đều tại đây."
 	},
 	"url": "music.youtube.com",
-	"version": "3.0.22",
+	"version": "3.0.23",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/thumbnail.png",
 	"color": "#E40813",

--- a/websites/Y/YouTube Music/presence.ts
+++ b/websites/Y/YouTube Music/presence.ts
@@ -273,8 +273,6 @@ presence.on("UpdateData", async () => {
 		}
 	}
 
-	if (!showBrowsing) return presence.clearActivity();
-
 	presenceData.type = ActivityType.Listening;
 	presence.setActivity(presenceData);
 });


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Resolves #8838
fix(Youtube Music): remove old if check for showBrowsing to preven it from erasing presenceData when showbrowsing is off and you aren listening to a song.
## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img src="https://github.com/user-attachments/assets/7bc50d7b-0c6a-41cf-852c-382735986a7f">



</details>
