### PR TITLE
fix(Netflix): resolve pausing and small images option issues

### DIFF
--- a/websites/N/Netflix/presence.ts
+++ b/websites/N/Netflix/presence.ts
@@ -146,8 +146,8 @@ presence.on("UpdateData", async () => {
 					: "",
 				smallImageText: paused ? strings.pause : strings.play,
 				...(showTimestamp && {
-					startTimestamp: paused ? null : startTimestamp,
-					endTimestamp: paused ? null : endTimestamp,
+					startTimestamp: paused ? 0 : startTimestamp,
+					endTimestamp: paused ? 0 : endTimestamp,
 				}),
 				...(usePresenceName && {
 					name: metadata.data.video.title,
@@ -199,8 +199,8 @@ presence.on("UpdateData", async () => {
 					: "",
 				smallImageText: paused ? strings.pause : strings.play,
 				...(showTimestamp && {
-					startTimestamp: paused ? null : startTimestamp,
-					endTimestamp: paused ? null : endTimestamp,
+					startTimestamp: paused ? 0 : startTimestamp,
+					endTimestamp: paused ? 0 : endTimestamp,
 				}),
 				...(usePresenceName && {
 					name: metadata.data.video.title,

--- a/websites/N/Netflix/presence.ts
+++ b/websites/N/Netflix/presence.ts
@@ -143,7 +143,7 @@ presence.on("UpdateData", async () => {
 					? paused
 						? Assets.Pause
 						: Assets.Play
-					: "",
+					: null,
 				smallImageText: paused ? strings.pause : strings.play,
 				...(showTimestamp && {
 					startTimestamp: paused ? 0 : startTimestamp,
@@ -196,7 +196,7 @@ presence.on("UpdateData", async () => {
 					? paused
 						? Assets.Pause
 						: Assets.Play
-					: "",
+					: null,
 				smallImageText: paused ? strings.pause : strings.play,
 				...(showTimestamp && {
 					startTimestamp: paused ? 0 : startTimestamp,

--- a/websites/S/Sflix/iframe.ts
+++ b/websites/S/Sflix/iframe.ts
@@ -1,0 +1,12 @@
+const iframe = new iFrame();
+
+iframe.on("UpdateData", async () => {
+	const video = document.querySelector<HTMLVideoElement>("video");
+	if (!isNaN(video?.duration)) {
+		iframe.send({
+			duration: video.duration,
+			currentTime: video.currentTime,
+			paused: video.paused,
+		});
+	}
+});

--- a/websites/S/Sflix/metadata.json
+++ b/websites/S/Sflix/metadata.json
@@ -1,0 +1,38 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.12",
+	"apiVersion": 1,
+	"author": {
+		"id": "290528827715747841",
+		"name": "iuriineves"
+	},
+	"service": "Sflix",
+	"description": {
+		"en": "SFlix is a Free Movies streaming site with zero ads. We let you watch movies online without having to register or paying, with over 10000 movies and TV-Series."
+	},
+	"url": [
+		"sflix2.to",
+		"enorme.tv"
+	],
+	"version": "1.0.0",
+	"logo": "https://img.sflix2.to/xxrz/400x400/100/66/35/66356c25ce98cb12993249e21742b129/66356c25ce98cb12993249e21742b129.png",
+	"thumbnail": "https://img.sflix.to/xxrz/1300x700/100/8e/5a/8e5afb7b78cfcb3c3667504fd5830a0f/8e5afb7b78cfcb3c3667504fd5830a0f.jpeg",
+	"color": "#03abb8",
+	"category": "videos",
+	"tags": [
+		"sflix",
+		"video",
+		"media",
+		"movies",
+		"shows"
+	],
+	"settings": [
+		{
+			"id": "thumbnail",
+			"title": "Show thumbnail",
+			"icon": "fad fa-album",
+			"value": true
+		}
+	],
+	"iframe": true,
+	"iFrameRegExp": ".*"
+}

--- a/websites/S/Sflix/metadata.json
+++ b/websites/S/Sflix/metadata.json
@@ -14,7 +14,7 @@
 		"enorme.tv"
 	],
 	"version": "1.0.0",
-	"logo": "https://img.sflix2.to/xxrz/400x400/100/66/35/66356c25ce98cb12993249e21742b129/66356c25ce98cb12993249e21742b129.png",
+	"logo": "https://imgur.com/u3xBsLk.png",
 	"thumbnail": "https://img.sflix.to/xxrz/1300x700/100/8e/5a/8e5afb7b78cfcb3c3667504fd5830a0f/8e5afb7b78cfcb3c3667504fd5830a0f.jpeg",
 	"color": "#03abb8",
 	"category": "videos",

--- a/websites/S/Sflix/metadata.json
+++ b/websites/S/Sflix/metadata.json
@@ -31,6 +31,12 @@
 			"title": "Show thumbnail",
 			"icon": "fad fa-album",
 			"value": true
+		},
+		{
+			"id": "privacy",
+			"title": "Privacy",
+			"icon": "fad fa-user-secret",
+			"value": false
 		}
 	],
 	"iframe": true,

--- a/websites/S/Sflix/presence.ts
+++ b/websites/S/Sflix/presence.ts
@@ -13,30 +13,38 @@ let video = {
 	paused: true,
 };
 
-presence.on("iFrameData", (data: { duration: number, currentTime: number, paused: boolean }) => {
-	video = data;
-});
+presence.on(
+	"iFrameData",
+	(data: { duration: number; currentTime: number; paused: boolean }) => {
+		video = data;
+	}
+);
 
 presence.on("UpdateData", async () => {
 	const presenceData: PresenceData = {
-		largeImageKey: Assets.Logo,
-		type: ActivityType.Watching,
-		startTimestamp: browsingTimestamp,
-	},
-
-	[ thumbnail, privacy ] = await Promise.all([
-		presence.getSetting<boolean>("thumbnail"),
-		presence.getSetting<boolean>("privacy"),
-	]),
-
-	variables = await presence.getPageVariable("currPage");
+			largeImageKey: Assets.Logo,
+			type: ActivityType.Watching,
+			startTimestamp: browsingTimestamp,
+		},
+		[thumbnail, privacy] = await Promise.all([
+			presence.getSetting<boolean>("thumbnail"),
+			presence.getSetting<boolean>("privacy"),
+		]),
+		variables = await presence.getPageVariable("currPage");
 
 	switch (variables.currPage) {
 		case "": {
 			presenceData.details = "Searching";
 			presenceData.smallImageKey = Assets.Search;
 			presenceData.smallImageText = "Searching";
-			presenceData.state = privacy ? "" : `${document.querySelector("h2[class*='cat-heading']").textContent.split('"')[1] || document.querySelector("h2[class*='cat-heading']").textContent}`; 
+			presenceData.state = privacy
+				? ""
+				: `${
+						document
+							.querySelector("h2[class*='cat-heading']")
+							.textContent.split('"')[1] ||
+						document.querySelector("h2[class*='cat-heading']").textContent
+				  }`;
 			break;
 		}
 		case "home_search":
@@ -49,23 +57,31 @@ presence.on("UpdateData", async () => {
 		}
 		case "detail": {
 			presenceData.details = "Browsing";
-			presenceData.state = privacy ? "" : document.querySelector(".heading-name")?.textContent;
+			presenceData.state = privacy
+				? ""
+				: document.querySelector(".heading-name")?.textContent;
 			presenceData.smallImageKey = Assets.Reading;
 			presenceData.smallImageText = "Browsing";
 			break;
 		}
 		case "watch": {
-
 			const showTitle = document.querySelector(".heading-name").textContent,
-				thumbnailURL = document.querySelector(`img[title*="${showTitle}"]`)?.getAttribute("src");
-			
+				thumbnailURL = document
+					.querySelector(`img[title*="${showTitle}"]`)
+					?.getAttribute("src");
+
 			presenceData.details = privacy ? "Watching" : `${showTitle}`;
-			presenceData.state = privacy ? "" : `${document.querySelector(".on-air div h3")?.textContent || ""}`;
-			presenceData.largeImageKey = (thumbnail && thumbnailURL && !privacy) ? thumbnailURL : Assets.Logo;
-			
+			presenceData.state = privacy
+				? ""
+				: `${document.querySelector(".on-air div h3")?.textContent || ""}`;
+			presenceData.largeImageKey =
+				thumbnail && thumbnailURL && !privacy ? thumbnailURL : Assets.Logo;
 
 			if (!video.paused) {
-				const timestamps = presence.getTimestamps(video.currentTime, video.duration);
+				const timestamps = presence.getTimestamps(
+					video.currentTime,
+					video.duration
+				);
 				presenceData.smallImageKey = Assets.Play;
 				presenceData.smallImageText = "Playing";
 				if (!privacy) {

--- a/websites/S/Sflix/presence.ts
+++ b/websites/S/Sflix/presence.ts
@@ -34,7 +34,8 @@ presence.on("UpdateData", async () => {
 	switch (variables.currPage) {
 		case "": {
 			presenceData.details = "Searching";
-			presenceData.smallImageKey = Assets.Search; 
+			presenceData.smallImageKey = Assets.Search;
+			presenceData.smallImageText = "Searching";
 			presenceData.state = privacy ? "" : `${document.querySelector("h2[class*='cat-heading']").textContent.split('"')[1] || document.querySelector("h2[class*='cat-heading']").textContent}`; 
 			break;
 		}
@@ -43,12 +44,14 @@ presence.on("UpdateData", async () => {
 			presenceData.details = "Browsing";
 			presenceData.state = "Home";
 			presenceData.smallImageKey = Assets.Reading;
+			presenceData.smallImageText = "Browsing";
 			break;
 		}
 		case "detail": {
 			presenceData.details = "Browsing";
 			presenceData.state = privacy ? "" : document.querySelector(".heading-name")?.textContent;
 			presenceData.smallImageKey = Assets.Reading;
+			presenceData.smallImageText = "Browsing";
 			break;
 		}
 		case "watch": {
@@ -64,12 +67,14 @@ presence.on("UpdateData", async () => {
 			if (!video.paused) {
 				const timestamps = presence.getTimestamps(video.currentTime, video.duration);
 				presenceData.smallImageKey = Assets.Play;
+				presenceData.smallImageText = "Playing";
 				if (!privacy) {
 					presenceData.startTimestamp = timestamps[0];
 					presenceData.endTimestamp = timestamps[1];
 				}
 			} else {
 				presenceData.smallImageKey = Assets.Pause;
+				presenceData.smallImageText = "Paused";
 				delete presenceData.startTimestamp;
 				delete presenceData.endTimestamp;
 			}

--- a/websites/S/Sflix/presence.ts
+++ b/websites/S/Sflix/presence.ts
@@ -1,0 +1,77 @@
+const presence = new Presence({
+		clientId: "1322565714128797798",
+	}),
+	browsingTimestamp = Math.floor(Date.now() / 1000);
+
+const enum Assets { // Other default assets can be found at index.d.ts
+	Logo = "https://img.sflix2.to/xxrz/400x400/100/66/35/66356c25ce98cb12993249e21742b129/66356c25ce98cb12993249e21742b129.png",
+}
+
+let video = {
+	duration: 0,
+	currentTime: 0,
+	paused: true,
+};
+
+presence.on("iFrameData", (data: { duration: number, currentTime: number, paused: boolean }) => {
+	video = data;
+});
+
+presence.on("UpdateData", async () => {
+	const presenceData: PresenceData = {
+		largeImageKey: Assets.Logo,
+		type: ActivityType.Watching,
+		startTimestamp: browsingTimestamp,
+	},
+
+	[ thumbnail ] = await Promise.all([
+		presence.getSetting<boolean>("thumbnail"),
+	]),
+
+	variables = await presence.getPageVariable("currPage");
+
+	switch (variables.currPage) {
+		case "": {
+			presenceData.details = "Searching";
+			presenceData.state = `${document.querySelector("h2[class*='cat-heading']").textContent.split('"')[1] || document.querySelector("h2[class*='cat-heading']").textContent}`;
+			presenceData.smallImageKey = Assets.Search;
+			break;
+		}
+		case "home_search":
+		case "home": {
+			presenceData.details = "Browsing";
+			presenceData.state = "Home";
+			presenceData.smallImageKey = Assets.Reading;
+			break;
+		}
+		case "detail": {
+			presenceData.details = "Browsing";
+			presenceData.state = document.querySelector(".heading-name")?.textContent;
+			presenceData.smallImageKey = Assets.Reading;
+			break;
+		}
+		case "watch": {
+
+			const showTitle = document.querySelector(".heading-name").textContent,
+				thumbnailURL = document.querySelector(`img[title*="${showTitle}"]`)?.getAttribute("src");
+			
+			presenceData.details = `${showTitle}`;
+			presenceData.state = `${document.querySelector(".on-air div h3")?.textContent || ""}`;
+			if (thumbnail && thumbnailURL) presenceData.largeImageKey = thumbnailURL;
+			
+
+			if (!video.paused) {
+				const timestamps = presence.getTimestamps(video.currentTime, video.duration);
+				presenceData.smallImageKey = Assets.Play;
+				presenceData.startTimestamp = timestamps[0];
+				presenceData.endTimestamp = timestamps[1];
+			} else {
+				presenceData.smallImageKey = Assets.Pause;
+				delete presenceData.startTimestamp;
+				delete presenceData.endTimestamp;
+			}
+			break;
+		}
+	}
+	presence.setActivity(presenceData);
+});

--- a/websites/S/Sflix/presence.ts
+++ b/websites/S/Sflix/presence.ts
@@ -4,7 +4,7 @@ const presence = new Presence({
 	browsingTimestamp = Math.floor(Date.now() / 1000);
 
 const enum Assets {
-	Logo = "https://img.sflix2.to/xxrz/400x400/100/66/35/66356c25ce98cb12993249e21742b129/66356c25ce98cb12993249e21742b129.png",
+	Logo = "https://imgur.com/u3xBsLk.png",
 }
 
 let video = {

--- a/websites/S/Sflix/presence.ts
+++ b/websites/S/Sflix/presence.ts
@@ -3,7 +3,7 @@ const presence = new Presence({
 	}),
 	browsingTimestamp = Math.floor(Date.now() / 1000);
 
-const enum Assets { // Other default assets can be found at index.d.ts
+const enum Assets {
 	Logo = "https://img.sflix2.to/xxrz/400x400/100/66/35/66356c25ce98cb12993249e21742b129/66356c25ce98cb12993249e21742b129.png",
 }
 

--- a/websites/S/Sflix/presence.ts
+++ b/websites/S/Sflix/presence.ts
@@ -39,12 +39,12 @@ presence.on("UpdateData", async () => {
 			presenceData.smallImageText = "Searching";
 			presenceData.state = privacy
 				? ""
-				: `${
+				: 
 						document
 							.querySelector("h2[class*='cat-heading']")
 							.textContent.split('"')[1] ||
 						document.querySelector("h2[class*='cat-heading']").textContent
-				  }`;
+				 
 			break;
 		}
 		case "home_search":

--- a/websites/S/Sflix/presence.ts
+++ b/websites/S/Sflix/presence.ts
@@ -39,12 +39,11 @@ presence.on("UpdateData", async () => {
 			presenceData.smallImageText = "Searching";
 			presenceData.state = privacy
 				? ""
-				: 
-						document
-							.querySelector("h2[class*='cat-heading']")
-							.textContent.split('"')[1] ||
-						document.querySelector("h2[class*='cat-heading']").textContent
-				 
+				: document
+						.querySelector("h2[class*='cat-heading']")
+						.textContent.split('"')[1] ||
+				  document.querySelector("h2[class*='cat-heading']").textContent;
+
 			break;
 		}
 		case "home_search":
@@ -73,21 +72,17 @@ presence.on("UpdateData", async () => {
 			presenceData.details = privacy ? "Watching" : `${showTitle}`;
 			presenceData.state = privacy
 				? ""
-				: {document.querySelector(".on-air div h3")?.textContent ?? ""
+				: document.querySelector(".on-air div h3")?.textContent ?? "";
 			presenceData.largeImageKey =
 				thumbnail && thumbnailURL && !privacy ? thumbnailURL : Assets.Logo;
 
 			if (!video.paused) {
-				const timestamps = presence.getTimestamps(
-					video.currentTime,
-					video.duration
-				);
+				if (!privacy) {
+					[presenceData.startTimestamp, presenceData.endTimestamp] =
+						presence.getTimestamps(video.currentTime, video.duration);
+				}
 				presenceData.smallImageKey = Assets.Play;
 				presenceData.smallImageText = "Playing";
-				if (!privacy) {
-					presenceData.startTimestamp = timestamps[0];
-					presenceData.endTimestamp = timestamps[1];
-				}
 			} else {
 				presenceData.smallImageKey = Assets.Pause;
 				presenceData.smallImageText = "Paused";

--- a/websites/S/Sflix/presence.ts
+++ b/websites/S/Sflix/presence.ts
@@ -73,7 +73,7 @@ presence.on("UpdateData", async () => {
 			presenceData.details = privacy ? "Watching" : `${showTitle}`;
 			presenceData.state = privacy
 				? ""
-				: `${document.querySelector(".on-air div h3")?.textContent || ""}`;
+				: {document.querySelector(".on-air div h3")?.textContent ?? ""
 			presenceData.largeImageKey =
 				thumbnail && thumbnailURL && !privacy ? thumbnailURL : Assets.Logo;
 

--- a/websites/S/Sflix/presence.ts
+++ b/websites/S/Sflix/presence.ts
@@ -58,7 +58,7 @@ presence.on("UpdateData", async () => {
 			
 			presenceData.details = privacy ? "Watching" : `${showTitle}`;
 			presenceData.state = privacy ? "" : `${document.querySelector(".on-air div h3")?.textContent || ""}`;
-			presenceData.largeImageKey = (thumbnail && thumbnailURL && !privacy) ? Assets.Logo : thumbnailURL;
+			presenceData.largeImageKey = (thumbnail && thumbnailURL && !privacy) ? thumbnailURL : Assets.Logo;
 			
 
 			if (!video.paused) {

--- a/websites/S/Sflix/presence.ts
+++ b/websites/S/Sflix/presence.ts
@@ -24,8 +24,9 @@ presence.on("UpdateData", async () => {
 		startTimestamp: browsingTimestamp,
 	},
 
-	[ thumbnail ] = await Promise.all([
+	[ thumbnail, privacy ] = await Promise.all([
 		presence.getSetting<boolean>("thumbnail"),
+		presence.getSetting<boolean>("privacy"),
 	]),
 
 	variables = await presence.getPageVariable("currPage");
@@ -33,8 +34,8 @@ presence.on("UpdateData", async () => {
 	switch (variables.currPage) {
 		case "": {
 			presenceData.details = "Searching";
-			presenceData.state = `${document.querySelector("h2[class*='cat-heading']").textContent.split('"')[1] || document.querySelector("h2[class*='cat-heading']").textContent}`;
-			presenceData.smallImageKey = Assets.Search;
+			presenceData.smallImageKey = Assets.Search; 
+			presenceData.state = privacy ? "" : `${document.querySelector("h2[class*='cat-heading']").textContent.split('"')[1] || document.querySelector("h2[class*='cat-heading']").textContent}`; 
 			break;
 		}
 		case "home_search":
@@ -46,7 +47,7 @@ presence.on("UpdateData", async () => {
 		}
 		case "detail": {
 			presenceData.details = "Browsing";
-			presenceData.state = document.querySelector(".heading-name")?.textContent;
+			presenceData.state = privacy ? "" : document.querySelector(".heading-name")?.textContent;
 			presenceData.smallImageKey = Assets.Reading;
 			break;
 		}
@@ -55,16 +56,18 @@ presence.on("UpdateData", async () => {
 			const showTitle = document.querySelector(".heading-name").textContent,
 				thumbnailURL = document.querySelector(`img[title*="${showTitle}"]`)?.getAttribute("src");
 			
-			presenceData.details = `${showTitle}`;
-			presenceData.state = `${document.querySelector(".on-air div h3")?.textContent || ""}`;
-			if (thumbnail && thumbnailURL) presenceData.largeImageKey = thumbnailURL;
+			presenceData.details = privacy ? "Watching" : `${showTitle}`;
+			presenceData.state = privacy ? "" : `${document.querySelector(".on-air div h3")?.textContent || ""}`;
+			presenceData.largeImageKey = (thumbnail && thumbnailURL && !privacy) ? Assets.Logo : thumbnailURL;
 			
 
 			if (!video.paused) {
 				const timestamps = presence.getTimestamps(video.currentTime, video.duration);
 				presenceData.smallImageKey = Assets.Play;
-				presenceData.startTimestamp = timestamps[0];
-				presenceData.endTimestamp = timestamps[1];
+				if (!privacy) {
+					presenceData.startTimestamp = timestamps[0];
+					presenceData.endTimestamp = timestamps[1];
+				}
 			} else {
 				presenceData.smallImageKey = Assets.Pause;
 				delete presenceData.startTimestamp;


### PR DESCRIPTION
## Description 

- Set timestamps to `0` when the video is paused - setting it to null breaks the `.setActivity()` function, only updating the information when the video is running;
- Set `smallImageKey` to `null` when `showSmallImages` is `false` - setting it to `""` didn't remove the image.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

(pausing)
![image](https://github.com/user-attachments/assets/8e9f1612-d137-4b40-9e55-da2fcae4d104)

(`showSmallImages` set to `false`)
![image](https://github.com/user-attachments/assets/16f07ad1-832d-431c-9aab-815f6e8e359a)

</details>
