### PR TITLE
feat(U-NEXT): add activity

### DIFF
--- a/websites/U/U-NEXT/U-NEXT.json
+++ b/websites/U/U-NEXT/U-NEXT.json
@@ -1,0 +1,30 @@
+{
+  "unext.latest": {
+    "description": "{0} will be replaced with a new line, but if you leave it out, the string will be in just 1 line.",
+    "message": "Viewing what's new and{0}popular on U-NEXT"
+  },
+  "unext.profile": {
+    "description": "",
+    "message": "Managing their profiles"
+  },
+  "unext.referral": {
+    "description": "{0} will be replaced with a new line, but if you leave it out, the string will be in just 1 line.",
+    "message": "Getting their{0}referral link"
+  },
+  "unext.viewList": {
+    "description": "List as in their saved series/movies.",
+    "message": "Viewing their list"
+  },
+  "unext.seriesDisplay.full": {
+    "description": "Shown when watching a series with 'watching seriesname' status, example: Season 6, Episode 2",
+    "message": "Episode {0}"
+  },
+  "unext.seriesDisplay.short": {
+    "description": "Shown when watching a series with 'watching U-NEXT' status, example: S6 E2 - Episode title",
+    "message": "E{0} - {1}"
+  },
+  "unext.movieDisplay": {
+    "description": "Shown when watching a movie, example: 2024 • 120 minutes",
+    "message": "{0} • {1} minutes"
+  }
+}

