### PR TITLE
fix(4chan): add urls

### DIFF
--- a/websites/0-9/4chan/metadata.json
+++ b/websites/0-9/4chan/metadata.json
@@ -11,9 +11,11 @@
 	},
 	"url": [
 		"www.4chan.org",
-		"4chan.org"
+		"4chan.org",
+		"boards.4chan.org",
+		"www.boards.4chan.org"
 	],
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/0-9/4chan/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/0-9/4chan/assets/thumbnail.png",
 	"color": "#789922",


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Adds the "boards.4chan.org" and "www.boards.4chan.org" URLs to the URL list in metadata.json.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/user-attachments/assets/d2cf4dea-26b7-4da9-a203-834f195bf762)

![image](https://github.com/user-attachments/assets/6ae692f7-5640-4b46-a67b-ac5507285fcd)


</details>
