### PR TITLE
fix(RTLplay): movie and channel media issues

### DIFF
--- a/websites/R/RTLplay/metadata.json
+++ b/websites/R/RTLplay/metadata.json
@@ -16,17 +16,17 @@
 		"Radio Contact"
 	],
 	"description": {
-		"en": "With RTLplay, you'll find all the programs of our RTL TVI, Club RTL, Plug RTL, RTL District, Bel RTL and Radio Contact channels live and in replay, as well as exclusive content.",
-		"fr": "Avec RTLplay, retrouvez tous les programmes de nos chaînes RTL TVI, Club RTL, Plug RTL, RTL District, Bel RTL et Radio Contact en direct et en replay ainsi que des contenus exclusifs.",
-		"nl": "Met RTLplay kun je alle programma's op onze zenders RTL TVI, Club RTL, Plug RTL, RTL District, Bel RTL en Radio Contact live en in replay bekijken, evenals exclusieve content.",
-		"de": "Mit RTLplay finden Sie alle Programme unserer Sender RTL TVI, Club RTL, Plug RTL, RTL District, Bel RTL und Radio Contact als Live- und Replay-Stream sowie exklusive Inhalte."
+		"en": "With RTLplay, you'll find all the programs of our RTL TVI, Club RTL, Plug RTL, RTL District, RTL sports, Bel RTL and Radio Contact channels live and in replay, as well as exclusive content.",
+		"fr": "Avec RTLplay, retrouvez tous les programmes de nos chaînes RTL TVI, Club RTL, Plug RTL, RTL District, RTL sports, Bel RTL et Radio Contact en direct et en replay ainsi que des contenus exclusifs.",
+		"nl": "Met RTLplay kun je alle programma's op onze zenders RTL TVI, Club RTL, Plug RTL, RTL District, RTL sports, Bel RTL en Radio Contact live en in replay bekijken, evenals exclusieve content.",
+		"de": "Mit RTLplay finden Sie alle Programme unserer Sender RTL TVI, Club RTL, Plug RTL, RTL District, RTL sports, Bel RTL und Radio Contact als Live- und Replay-Stream sowie exklusive Inhalte."
 	},
 	"url": [
 		"www.rtlplay.be",
 		"www.radiocontact.be",
 		"www.belrtl.be"
 	],
-	"version": "2.0.2",
+	"version": "2.1.0",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/R/RTLplay/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/R/RTLplay/assets/thumbnail.jpeg",
 	"color": "#121726",
@@ -40,6 +40,7 @@
 		"club",
 		"plug",
 		"district",
+		"sports",
 		"contact",
 		"belrtl",
 		"belgique",
@@ -48,6 +49,7 @@
 		"media",
 		"video",
 		"radio",
+		"movie",
 		"tv",
 		"broadcast"
 	],

--- a/websites/R/RTLplay/util.ts
+++ b/websites/R/RTLplay/util.ts
@@ -94,6 +94,7 @@ export const enum LargeAssets {
 	RTLClub = "https://cdn.rcd.gg/PreMiD/websites/R/RTLplay/assets/8.png",
 	RTLPlug = "https://cdn.rcd.gg/PreMiD/websites/R/RTLplay/assets/9.png",
 	RTLDistrict = "https://cdn.rcd.gg/PreMiD/websites/R/RTLplay/assets/15.png",
+	RTLSports = "https://i.imgur.com/pUw14pp.png",
 	BelRTL = "https://cdn.rcd.gg/PreMiD/websites/R/RTLplay/assets/10.png",
 	Contact = "https://cdn.rcd.gg/PreMiD/websites/R/RTLplay/assets/11.png",
 }
@@ -189,6 +190,13 @@ export function getChannel(channel: string): ChannelInfo {
 				logo: LargeAssets.Contact,
 				radioplayerAPI:
 					"https://core-search.radioplayer.cloud/056/qp/v4/events/?rpId=1",
+			};
+		}
+		case ["rtlplay2", "sports"].includes(channel): {
+			return {
+				channel: "RTL sports",
+				type: ActivityType.Watching,
+				logo: LargeAssets.RTLSports,
 			};
 		}
 		default: {


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Bugfixes:
- When a movie was played, the activity was cleared by accident.
- The selector for the media title on the live broadcast page has been updated

Added:
- New tv channel: RTL sports

## Acknowledgements
- [X] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `yarn format`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![fix_mediaChannel](https://github.com/user-attachments/assets/94fdea8e-761f-42d7-960a-c979eb0bcd98)

![fix_movie](https://github.com/user-attachments/assets/5f4bf011-1b20-4e88-b922-ad4792115af5)

![fix_rtlsports](https://github.com/user-attachments/assets/dc079dbb-8b57-4d53-8072-6cd65c20daea)



</details>