--- a/websites/U/U-NEXT/U-NEXT.json
+++ b/websites/U/U-NEXT/U-NEXT.json
@@ -1,33 +1,33 @@
 {
-  "unext.latest": {
+  "u-next.latest": {
     "description": "{0} will be replaced with a new line, but if you leave it out, the string will be in just 1 line.",
     "message": "Viewing what's new and{0}popular on U-NEXT"
   },
-  "unext.profile": {
+  "u-next.profile": {
     "description": "",
     "message": "Managing their profiles"
   },
-  "unext.referral": {
+  "u-next.referral": {
     "description": "{0} will be replaced with a new line, but if you leave it out, the string will be in just 1 line.",
     "message": "Getting their{0}referral link"
   },
-  "unext.viewList": {
+  "u-next.viewList": {
     "description": "List as in their saved series/movies.",
     "message": "Viewing their list"
   },
-  "unext.seriesDisplay.full": {
+  "u-next.seriesDisplay.full": {
     "description": "Shown when watching a series with 'watching seriesname' status, example: Season 6, Episode 2",
     "message": "Episode {0}"
   },
-  "unext.seriesDisplay.short": {
+  "u-next.seriesDisplay.short": {
     "description": "Shown when watching a series with 'watching U-NEXT' status, example: S6 E2 - Episode title",
     "message": "E{0} - {1}"
   },
-  "unext.movieDisplay": {
+  "u-next.movieDisplay": {
     "description": "Shown when watching a movie, example: 2024 • 120 minutes",
     "message": "{0} • {1} minutes"
   },
-  "unext.liveDisplay": {
+  "u-next.liveDisplay": {
     "description": "Shown when watching a livestream, example: 2024 • 120 minutes",
     "message": "{0} • {1} minutes"
   }

--- a/websites/U/U-NEXT/U-NEXT.json
+++ b/websites/U/U-NEXT/U-NEXT.json
@@ -1,20 +1,4 @@
 {
-  "u-next.latest": {
-    "description": "{0} will be replaced with a new line, but if you leave it out, the string will be in just 1 line.",
-    "message": "Viewing what's new and{0}popular on U-NEXT"
-  },
-  "u-next.profile": {
-    "description": "",
-    "message": "Managing their profiles"
-  },
-  "u-next.referral": {
-    "description": "{0} will be replaced with a new line, but if you leave it out, the string will be in just 1 line.",
-    "message": "Getting their{0}referral link"
-  },
-  "u-next.viewList": {
-    "description": "List as in their saved series/movies.",
-    "message": "Viewing their list"
-  },
   "u-next.seriesDisplay.full": {
     "description": "Shown when watching a series with 'watching seriesname' status, example: Season 6, Episode 2",
     "message": "Episode {0}"

--- a/websites/U/U-NEXT/U-NEXT.json
+++ b/websites/U/U-NEXT/U-NEXT.json
@@ -26,5 +26,9 @@
   "unext.movieDisplay": {
     "description": "Shown when watching a movie, example: 2024 • 120 minutes",
     "message": "{0} • {1} minutes"
+  },
+  "unext.liveDisplay": {
+    "description": "Shown when watching a livestream, example: 2024 • 120 minutes",
+    "message": "{0} • {1} minutes"
   }
 }

--- a/websites/U/U-NEXT/functions/fetchLiveMetadata.ts
+++ b/websites/U/U-NEXT/functions/fetchLiveMetadata.ts
@@ -1,0 +1,47 @@
+import pLimit from "p-limit";
+import { LiveRoot } from "../types";
+
+const limit = pLimit(1);
+
+export let liveMetadata: {
+	url: string;
+	data?: LiveRoot;
+} | null = null;
+
+export async function fetchLiveMetadata(id: string): Promise<void> {
+	await limit(async () => {
+		if (liveMetadata?.url === document.location.href) return;
+
+		const getLiveDetailResponse = await fetch("https://cc.unext.jp/", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({
+				operationName: "cosmo_getLiveDetail",
+				variables: {
+					liveCode: id,
+				},
+				extensions: {
+					persistedQuery: {
+						version: 1,
+						sha256Hash:
+							"02f3512167abdfa1ebc3ba0fba04f54d2ccf5203e3e5639cbe36e5b844cbee38",
+					},
+				},
+			}),
+		});
+
+		liveMetadata = {
+			url: document.location.href,
+			data: {
+				webfrontGetLive: (await getLiveDetailResponse.json()).data
+					.webfront_getLive,
+			},
+		};
+	});
+}
+
+export function clearLiveMetadata(): void {
+	liveMetadata = null;
+}

--- a/websites/U/U-NEXT/functions/fetchMetadata.ts
+++ b/websites/U/U-NEXT/functions/fetchMetadata.ts
@@ -1,0 +1,70 @@
+import pLimit from "p-limit";
+import { Root } from "../types";
+
+const limit = pLimit(1);
+
+export let metadata: {
+	url: string;
+	data?: Root;
+} | null = null;
+
+export async function fetchMetadata(id: string): Promise<void> {
+	await limit(async () => {
+		if (metadata?.url === document.location.href) return;
+
+		const getVideoTitleResponse = await fetch("https://cc.unext.jp/", {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					operationName: "cosmo_getVideoTitle",
+					variables: {
+						code: id,
+					},
+					extensions: {
+						persistedQuery: {
+							version: 1,
+							sha256Hash:
+								"9c27258639966cfe47ebf308f155c3107d7489ed421b4d6e5ea61c3dd3c06c57",
+						},
+					},
+				}),
+			}),
+			getVideoTitleEpisodesResponse = await fetch("https://cc.unext.jp/", {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					operationName: "cosmo_getVideoTitleEpisodes",
+					variables: {
+						code: id,
+						page: 1,
+						pageSize: 20,
+					},
+					extensions: {
+						persistedQuery: {
+							version: 1,
+							sha256Hash:
+								"a2ee1b5c371aa0385a45bd8066671e50b8e618312246356a4d6b3feaf50d6a93",
+						},
+					},
+				}),
+			});
+
+		metadata = {
+			url: document.location.href,
+			data: {
+				webfrontTitleStage: (await getVideoTitleResponse.json()).data
+					.webfront_title_stage,
+				webfrontTitleTitleEpisodes: (await getVideoTitleEpisodesResponse.json())
+					.data.webfront_title_titleEpisodes,
+			},
+		};
+	});
+}
+
+export function clearMetadata(): void {
+	metadata = null;
+}

--- a/websites/U/U-NEXT/metadata.json
+++ b/websites/U/U-NEXT/metadata.json
@@ -12,7 +12,7 @@
 	],
 	"description": {
 		"en": "U-NEXT, operated by U-NEXT Corporation, a subsidiary of U-NEXT HOLDINGS, is a leading Japanese streaming platform offering over-the-top (OTT) content. As of May 2024, it boasts approximately 4.34 million paying subscribers, making it the largest homegrown video-on-demand (VOD) service in Japan.",
-		"ja": "U-NEXTは、U-NEXT HOLDINGS子会社の株式会社U-NEXTが運営する、日本のOTTコンテンツ・プラットフォーム。有料会員数は2024年5月時点で約434万人で、国産のVODサービスとしては最大手。"
+		"ja_JP": "U-NEXTは、U-NEXT HOLDINGS子会社の株式会社U-NEXTが運営する、日本のOTTコンテンツ・プラットフォーム。有料会員数は2024年5月時点で約434万人で、国産のVODサービスとしては最大手。"
 	},
 	"url": [
 		"video.unext.jp",

--- a/websites/U/U-NEXT/metadata.json
+++ b/websites/U/U-NEXT/metadata.json
@@ -20,7 +20,7 @@
 	],
 	"version": "1.0.0",
 	"logo": "https://i.imgur.com/tuSR9Ef.png",
-	"thumbnail": "https://www.unext.co.jp/static/images/top/placeholder.jpg",
+	"thumbnail": "https://i.imgur.com/UX5e7Vk.png",
 	"color": "#000000",
 	"category": "videos",
 	"tags": [

--- a/websites/U/U-NEXT/metadata.json
+++ b/websites/U/U-NEXT/metadata.json
@@ -1,0 +1,94 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.12",
+	"apiVersion": 1,
+	"author": {
+		"name": "KohnoseLami",
+		"id": "1180088441459978261"
+	},
+	"contributors": [],
+	"service": "U-NEXT",
+	"altnames": [
+		"ユーネクスト"
+	],
+	"description": {
+		"en": "U-NEXT, operated by U-NEXT Corporation, a subsidiary of U-NEXT HOLDINGS, is a leading Japanese streaming platform offering over-the-top (OTT) content. As of May 2024, it boasts approximately 4.34 million paying subscribers, making it the largest homegrown video-on-demand (VOD) service in Japan.",
+		"ja": "U-NEXTは、U-NEXT HOLDINGS子会社の株式会社U-NEXTが運営する、日本のOTTコンテンツ・プラットフォーム。有料会員数は2024年5月時点で約434万人で、国産のVODサービスとしては最大手。"
+	},
+	"url": [
+		"video.unext.jp",
+		"unext.jp"
+	],
+	"version": "1.0.0",
+	"logo": "https://i.imgur.com/tuSR9Ef.png",
+	"thumbnail": "https://www.unext.co.jp/static/images/top/placeholder.jpg",
+	"color": "#000000",
+	"category": "videos",
+	"tags": [
+		"u-next",
+		"video",
+		"media"
+	],
+	"settings": [
+		{
+			"id": "lang",
+			"multiLanguage": true
+		},
+		{
+			"id": "privacy",
+			"title": "Privacy Mode",
+			"icon": "fad fa-user-secret",
+			"value": false
+		},
+		{
+			"id": "usePresenceName",
+			"title": "Show Title as Presence",
+			"icon": "fad fa-user-edit",
+			"value": true,
+			"if": {
+				"privacy": false
+			}
+		},
+		{
+			"id": "showBrowsingStatus",
+			"title": "Show Browsing Status",
+			"icon": "fad fa-book-reader",
+			"value": true
+		},
+		{
+			"id": "showCover",
+			"if": {
+				"privacy": false
+			},
+			"title": "Show Cover",
+			"icon": "fas fa-images",
+			"value": true
+		},
+		{
+			"id": "showMovies",
+			"title": "Show Movies",
+			"icon": "fad fa-camera-movie",
+			"value": true
+		},
+		{
+			"id": "showSeries",
+			"title": "Show Series",
+			"icon": "fad fa-film",
+			"value": true
+		},
+		{
+			"id": "showSmallImages",
+			"title": "Show Small Images",
+			"icon": "fad fa-pause",
+			"value": true
+		},
+		{
+			"id": "timestamp",
+			"title": "Show Timestamps",
+			"icon": "fad fa-stopwatch",
+			"value": true,
+			"if": {
+				"privacy": false
+			}
+		}
+	]
+}

--- a/websites/U/U-NEXT/package-lock.json
+++ b/websites/U/U-NEXT/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "U-NEXT",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "p-limit": "5.0.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/websites/U/U-NEXT/package.json
+++ b/websites/U/U-NEXT/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "p-limit": "5.0.0"
+  }
+}

--- a/websites/U/U-NEXT/presence.ts
+++ b/websites/U/U-NEXT/presence.ts
@@ -26,10 +26,10 @@ const presence = new Presence({
 				watchEpisode: "general.buttonViewEpisode",
 				watchMovie: "general.buttonWatchMovie",
 				watchStream: "general.buttonWatchStream",
-				seriesDisplayFull: "unext.seriesDisplay.full",
-				seriesDisplayShort: "unext.seriesDisplay.short",
-				movieDisplay: "unext.movieDisplay",
-				liveDisplay: "unext.liveDisplay",
+				seriesDisplayFull: "u-next.seriesDisplay.full",
+				seriesDisplayShort: "u-next.seriesDisplay.short",
+				movieDisplay: "u-next.movieDisplay",
+				liveDisplay: "u-next.liveDisplay",
 			},
 			await presence.getSetting<string>("lang").catch(() => "en")
 		);

--- a/websites/U/U-NEXT/presence.ts
+++ b/websites/U/U-NEXT/presence.ts
@@ -3,6 +3,11 @@ import {
 	fetchMetadata,
 	metadata,
 } from "./functions/fetchMetadata";
+import {
+	clearLiveMetadata,
+	fetchLiveMetadata,
+	liveMetadata,
+} from "./functions/fetchLiveMetadata";
 
 const presence = new Presence({
 		clientId: "1325519017527476316",
@@ -15,13 +20,16 @@ const presence = new Presence({
 				browse: "general.browsing",
 				watchingMovie: "general.watchingMovie",
 				watchingSeries: "general.watchingSeries",
+				watchingLive: "general.watchingLive",
 				viewSeries: "general.buttonViewSeries",
 				viewMovies: "general.buttonViewMovie",
 				watchEpisode: "general.buttonViewEpisode",
 				watchMovie: "general.buttonWatchMovie",
+				watchStream: "general.buttonWatchStream",
 				seriesDisplayFull: "unext.seriesDisplay.full",
 				seriesDisplayShort: "unext.seriesDisplay.short",
 				movieDisplay: "unext.movieDisplay",
+				liveDisplay: "unext.liveDisplay",
 			},
 			await presence.getSetting<string>("lang").catch(() => "en")
 		);
@@ -209,6 +217,101 @@ presence.on("UpdateData", async () => {
 
 	//* Reset because no data can be fetched
 	clearMetadata();
+
+	const browsingLiveId = path.match(/lc=(\w+)/);
+
+	if (browsingLiveId) {
+		if (privacyMode) return presence.clearActivity();
+
+		await fetchLiveMetadata(browsingLiveId[1]);
+
+		return await presence.setActivity({
+			details: liveMetadata.data.webfrontGetLive.name,
+			state: liveMetadata.data.webfrontGetLive.attractions.slice(0, 128),
+			largeImageKey: !showCover
+				? "https://i.imgur.com/tuSR9Ef.png"
+				: `https://${liveMetadata.data.webfrontGetLive.notices[0].thumbnail.standard}`,
+			...(showSmallImages && {
+				smallImageKey: Assets.Reading,
+			}),
+			smallImageText: strings.browse,
+			buttons: [
+				{
+					label: strings.watchStream,
+					url: document.location.href,
+				},
+			],
+		});
+	}
+
+	//* Match /live/liv and get liv
+	const watchingLiveId = path.match(/\/live\/(\w+)/);
+	if (watchingLiveId) {
+		await fetchLiveMetadata(watchingLiveId[1]);
+		const video = document.querySelector("video");
+
+		if (!video) return;
+
+		const { paused } = video,
+			[startTimestamp, endTimestamp] = presence.getTimestampsfromMedia(video);
+
+		if (privacyMode) {
+			return await presence.setActivity({
+				type: ActivityType.Watching,
+				details: strings.watchingLive,
+				largeImageKey: "https://i.imgur.com/tuSR9Ef.png",
+			});
+		}
+
+		return await presence.setActivity({
+			type: ActivityType.Watching,
+			details: liveMetadata.data.webfrontGetLive.name,
+			state: strings.liveDisplay
+				.replace(
+					"{0}",
+					new Date(liveMetadata.data.webfrontGetLive.deliveryStartDateTime)
+						.getFullYear()
+						.toString()
+				)
+				.replace(
+					"{1}",
+					Math.floor(
+						(new Date(
+							liveMetadata.data.webfrontGetLive.deliveryEndDateTime
+						).getTime() -
+							new Date(
+								liveMetadata.data.webfrontGetLive.deliveryStartDateTime
+							).getTime()) /
+							1000 /
+							60
+					).toString()
+				),
+			largeImageKey: !showCover
+				? "https://i.imgur.com/tuSR9Ef.png"
+				: `https://${liveMetadata.data.webfrontGetLive.notices[0].thumbnail.standard}`,
+			...(showSmallImages && {
+				smallImageKey: paused ? Assets.Pause : Assets.Play,
+			}),
+			smallImageText: paused ? strings.pause : strings.play,
+			...(showTimestamp &&
+				!paused && {
+					startTimestamp,
+					endTimestamp,
+				}),
+			...(usePresenceName && {
+				name: liveMetadata.data.webfrontGetLive.name,
+			}),
+			buttons: [
+				{
+					label: strings.watchStream,
+					url: document.location.href.split("?")[0],
+				},
+			],
+		});
+	}
+
+	//* Reset because no data can be fetched
+	clearLiveMetadata();
 
 	if (showBrowsingStatus && !privacyMode) {
 		return await presence.setActivity({

--- a/websites/U/U-NEXT/presence.ts
+++ b/websites/U/U-NEXT/presence.ts
@@ -1,0 +1,222 @@
+import {
+	clearMetadata,
+	fetchMetadata,
+	metadata,
+} from "./functions/fetchMetadata";
+
+const presence = new Presence({
+		clientId: "1325519017527476316",
+	}),
+	getStrings = async () => {
+		return presence.getStrings(
+			{
+				play: "general.playing",
+				pause: "general.paused",
+				browse: "general.browsing",
+				watchingMovie: "general.watchingMovie",
+				watchingSeries: "general.watchingSeries",
+				viewSeries: "general.buttonViewSeries",
+				viewMovies: "general.buttonViewMovie",
+				watchEpisode: "general.buttonViewEpisode",
+				watchMovie: "general.buttonWatchMovie",
+				seriesDisplayFull: "unext.seriesDisplay.full",
+				seriesDisplayShort: "unext.seriesDisplay.short",
+				movieDisplay: "unext.movieDisplay",
+			},
+			await presence.getSetting<string>("lang").catch(() => "en")
+		);
+	};
+let oldLang: string = null,
+	strings: Awaited<ReturnType<typeof getStrings>>;
+
+presence.on("UpdateData", async () => {
+	const [
+		lang,
+		usePresenceName,
+		showTimestamp,
+		showBrowsingStatus,
+		showCover,
+		showSeries,
+		showMovies,
+		showSmallImages,
+		privacyMode,
+	] = await Promise.all([
+		presence.getSetting<string>("lang").catch(() => "en"),
+		presence.getSetting<boolean>("usePresenceName"),
+		presence.getSetting<boolean>("timestamp"),
+		presence.getSetting<boolean>("showBrowsingStatus"),
+		presence.getSetting<boolean>("showCover"),
+		presence.getSetting<boolean>("showSeries"),
+		presence.getSetting<boolean>("showMovies"),
+		presence.getSetting<boolean>("showSmallImages"),
+		presence.getSetting<boolean>("privacy"),
+	]);
+
+	if (oldLang !== lang) {
+		oldLang = lang;
+		strings = await getStrings();
+	}
+
+	const path = document.location.href,
+		//* Match /title/sid and get sid (When you load the page / reload while browsing)
+		browsingMediaId =
+			path.match(/\/title\/(\w+)/) ??
+			//* ?td=td when normally browsing and clicking on smth
+			path.match(/td=(\w+)/);
+
+	if (browsingMediaId) {
+		if (privacyMode) return presence.clearActivity();
+
+		await fetchMetadata(browsingMediaId[1]);
+
+		return await presence.setActivity({
+			details: metadata.data.webfrontTitleStage.titleName,
+			state: metadata.data.webfrontTitleStage.attractions.slice(0, 128),
+			largeImageKey: !showCover
+				? "https://i.imgur.com/tuSR9Ef.png"
+				: `https://${metadata.data.webfrontTitleStage.thumbnail.standard}`,
+			...(showSmallImages && {
+				smallImageKey: Assets.Reading,
+			}),
+			smallImageText: strings.browse,
+			buttons: [
+				{
+					label: metadata.data.webfrontTitleStage.keyEpisodes.current
+						.existsRelatedEpisode
+						? strings.viewMovies
+						: strings.viewSeries,
+					url: document.location.href,
+				},
+			],
+		});
+	}
+
+	//* Match /play/sid/ed and get ed
+	const watchingMediaId = path.match(/\/play\/(\w+)\/(\w+)/);
+	if (watchingMediaId) {
+		await fetchMetadata(watchingMediaId[1]);
+		const video = document.querySelector("video");
+
+		if (!video) return;
+
+		const { paused } = video,
+			[startTimestamp, endTimestamp] = presence.getTimestampsfromMedia(video);
+
+		if (
+			metadata.data.webfrontTitleStage.keyEpisodes.current
+				.existsRelatedEpisode &&
+			showSeries
+		) {
+			if (privacyMode) {
+				return await presence.setActivity({
+					type: ActivityType.Watching,
+					details: strings.watchingSeries,
+					largeImageKey: "https://i.imgur.com/tuSR9Ef.png",
+				});
+			}
+
+			const episode = metadata.data.webfrontTitleTitleEpisodes.episodes.find(
+				e => !e.completeFlag
+			);
+
+			return await presence.setActivity({
+				type: ActivityType.Watching,
+				details: metadata.data.webfrontTitleStage.titleName,
+				state: strings.seriesDisplayShort
+					.replace("{0}", episode.displayNo)
+					.replace("{1}", episode.episodeName),
+				largeImageKey: !showCover
+					? "https://i.imgur.com/tuSR9Ef.png"
+					: `https://${metadata.data.webfrontTitleStage.thumbnail.standard}`,
+				...(showSmallImages && {
+					smallImageKey: paused ? Assets.Pause : Assets.Play,
+				}),
+				smallImageText: paused ? strings.pause : strings.play,
+				...(showTimestamp &&
+					!paused && {
+						startTimestamp,
+						endTimestamp,
+					}),
+				...(usePresenceName && {
+					name: metadata.data.webfrontTitleStage.titleName,
+					details: episode.episodeName,
+					state: strings.seriesDisplayFull.replace("{0}", episode.displayNo),
+				}),
+				buttons: [
+					{
+						label: strings.watchEpisode,
+						url: document.location.href.split("?")[0],
+					},
+					{
+						label: strings.viewSeries,
+						url: `https://video.unext.jp/?td=${metadata.data.webfrontTitleStage.id}`,
+					},
+				],
+			});
+		}
+
+		if (
+			!metadata.data.webfrontTitleStage.keyEpisodes.current
+				.existsRelatedEpisode &&
+			showMovies
+		) {
+			if (privacyMode) {
+				return await presence.setActivity({
+					type: ActivityType.Watching,
+					details: strings.watchingMovie,
+					largeImageKey: "https://i.imgur.com/tuSR9Ef.png",
+				});
+			}
+
+			return await presence.setActivity({
+				type: ActivityType.Watching,
+				details: metadata.data.webfrontTitleStage.titleName,
+				state: strings.movieDisplay
+					.replace("{0}", metadata.data.webfrontTitleStage.productionYear)
+					.replace(
+						"{1}",
+						Math.floor(
+							metadata.data.webfrontTitleStage.keyEpisodes.current.duration / 60
+						).toString()
+					),
+				largeImageKey: !showCover
+					? "https://i.imgur.com/tuSR9Ef.png"
+					: `https://${metadata.data.webfrontTitleStage.thumbnail.standard}`,
+				...(showSmallImages && {
+					smallImageKey: paused ? Assets.Pause : Assets.Play,
+				}),
+				smallImageText: paused ? strings.pause : strings.play,
+				...(showTimestamp &&
+					!paused && {
+						startTimestamp,
+						endTimestamp,
+					}),
+				...(usePresenceName && {
+					name: metadata.data.webfrontTitleStage.titleName,
+				}),
+				buttons: [
+					{
+						label: strings.watchMovie,
+						url: document.location.href.split("?")[0],
+					},
+				],
+			});
+		}
+
+		//* show Series & Movies disabled, clearactivity, nothing to show?
+		return presence.clearActivity();
+	}
+
+	//* Reset because no data can be fetched
+	clearMetadata();
+
+	if (showBrowsingStatus && !privacyMode) {
+		return await presence.setActivity({
+			details: strings.browse,
+			largeImageKey: "https://i.imgur.com/tuSR9Ef.png",
+			smallImageKey: Assets.Reading,
+			smallImageText: strings.browse,
+		});
+	}
+	return presence.clearActivity();
+});

--- a/websites/U/U-NEXT/presence.ts
+++ b/websites/U/U-NEXT/presence.ts
@@ -218,7 +218,11 @@ presence.on("UpdateData", async () => {
 	//* Reset because no data can be fetched
 	clearMetadata();
 
-	const browsingLiveId = path.match(/lc=(\w+)/);
+	//* Match /livedetail/liv and get liv (When you load the page / reload while browsing)
+	const browsingLiveId =
+		path.match(/\/livedetail\/(\w+)/) ??
+		//* ?lc=lc when normally browsing and clicking on smth
+		path.match(/lc=(\w+)/);
 
 	if (browsingLiveId) {
 		if (privacyMode) return presence.clearActivity();

--- a/websites/U/U-NEXT/types.ts
+++ b/websites/U/U-NEXT/types.ts
@@ -102,3 +102,65 @@ export type Root = {
 		__typename: string;
 	};
 };
+
+export type LiveRoot = {
+	webfrontGetLive: {
+		id: string;
+		name: string;
+		description: string;
+		attractions: string;
+		copyright: string;
+		note: string;
+		viewableDeviceText: string;
+		displayLiveMinute: number;
+		venue: string;
+		location: string;
+		deliveryStartDateTime: string;
+		deliveryEndDateTime: string;
+		displaySaleEndDateTime: unknown;
+		performanceStartDateTime: string;
+		isOnlyOn: boolean;
+		saleTypeCode: string;
+		allowsTimeshiftedPlayback: boolean;
+		timeshiftedPlaybackAllowedUntil: unknown;
+		paymentBadgeList: {
+			id: string;
+			name: string;
+			code: string;
+			__typename: string;
+		}[];
+		subContentList: {
+			typeCode: string;
+			publicStartDateTime: string;
+			publicEndDateTime: string;
+			__typename: string;
+		}[];
+		notices: {
+			id: string;
+			typeCode: string;
+			publicStartDateTime: string;
+			thumbnail: {
+				standard: string;
+				secondary: string;
+				__typename: string;
+			};
+			__typename: string;
+		}[];
+		tickets: unknown[];
+		purchased: boolean;
+		productLineupCodeList: string[];
+		hasPackRights: boolean;
+		testLiveId: string;
+		credits: {
+			personNameCode: string;
+			personName: string;
+			characterName: string;
+			castTypeName: string;
+			personCode: string;
+			__typename: string;
+		}[];
+		caution: string;
+		announcements: unknown[];
+		__typename: string;
+	};
+};

--- a/websites/U/U-NEXT/types.ts
+++ b/websites/U/U-NEXT/types.ts
@@ -1,0 +1,104 @@
+export type Root = {
+	webfrontTitleStage: {
+		id: string;
+		titleName: string;
+		rate: number;
+		userRate: number;
+		productionYear: string;
+		country: string;
+		catchphrase: string;
+		attractions: string;
+		story: string;
+		check: string;
+		seriesCode: string;
+		seriesName: string;
+		publicStartDate: string;
+		displayPublicEndDate: string;
+		restrictedCode: string;
+		copyright: string;
+		mainGenreId: string;
+		bookmarkStatus: boolean;
+		thumbnail: {
+			standard: string;
+			secondary: string;
+			__typename: string;
+		};
+		mainGenreName: string;
+		isNew: boolean;
+		exclusive: {
+			typeCode: unknown;
+			isOnlyOn: boolean;
+			__typename: string;
+		};
+		isOriginal: boolean;
+		lastEpisode: string;
+		updateOfWeek: number;
+		nextUpdateDateTime: string;
+		productLineupCodeList: string[];
+		hasMultiprice: boolean;
+		minimumPrice: number;
+		paymentBadgeList: unknown[];
+		nfreeBadge: string;
+		hasDub: boolean;
+		hasSubtitle: boolean;
+		saleText: string;
+		keyEpisodes: {
+			current: {
+				id: string;
+				interruption: number;
+				duration: number;
+				completeFlag: boolean;
+				displayDurationText: string;
+				existsRelatedEpisode: boolean;
+				playButtonName: string;
+				purchaseEpisodeLimitday: string;
+				saleTypeCode: string;
+				productLineupCodeList: string[];
+				hasPackRights: boolean;
+				__typename: string;
+			};
+			latest: unknown;
+			__typename: string;
+		};
+		publicMainEpisodeCount: number;
+		comingSoonMainEpisodeCount: number;
+		missingAlertText: string;
+		sakuhinNotices: unknown[];
+		hasPackRights: boolean;
+		__typename: string;
+	};
+	webfrontTitleTitleEpisodes: {
+		episodes: {
+			id: string;
+			episodeName: string;
+			purchaseEpisodeLimitday: string;
+			thumbnail: {
+				standard: string;
+				__typename: string;
+			};
+			duration: number;
+			displayNo: string;
+			interruption: number;
+			completeFlag: boolean;
+			saleTypeCode: string;
+			introduction: string;
+			saleText: string;
+			episodeNotices: unknown[];
+			isNew: boolean;
+			hasPackRights: boolean;
+			minimumPrice: number;
+			hasMultiplePrices: boolean;
+			productLineupCodeList: string[];
+			isPurchased: boolean;
+			__typename: string;
+		}[];
+		pageInfo: {
+			page: number;
+			pages: number;
+			pageSize: number;
+			results: number;
+			__typename: string;
+		};
+		__typename: string;
+	};
+};


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Add a presence for the Japanese VOD service U-NEXT.
This was created on a Netflix basis

Resolves: https://github.com/PreMiD/Presences/issues/7081

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
![image](https://github.com/user-attachments/assets/fd2e1a42-8ee7-4d3f-bfea-8286692d3e31)

![image](https://github.com/user-attachments/assets/da52d817-e184-4e33-82a3-39a5fa5c8649)

![image](https://github.com/user-attachments/assets/0145f629-4a98-406e-95df-f216f68f7143)

![image](https://github.com/user-attachments/assets/bd1d6cf3-58c9-4f8d-b160-770f9b1efe07)

![image](https://github.com/user-attachments/assets/b70a16d7-d871-4872-ab6e-e1d12704d394)




</details>
