### PR TITLE
feat(AnimeLib): add support for 'messages' and 'downloads' cases

### DIFF
--- a/websites/A/AnimeLib/metadata.json
+++ b/websites/A/AnimeLib/metadata.json
@@ -14,7 +14,7 @@
 		"ru": "Смотрите аниме онлайн на русском"
 	},
 	"url": "anilib.me",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeLib/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeLib/assets/thumbnail.png",
 	"color": "#A020F0",

--- a/websites/A/AnimeLib/presence.ts
+++ b/websites/A/AnimeLib/presence.ts
@@ -237,20 +237,25 @@ presence.on("UpdateData", async () => {
 			break;
 		case "user":
 			if (path.split("/")[3]) {
-				userData = await AnimeLib.getUser(path.split("/")[3]).then(
-					response => <UserData>response.data
-				);
+				if (path.split("/")[3] === "notifications") {
+					presenceData.details = "Страница уведомлений";
+					presenceData.state = "Что-то новенькое?";
+				} else {
+					userData = await AnimeLib.getUser(path.split("/")[3]).then(
+						response => <UserData>response.data
+					);
 
-				presenceData.details = "Страница пользователя";
-				presenceData.state = userData.username;
-				presenceData.largeImageKey = userData.avatar.url;
-				presenceData.smallImageKey = Assets.Logo;
-				presenceData.buttons = [
-					{
-						label: "Открыть профиль",
-						url: cleanUrl(document.location),
-					},
-				];
+					presenceData.details = "Страница пользователя";
+					presenceData.state = userData.username;
+					presenceData.largeImageKey = userData.avatar.url;
+					presenceData.smallImageKey = Assets.Logo;
+					presenceData.buttons = [
+						{
+							label: "Открыть профиль",
+							url: cleanUrl(document.location),
+						},
+					];
+				}
 			} else {
 				presenceData.details = "Страница пользователей";
 				presenceData.state = "Столько интересных личностей!";
@@ -448,6 +453,14 @@ presence.on("UpdateData", async () => {
 				presenceData.details = "Страница вопросов и ответов";
 				presenceData.state = "Ответ на любой вопрос здесь!";
 			}
+			break;
+		case "messages":
+			presenceData.details = "В личных сообщениях";
+			presenceData.state = "С кем-то общается...";
+			break;
+		case "downloads":
+			presenceData.details = "Страница загрузок";
+			presenceData.state = "Просматривает загруженные материалы";
 			break;
 		default:
 			presenceData.details = "Где-то...";


### PR DESCRIPTION
feat(AnimeLib): add support for 'notifications' under 'user' case

## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/user-attachments/assets/4fb1b339-2767-42c4-b7c4-29bd6d053a8c)
![image](https://github.com/user-attachments/assets/dd1fe669-a447-4221-b5dd-f61339c521fe)
![image](https://github.com/user-attachments/assets/384458f7-4ea5-47dc-bc1b-9dda94886e36)

</details>
