### PR TITLE
fix(Genius): addressing bug where song titles are undefined

### DIFF
--- a/websites/G/Genius/metadata.json
+++ b/websites/G/Genius/metadata.json
@@ -12,7 +12,7 @@
 		"vi_VN": "Genius là bộ sưu tập lời bài hát và kiến thức âm nhạc lớn nhất thế giới."
 	},
 	"url": "genius.com",
-	"version": "2.0.26",
+	"version": "2.0.27",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/G/Genius/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/G/Genius/assets/thumbnail.png",
 	"color": "#FFFF64",

--- a/websites/G/Genius/presence.ts
+++ b/websites/G/Genius/presence.ts
@@ -78,10 +78,10 @@ presence.on("UpdateData", async () => {
 		presenceData.details = strings.lyrics;
 		presenceData.state = `${artist["_sf_async_config.authors"]} - ${
 			document
-				.querySelector('h1[class*="SongHeaderdesktop__Title"]')
+				.querySelector('h1[class*="SongHeader-desktop"]')
 				?.textContent.trim() ||
 			document
-				.querySelector('h1[class*="SongHeadermobile__Title"]')
+				.querySelector('h1[class*="SongHeader-mobile"]')
 				?.textContent.trim()
 		}`;
 		if (buttons) {


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

Genius is currently working on their new song page and somewhere along the line, introduced a change that broke the way this Presence found the title for every song. Currently this makes every song show "undefined" as the title like so:
![image](https://github.com/user-attachments/assets/a68cac3a-fb0f-4d3a-8420-f716122dc7a4)

This pull request includes one change that alters the class that the Presence is looking for, letting it find the song title properly.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
[Tested on "hey now" by Kendrick Lamar.](https://genius.com/Kendrick-lamar-hey-now-lyrics)
The extension seems to have another glitch where I can't do the "Load Presence" thing so I can't run this fork of the Presence myself, but I can show you that the selector works in console on mobile web and desktop web:

![image](https://github.com/user-attachments/assets/15427218-3a9a-4936-9214-cd6bbde0a0ac)
![image](https://github.com/user-attachments/assets/ec346701-5ffe-4e19-9c50-fccd3694a6bc)