### PR TITLE
chore(workflows): update stale issue handling

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,5 +32,5 @@ jobs:
             If you believe this PR is still relevant, feel free to reopen it or create a new one with updated information.
           stale-pr-label: inactive
           stale-issue-label: inactive
-          only-issue-labels: bug
+          only-issue-labels: bug,needs repro
           operations-per-run: 1000


### PR DESCRIPTION
Updates the stale config to require both `bug` and `needs repro` as requested by @theusaf 