### PR TITLE
chore(YouTube): change id to reset setting to default

### DIFF
--- a/websites/Y/YouTube/metadata.json
+++ b/websites/Y/YouTube/metadata.json
@@ -72,7 +72,7 @@
 		"www.youtube.com",
 		"studio.youtube.com"
 	],
-	"version": "5.13.6",
+	"version": "5.13.7",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/thumbnail.jpg",
 	"color": "#E40813",
@@ -158,7 +158,7 @@
 			"value": false
 		},
 		{
-			"id": "logo",
+			"id": "largeImage",
 			"if": {
 				"privacy": false
 			},

--- a/websites/Y/YouTube/presence.ts
+++ b/websites/Y/YouTube/presence.ts
@@ -61,7 +61,7 @@ presence.on("UpdateData", async () => {
 			getSetting<string>("vidDetail", "%title%"),
 			getSetting<string>("vidState", "%uploader%"),
 			getSetting<boolean>("channelPic", false),
-			getSetting<number>("logo", 0),
+			getSetting<number>("largeImage", 0),
 			getSetting<boolean>("buttons", true),
 			getSetting<boolean>("hideHome", false),
 			getSetting<boolean>("hidePaused", true),


### PR DESCRIPTION
This Pull Request changes the id of the `logo` option so that it gets reset for all users, this is because we changed the default value and for all current users its on the old default aka YouTube Logo

Metadata updates:

* [`websites/Y/YouTube/metadata.json`](diffhunk://#diff-eeee46808f5302d469ed34bac56b60789b3568b0d2c9b2eb418b664f3e857d84L75-R75): Updated the version from `5.13.6` to `5.13.7`.

Configuration setting renaming:

* [`websites/Y/YouTube/metadata.json`](diffhunk://#diff-eeee46808f5302d469ed34bac56b60789b3568b0d2c9b2eb418b664f3e857d84L161-R161): Renamed the `"id"` field from `"logo"` to `"largeImage"`.
* [`websites/Y/YouTube/presence.ts`](diffhunk://#diff-3d6bbda83d32ce58c2aad1b5f9304ec66ea7b243bbdfd2a7dc76b431c1144f76L64-R64): Updated the setting key from `"logo"` to `"largeImage"` in the `presence.on("UpdateData", async () => {` function.