### PR TITLE
feat(BeatLeader): add watching & ReBeat images

### DIFF
--- a/websites/B/BeatLeader/assets.ts
+++ b/websites/B/BeatLeader/assets.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 export const leaderboardImages: Record<string, string> = {
 	"360DegreeEasy":
 		"https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/1.png",
@@ -185,15 +186,54 @@ export const leaderboardImages: Record<string, string> = {
 		"https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/129.png",
 	Generated90Degree:
 		"https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/130.png",
-	ReBeatEasy: "https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/131.png",
-	ReBeatExpert:
+	ReBeat_StandardEasy:
+		"https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/131.png",
+	ReBeat_StandardExpert:
 		"https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/132.png",
-	ReBeatExpertPlus:
+	ReBeat_StandardExpertPlus:
 		"https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/133.png",
-	ReBeatHard: "https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/134.png",
-	ReBeatNormal:
+	ReBeat_StandardHard:
+		"https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/134.png",
+	ReBeat_StandardNormal:
 		"https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/135.png",
-	ReBeat: "https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/136.png",
+	ReBeat_Standard:
+		"https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/136.png",
+	ReBeat_OneSaberEasy: "https://i.imgur.com/5Ao6Xqq.png",
+	ReBeat_OneSaberExpert: "https://i.imgur.com/laT9Byr.png",
+	ReBeat_OneSaberExpertPlus: "https://i.imgur.com/88ISudR.png",
+	ReBeat_OneSaberHard: "https://i.imgur.com/SUg4WDo.png",
+	ReBeat_OneSaberNormal: "https://i.imgur.com/8fEe1vq.png",
+	ReBeat_OneSaber: "https://i.imgur.com/FLTtn7z.png",
+	ReBeat_90DegreeEasy: "https://i.imgur.com/HSYa4m5.png",
+	ReBeat_90DegreeExpert: "https://i.imgur.com/ErLBlF2.png",
+	ReBeat_90DegreeExpertPlus: "https://i.imgur.com/mlBeHct.png",
+	ReBeat_90DegreeHard: "https://i.imgur.com/huNP7Se.png",
+	ReBeat_90DegreeNormal: "https://i.imgur.com/gJ0q523.png",
+	ReBeat_90Degree: "https://i.imgur.com/WJ0rz55.png",
+	ReBeat_360DegreeEasy: "https://i.imgur.com/8dn3fRK.png",
+	ReBeat_360DegreeExpert: "https://i.imgur.com/tCTvxQF.png",
+	ReBeat_360DegreeExpertPlus: "https://i.imgur.com/l5dD7w5.png",
+	ReBeat_360DegreeHard: "https://i.imgur.com/03vakEt.png",
+	ReBeat_360DegreeNormal: "https://i.imgur.com/TOfdQV5.png",
+	ReBeat_360Degree: "https://i.imgur.com/6Y8KECM.png",
+	ReBeat_LawlessEasy: "https://i.imgur.com/IBVZSmU.png",
+	ReBeat_LawlessExpert: "https://i.imgur.com/cNqtIR6.png",
+	ReBeat_LawlessExpertPlus: "https://i.imgur.com/b9mUDTG.png",
+	ReBeat_LawlessHard: "https://i.imgur.com/Pqh3UxI.png",
+	ReBeat_LawlessNormal: "https://i.imgur.com/4TRkLD5.png",
+	ReBeat_Lawless: "https://i.imgur.com/ABh5ohg.png",
+	ReBeat_NoArrowsEasy: "https://i.imgur.com/6CXF00d.png",
+	ReBeat_NoArrowsExpert: "https://i.imgur.com/XuoU1Fs.png",
+	ReBeat_NoArrowsExpertPlus: "https://i.imgur.com/xYNMJIy.png",
+	ReBeat_NoArrowsHard: "https://i.imgur.com/KC9ltqt.png",
+	ReBeat_NoArrowsNormal: "https://i.imgur.com/J8neyyr.png",
+	ReBeat_NoArrows: "https://i.imgur.com/zvMIe8I.png",
+	ReBeat_LightshowEasy: "https://i.imgur.com/8VftlDI.png",
+	ReBeat_LightshowExpert: "https://i.imgur.com/RIghQr3.png",
+	ReBeat_LightshowExpertPlus: "https://i.imgur.com/dKfcDXI.png",
+	ReBeat_LightshowHard: "https://i.imgur.com/SYtY2af.png",
+	ReBeat_LightshowNormal: "https://i.imgur.com/ggYwNNt.png",
+	ReBeat_Lightshow: "https://i.imgur.com/HCQw79Z.png",
 	Easy: "https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/103.png",
 	Expert: "https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/104.png",
 	ExpertPlus: "https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/105.png",

--- a/websites/B/BeatLeader/metadata.json
+++ b/websites/B/BeatLeader/metadata.json
@@ -16,7 +16,7 @@
 		"royale.beatleader.xyz"
 	],
 	"regExp": "beatleader\\.xyz|beatleader\\.net",
-	"version": "1.10.3",
+	"version": "1.11.10",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/thumbnail.png",
 	"color": "#c81c9f",

--- a/websites/B/BeatLeader/metadata.json
+++ b/websites/B/BeatLeader/metadata.json
@@ -16,7 +16,7 @@
 		"royale.beatleader.xyz"
 	],
 	"regExp": "beatleader\\.xyz|beatleader\\.net",
