### PR TITLE
fix(Holodex): correct the multiLanguage property

### DIFF
--- a/websites/H/Holodex/metadata.json
+++ b/websites/H/Holodex/metadata.json
@@ -13,7 +13,7 @@
 		"staging.holodex.net",
 		"holodex.net"
 	],
-	"version": "1.0.24",
+	"version": "1.0.25",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/H/Holodex/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/H/Holodex/assets/thumbnail.png",
 	"color": "#64b5f6",
@@ -27,7 +27,7 @@
 	"settings": [
 		{
 			"id": "lang",
-			"multiLanguage": "true"
+			"multiLanguage": true
 		},
 		{
 			"id": "cover",


### PR DESCRIPTION
This pull request includes updates to the `websites/H/Holodex/metadata.json` file. The changes involve version increment and a correction to the `multiLanguage` setting.

* Updated the version from `1.0.24` to `1.0.25`.
* Corrected the `multiLanguage` setting from a string `"true"` to a boolean `true`.