### PR TITLE
fix(Spotify Podcasts): show large image cover

### DIFF
--- a/websites/S/Spotify Podcasts/metadata.json
+++ b/websites/S/Spotify Podcasts/metadata.json
@@ -33,7 +33,7 @@
 		"podcasters.spotify.com",
 		"accounts.spotify.com"
 	],
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/S/Spotify%20Podcasts/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/S/Spotify%20Podcasts/assets/thumbnail.png",
 	"color": "#1ed760",

--- a/websites/S/Spotify Podcasts/presence.ts
+++ b/websites/S/Spotify Podcasts/presence.ts
@@ -267,7 +267,7 @@ presence.on("UpdateData", async () => {
 					)?.textContent;
 					presenceData.largeImageKey = document
 						.querySelector(
-							"div.klz_XuZpllvTMzpJF1gw > div > img.mMx2LUixlnN_Fu45JpFB"
+							"div._gLjHpwOxHFwo5nLM8hb > div > img.mMx2LUixlnN_Fu45JpFB"
 						)
 						?.getAttribute("src");
 					presenceData.smallImageKey = Assets.Logo;


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

Fixed large image covers not appearing on Spotify Podcasts shows.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://github.com/user-attachments/assets/8d4dcb14-cf91-4421-9d48-f7945bc34f76)
</details>
