### PR TITLE
fix(Netflix): pause and showsmallimages issues

### DIFF
--- a/websites/N/Netflix/metadata.json
+++ b/websites/N/Netflix/metadata.json
@@ -56,7 +56,7 @@
 		"www.netflix.com",
 		"netflix.com"
 	],
-	"version": "6.1.1",
+	"version": "6.1.2",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/N/Netflix/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/N/Netflix/assets/thumbnail.jpg",
 	"color": "#db0000",

--- a/websites/N/Netflix/presence.ts
+++ b/websites/N/Netflix/presence.ts
@@ -84,7 +84,7 @@ presence.on("UpdateData", async () => {
 				? [LargImages.Animated, LargImages.Logo, LargImages.Noback][logoType] ||
 				  LargImages.Logo
 				: metadata.data.video.boxart.at(0).url,
-			smallImageKey: showSmallImages ? Assets.Reading : "",
+			smallImageKey: showSmallImages ? Assets.Reading : null,
 			smallImageText: strings.browse,
 			buttons: [
 				{
@@ -143,11 +143,11 @@ presence.on("UpdateData", async () => {
 					? paused
 						? Assets.Pause
 						: Assets.Play
-					: "",
+					: null,
 				smallImageText: paused ? strings.pause : strings.play,
 				...(showTimestamp && {
-					startTimestamp: paused ? null : startTimestamp,
-					endTimestamp: paused ? null : endTimestamp,
+					startTimestamp: paused ? 0 : startTimestamp,
+					endTimestamp: paused ? 0 : endTimestamp,
 				}),
 				...(usePresenceName && {
 					name: metadata.data.video.title,
@@ -196,11 +196,11 @@ presence.on("UpdateData", async () => {
 					? paused
 						? Assets.Pause
 						: Assets.Play
-					: "",
+					: null,
 				smallImageText: paused ? strings.pause : strings.play,
 				...(showTimestamp && {
-					startTimestamp: paused ? null : startTimestamp,
-					endTimestamp: paused ? null : endTimestamp,
+					startTimestamp: paused ? 0 : startTimestamp,
+					endTimestamp: paused ? 0 : endTimestamp,
 				}),
 				...(usePresenceName && {
 					name: metadata.data.video.title,

--- a/websites/N/Netflix/presence.ts
+++ b/websites/N/Netflix/presence.ts
@@ -84,7 +84,9 @@ presence.on("UpdateData", async () => {
 				? [LargImages.Animated, LargImages.Logo, LargImages.Noback][logoType] ||
 				  LargImages.Logo
 				: metadata.data.video.boxart.at(0).url,
-			smallImageKey: showSmallImages ? Assets.Reading : null,
+			...(showSmallImages && {
+				smallImageKey: Assets.Reading,
+			}),
 			smallImageText: strings.browse,
 			buttons: [
 				{
@@ -139,16 +141,15 @@ presence.on("UpdateData", async () => {
 							logoType
 					  ] || LargImages.Logo
 					: metadata.data.video.boxart.at(0).url,
-				smallImageKey: showSmallImages
-					? paused
-						? Assets.Pause
-						: Assets.Play
-					: null,
-				smallImageText: paused ? strings.pause : strings.play,
-				...(showTimestamp && {
-					startTimestamp: paused ? 0 : startTimestamp,
-					endTimestamp: paused ? 0 : endTimestamp,
+				...(showSmallImages && {
+					smallImageKey: paused ? Assets.Pause : Assets.Play,
 				}),
+				smallImageText: paused ? strings.pause : strings.play,
+				...(showTimestamp &&
+					!paused && {
+						startTimestamp,
+						endTimestamp,
+					}),
 				...(usePresenceName && {
 					name: metadata.data.video.title,
 					details: episode.title,
@@ -192,16 +193,15 @@ presence.on("UpdateData", async () => {
 							logoType
 					  ] || LargImages.Logo
 					: metadata.data.video.boxart.at(0).url,
-				smallImageKey: showSmallImages
-					? paused
-						? Assets.Pause
-						: Assets.Play
-					: null,
-				smallImageText: paused ? strings.pause : strings.play,
-				...(showTimestamp && {
-					startTimestamp: paused ? 0 : startTimestamp,
-					endTimestamp: paused ? 0 : endTimestamp,
+				...(showSmallImages && {
+					smallImageKey: paused ? Assets.Pause : Assets.Play,
 				}),
+				smallImageText: paused ? strings.pause : strings.play,
+				...(showTimestamp &&
+					!paused && {
+						startTimestamp,
+						endTimestamp,
+					}),
 				...(usePresenceName && {
 					name: metadata.data.video.title,
 				}),


### PR DESCRIPTION
## Description 

- Set timestamps to `0` when the video is paused - setting it to `null` breaks the `.setActivity()` function, only updating the information when the video is running;
- Set `smallImageKey` to `null` when `showSmallImages` is `false` - setting it to `""` didn't remove the image.

Closes #9031.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

(pausing)
![image](https://github.com/user-attachments/assets/8e9f1612-d137-4b40-9e55-da2fcae4d104)

(`showSmallImages` set to `false`)
![image](https://github.com/user-attachments/assets/16f07ad1-832d-431c-9aab-815f6e8e359a)

</details>


