### PR TITLE
feat(AnimeLib): add support for buttons

### DIFF
--- a/websites/A/AnimeLib/metadata.json
+++ b/websites/A/AnimeLib/metadata.json
@@ -14,7 +14,7 @@
 		"ru": "Смотрите аниме онлайн на русском"
 	},
 	"url": "anilib.me",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeLib/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeLib/assets/thumbnail.png",
 	"color": "#A020F0",
@@ -28,7 +28,13 @@
 	"iFrameRegExp": "kodik[.]info",
 	"settings": [
 		{
-			"id": "privacy-mode",
+			"id": "buttons",
+			"title": "Show Buttons",
+			"icon": "fas fa-compress-arrows-alt",
+			"value": true
+		},
+		{
+			"id": "privacy",
 			"title": "Privacy Mode",
 			"icon": "fad fa-user-secret",
 			"value": false

--- a/websites/A/AnimeLib/presence.ts
+++ b/websites/A/AnimeLib/presence.ts
@@ -33,7 +33,9 @@ const isPrivacyMode = (setting: boolean, ageRestriction?: AgeRestriction) =>
 	setPrivacyMode = (presenceData: PresenceData) => {
 		presenceData.details = "Приватный режим";
 		presenceData.state = "Вам не следует знать лишнего!";
-	};
+	},
+	cleanUrl = (location: Location) =>
+		location.href.replace(location.search, "").replace("/watch", "");
 
 let iFrameVideo: IFrameVideo;
 
@@ -47,7 +49,10 @@ presence.on("UpdateData", async () => {
 			type: ActivityType.Watching,
 			startTimestamp: browsingTimestamp,
 		},
-		privacySetting = await presence.getSetting<boolean>("privacy-mode"),
+		[privacySetting, buttonsSetting] = await Promise.all([
+			presence.getSetting<boolean>("privacy"),
+			presence.getSetting<boolean>("buttons"),
+		]),
 		path = document.location.pathname;
 
 	let animeData: AnimeData,
@@ -112,6 +117,12 @@ presence.on("UpdateData", async () => {
 						"Фильм"
 					} | ${dub}`;
 					presenceData.largeImageKey = animeData.cover.default;
+					presenceData.buttons = [
+						{
+							label: "Открыть аниме",
+							url: cleanUrl(document.location),
+						},
+					];
 
 					presenceData.smallImageKey = Assets.Pause;
 					presenceData.smallImageText = "На паузе";
@@ -154,6 +165,12 @@ presence.on("UpdateData", async () => {
 					animeData.eng_name ?? animeData.name
 				})`;
 				presenceData.largeImageKey = animeData.cover.default;
+				presenceData.buttons = [
+					{
+						label: "Открыть аниме",
+						url: cleanUrl(document.location),
+					},
+				];
 			}
 			break;
 		case "characters":
@@ -170,6 +187,12 @@ presence.on("UpdateData", async () => {
 					presenceData.details = "Страница персонажа";
 					presenceData.state = `${characterData.rus_name} (${characterData.name})`;
 					presenceData.largeImageKey = characterData.cover.default;
+					presenceData.buttons = [
+						{
+							label: "Oткрыть персoнажа",
+							url: cleanUrl(document.location),
+						},
+					];
 				}
 			} else {
 				presenceData.details = "Страница персонажей";
@@ -196,6 +219,12 @@ presence.on("UpdateData", async () => {
 							: peopleData.name
 					} (${peopleData.name})`;
 					presenceData.largeImageKey = peopleData.cover.default;
+					presenceData.buttons = [
+						{
+							label: "Открыть человека",
+							url: cleanUrl(document.location),
+						},
+					];
 				}
 			} else {
 				presenceData.details = "Страница людей";
@@ -212,9 +241,16 @@ presence.on("UpdateData", async () => {
 					response => <UserData>response.data
 				);
 
-				presenceData.details = "В профиле";
+				presenceData.details = "Страница пользователя";
 				presenceData.state = userData.username;
 				presenceData.largeImageKey = userData.avatar.url;
+				presenceData.smallImageKey = Assets.Logo;
+				presenceData.buttons = [
+					{
+						label: "Открыть профиль",
+						url: cleanUrl(document.location),
+					},
+				];
 			} else {
 				presenceData.details = "Страница пользователей";
 				presenceData.state = "Столько интересных личностей!";
@@ -237,6 +273,12 @@ presence.on("UpdateData", async () => {
 					presenceData.details = "Страница коллекции";
 					presenceData.state = `${collectionData.name} от ${collectionData.user.username}`;
 					presenceData.largeImageKey = collectionData.user.avatar.url;
+					presenceData.buttons = [
+						{
+							label: "Oткрыть кoллекцию",
+							url: cleanUrl(document.location),
+						},
+					];
 				}
 			} else {
 				presenceData.details = "Страница коллекций";
@@ -266,6 +308,12 @@ presence.on("UpdateData", async () => {
 					presenceData.largeImageKey = reviewData.related.cover.default;
 					presenceData.smallImageKey = reviewData.user.avatar.url;
 					presenceData.smallImageText = reviewData.user.username;
+					presenceData.buttons = [
+						{
+							label: "Открыть отзыв",
+							url: cleanUrl(document.location),
+						},
+					];
 				}
 			} else {
 				presenceData.details = "Страница отзывов";
@@ -288,6 +336,13 @@ presence.on("UpdateData", async () => {
 						teamData.alt_name ?? teamData.name
 					})`;
 					presenceData.largeImageKey = teamData.cover.default;
+					presenceData.smallImageKey = Assets.Logo;
+					presenceData.buttons = [
+						{
+							label: "Открыть команду",
+							url: cleanUrl(document.location),
+						},
+					];
 				}
 			} else {
 				presenceData.details = "Страница команд";
@@ -304,10 +359,16 @@ presence.on("UpdateData", async () => {
 					presenceData.state = `${name.textContent} (${
 						altName.textContent.split("/")[0]
 					})`;
-				} else {
-					presenceData.details = "Страница франшиз";
-					presenceData.state = "Их так много...";
+					presenceData.buttons = [
+						{
+							label: "Открыть франшизу",
+							url: cleanUrl(document.location),
+						},
+					];
 				}
+			} else {
+				presenceData.details = "Страница франшиз";
+				presenceData.state = "Их так много...";
 			}
 			break;
 		case "publisher":
@@ -326,6 +387,12 @@ presence.on("UpdateData", async () => {
 						publisherData.rus_name ?? publisherData.name
 					} (${publisherData.name})`;
 					presenceData.largeImageKey = publisherData.cover.default;
+					presenceData.buttons = [
+						{
+							label: "Открыть издателя",
+							url: cleanUrl(document.location),
+						},
+					];
 				}
 			} else {
 				presenceData.details = "Страница издетелей";
@@ -352,16 +419,43 @@ presence.on("UpdateData", async () => {
 					presenceData.details = "Читает новость";
 					presenceData.state = `${title} от ${username}`;
 					presenceData.largeImageKey = avatar;
+					presenceData.smallImageKey = Assets.Logo;
+					presenceData.buttons = [
+						{
+							label: "Открыть новость",
+							url: cleanUrl(document.location),
+						},
+					];
 				}
 			} else {
 				presenceData.details = "На странице новостей";
 				presenceData.state = "Ищет, чего бы почитать";
 			}
 			break;
+		case "faq":
+			if (path.split("/")[3]) {
+				if (document.querySelector("h1")) {
+					presenceData.details = "Страница вопросов и ответов";
+					presenceData.state = document.querySelector("h1").textContent;
+					presenceData.buttons = [
+						{
+							label: "Открыть страницу",
+							url: cleanUrl(document.location),
+						},
+					];
+				}
+			} else {
+				presenceData.details = "Страница вопросов и ответов";
+				presenceData.state = "Ответ на любой вопрос здесь!";
+			}
+			break;
 		default:
 			presenceData.details = "Где-то...";
 			presenceData.state = "Не пытайтесь найти!";
+			break;
 	}
+
+	if (!buttonsSetting) delete presenceData.buttons;
 
 	presence.setActivity(presenceData);
 });


### PR DESCRIPTION
feat(AnimeLib): add supprot for 'faq' page

fix(AnimeLib): wrong else block position in 'franchise' case

Since the else block was in a wrong position, the browsing franchises state was never shown.

style(AnimeLib): change activity style for 'news', 'user' 'team' cases

Added a site logo to smallImageKey

## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

(Feat) Buttons:
![image](https://github.com/user-attachments/assets/136b214d-3dcf-4888-a944-7e905cb8d418)
The Show Buttons setting goes with it as well
![image](https://github.com/user-attachments/assets/e1cd3b74-f744-4259-99b5-f200a5476e4e)
![image](https://github.com/user-attachments/assets/c44597ca-1241-4249-bbc7-13b5022d4b64)
![image](https://github.com/user-attachments/assets/3c7926d7-28b8-4db7-b36a-05883a87f36f)

(Feat) Support for 'faq' page
![image](https://github.com/user-attachments/assets/f2e4c3f1-d9f9-46e2-a49d-75f2cbad249e)

(Fix) Browsing franchises state
![image](https://github.com/user-attachments/assets/fe9a7c0b-23a2-40a9-8857-77c90408afc8)


</details>