-	"version": "1.11.10",
+	"version": "1.11.0",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/B/BeatLeader/assets/thumbnail.png",
 	"color": "#c81c9f",

--- a/websites/B/BeatLeader/presence.ts
+++ b/websites/B/BeatLeader/presence.ts
@@ -17,13 +17,6 @@ function simplifyKey(key: string): string {
 		result = result.replace("-PinkPlay_Controllable", "");
 	if (result.match(/(Horizontal|Vertical|Inverted|Inverse)/))
 		result = result.replace(/Lawless|OneSaber|NoArrows|Standard|Legacy/, "");
-	if (result.match(/ReBeat_/)) {
-		result = result.replace(
-			/(Lawless|OneSaber|NoArrows|Standard|Legacy|90Degree|360Degree)/,
-			""
-		);
-		result = result.replaceAll("_", "");
-	}
 	return result;
 }
 
@@ -119,11 +112,13 @@ presence.on("UpdateData", async () => {
 		};
 
 	if (hostname.split(".")[0] === "replay") {
+		presenceData.type = ActivityType.Watching;
+		presenceData.name = "BL Replay";
 		presenceData.largeImageKey = cover
 			? document.querySelector<HTMLImageElement>("#songImage")
 			: replayIcon;
-		presenceData.details = document.querySelector("#songName").textContent;
-		presenceData.state = document.querySelector("#playerName").textContent;
+		presenceData.details = document.querySelector("#songName")?.textContent;
+		presenceData.state = document.querySelector("#playerName")?.textContent;
 		presenceData.smallImageKey = document.querySelector("div.btn.play")
 			? Assets.Pause
 			: Assets.Play;
@@ -148,6 +143,8 @@ presence.on("UpdateData", async () => {
 			},
 		];
 	} else if (hostname.split(".")[0] === "royale") {
+		presenceData.type = ActivityType.Watching;
+		presenceData.name = "BL Royale";
 		presenceData.largeImageKey = cover
 			? document.querySelector<HTMLImageElement>("#songImage")
 			: replayIcon;
@@ -353,6 +350,8 @@ presence.on("UpdateData", async () => {
 				?.src.includes("replay.beatleader.") &&
 			replay.name
 		) {
+			presenceData.type = ActivityType.Watching;
+			presenceData.name = "BL Replay";
 			presenceData.largeImageKey = cover ? replay.cover : replayIcon;
 			presenceData.details = replay.name;
 			presenceData.state = replay.playerName;
@@ -384,6 +383,7 @@ presence.on("UpdateData", async () => {
 		delete presenceData.startTimestamp;
 		delete presenceData.endTimestamp;
 	}
+
 	if (!buttons && presenceData.buttons) delete presenceData.buttons;
 
 	if (presenceData.details && presenceData.largeImageKey)


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

Added all the new ReBeat images.
Added watching ActivityType where it is applicable, so the time bar will show.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/user-attachments/assets/91ecd866-b626-49db-9b0f-a1bf9dc1e604)
![image](https://github.com/user-attachments/assets/77367afc-5398-4aa6-b46a-db492328c155)
![image](https://github.com/user-attachments/assets/24af85d7-45e3-4f9d-a21d-77eeb0e79bd2)


</details>
