### PR TITLE
fix(Heroku): remove unused multiLanguage property

### DIFF
--- a/websites/H/Heroku/metadata.json
+++ b/websites/H/Heroku/metadata.json
@@ -20,7 +20,7 @@
 		"help.heroku.com",
 		"status.heroku.com"
 	],
-	"version": "1.0.9",
+	"version": "1.0.10",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/H/Heroku/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/H/Heroku/assets/thumbnail.png",
 	"color": "#211746",
@@ -34,7 +34,6 @@
 		{
 			"id": "showNames",
 			"value": false,
-			"multiLanguage": false,
 			"title": "Show Application Names",
 			"icon": "fas fa-text"
 		}


### PR DESCRIPTION
This pull request includes updates to the `websites/H/Heroku/metadata.json` file, primarily focusing on versioning and configuration settings.

Version update:

* Updated the `version` field from "1.0.9" to "1.0.10".

Configuration settings:

* Removed the `multiLanguage` property from the "showNames" configuration setting.