### PR TITLE
chore(YouTube Music): update various things

### DIFF
--- a/websites/Y/YouTube Music/metadata.json
+++ b/websites/Y/YouTube Music/metadata.json
@@ -20,7 +20,7 @@
 		"vi_VN": "Một dịch vụ phát nhạc với các album, đĩa đơn, video, bản remix, và các tiết mục trực tiếp chính thức và hơn nữa cho Android, iOS và máy tính. Tất cả đều tại đây."
 	},
 	"url": "music.youtube.com",
-	"version": "3.0.24",
+	"version": "3.0.25",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/thumbnail.png",
 	"color": "#E40813",

--- a/websites/Y/YouTube Music/presence.ts
+++ b/websites/Y/YouTube Music/presence.ts
@@ -37,7 +37,7 @@ presence.on("UpdateData", async () => {
 				?.href.match(/v=([^&#]{5,})/)?.[1],
 		repeatMode = document
 			.querySelector('ytmusic-player-bar[slot="player-bar"]')
-			?.getAttribute("repeat-Mode_"),
+			?.getAttribute("repeat-mode"),
 		videoElement =
 			document.querySelector<HTMLVideoElement>("video.video-stream");
 
@@ -65,20 +65,17 @@ presence.on("UpdateData", async () => {
 		videoListenerAttached = false;
 	}
 
-	presenceData = null;
+	presenceData = {};
 
 	if (hidePaused && mediaSession?.playbackState !== "playing")
 		return presence.clearActivity();
 
 	if (["playing", "paused"].includes(mediaSession?.playbackState)) {
 		if (privacyMode) {
-			presenceData.type = ActivityType.Listening;
 			return presence.setActivity({
-				...(mediaSession.playbackState === "playing" && {
-					largeImageKey:
-						"https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/logo.png",
-					details: "Listening to music",
-				}),
+				type: ActivityType.Listening,
+				largeImageKey:
+					"https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/logo.png",
 			});
 		}
 
@@ -124,33 +121,34 @@ presence.on("UpdateData", async () => {
 		}
 
 		presenceData = {
+			type: ActivityType.Listening,
+			name: mediaSession.metadata.title,
 			largeImageKey: showCover
 				? mediaSession?.metadata?.artwork?.at(-1)?.src ??
 				  "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/1.png"
 				: "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/1.png",
-			details: mediaSession.metadata.title,
-			state: [mediaSession.metadata.artist, mediaSession.metadata.album]
-				.filter(Boolean)
-				.join(" - "),
+			details: mediaSession.metadata.album,
+			state: mediaSession.metadata.artist,
 			...(showButtons && {
 				buttons,
 			}),
-			smallImageKey:
-				mediaSession.playbackState === "paused"
-					? Assets.Pause
-					: repeatMode === "ONE"
-					? Assets.RepeatOne
-					: repeatMode === "ALL"
-					? Assets.Repeat
-					: Assets.Play,
-			smallImageText:
-				mediaSession.playbackState === "paused"
-					? "Paused"
-					: repeatMode === "ONE"
-					? "On loop"
-					: repeatMode === "ALL"
-					? "Playlist on loop"
-					: "Playing",
+			...(mediaSession.playbackState === "paused" ||
+			(repeatMode && repeatMode !== "NONE")
+				? {
+						smallImageKey:
+							mediaSession.playbackState === "paused"
+								? Assets.Pause
+								: repeatMode === "ONE"
+								? Assets.RepeatOne
+								: Assets.Repeat,
+						smallImageText:
+							mediaSession.playbackState === "paused"
+								? "Paused"
+								: repeatMode === "ONE"
+								? "On loop"
+								: "Playlist on loop",
+				  }
+				: null),
 			...(showTimestamps &&
 				mediaSession.playbackState === "playing" && {
 					startTimestamp: mediaTimestamps[0],
@@ -159,7 +157,6 @@ presence.on("UpdateData", async () => {
 		};
 	} else if (showBrowsing) {
 		if (privacyMode) {
-			presenceData.type = ActivityType.Listening;
 			return presence.setActivity({
 				largeImageKey:
 					"https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/logo.png",
@@ -173,6 +170,7 @@ presence.on("UpdateData", async () => {
 		}
 
 		presenceData = {
+			type: ActivityType.Playing,
 			largeImageKey:
 				"https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/logo.png",
 			details: "Browsing",
@@ -273,7 +271,6 @@ presence.on("UpdateData", async () => {
 		}
 	}
 
-	presenceData.type = ActivityType.Listening;
 	presence.setActivity(presenceData);
 });
 


### PR DESCRIPTION
## Description 
This pull request includes updates to the YouTube Music integration, focusing on metadata versioning and the presence update functionality. The most important changes include fixing attribute casing, initializing `presenceData` correctly, and updating the activity type and details for presence data. It now also shows "Listening to xyz" instead of "Listening to YouTube Music"

Metadata versioning:

* [`websites/Y/YouTube Music/metadata.json`](diffhunk://#diff-e1c3b8f15f102627384b3c2bf0e720c3e22ecabe59fcdcac3d653748b9f1bc58L23-R23): Updated the version from `3.0.24` to `3.0.25`.

Presence update functionality:

* [`websites/Y/YouTube Music/presence.ts`](diffhunk://#diff-5f14e1c675234b5bddcca686dffea56d54e32f294432a10d578ba3eeefdc2bb9L40-R40): Fixed the casing of the `repeat-mode` attribute to ensure proper retrieval of the repeat mode.
* [`websites/Y/YouTube Music/presence.ts`](diffhunk://#diff-5f14e1c675234b5bddcca686dffea56d54e32f294432a10d578ba3eeefdc2bb9L68-L81): Changed the initialization of `presenceData` from `null` to an empty object to avoid potential null reference errors.
* [`websites/Y/YouTube Music/presence.ts`](diffhunk://#diff-5f14e1c675234b5bddcca686dffea56d54e32f294432a10d578ba3eeefdc2bb9R124-R151): Updated the presence data structure to include the activity type and correctly set the details and state based on the media session metadata. [[1]](diffhunk://#diff-5f14e1c675234b5bddcca686dffea56d54e32f294432a10d578ba3eeefdc2bb9R124-R151) [[2]](diffhunk://#diff-5f14e1c675234b5bddcca686dffea56d54e32f294432a10d578ba3eeefdc2bb9L162) [[3]](diffhunk://#diff-5f14e1c675234b5bddcca686dffea56d54e32f294432a10d578ba3eeefdc2bb9R173) [[4]](diffhunk://#diff-5f14e1c675234b5bddcca686dffea56d54e32f294432a10d578ba3eeefdc2bb9L276)
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/user-attachments/assets/17d710a8-3747-4f2c-bb9d-5b2d11079d54)



</details>
