### PR TITLE
style(AnimeLib): change activity styling

### DIFF
--- a/websites/A/AnimeLib/lib.ts
+++ b/websites/A/AnimeLib/lib.ts
@@ -51,6 +51,8 @@ export interface CollectionData {
 	id: number;
 	name: string;
 	user: Author;
+	type: "titles" | "character" | "people";
+	adult: boolean;
 }
 
 export interface ReviewData {
@@ -93,6 +95,7 @@ interface Cover {
 }
 
 export type AgeRestriction =
+	| { id: 0; label: "Нет" }
 	| { id: 1; label: "6+" }
 	| { id: 2; label: "12+" }
 	| { id: 3; label: "16+" }

--- a/websites/A/AnimeLib/metadata.json
+++ b/websites/A/AnimeLib/metadata.json
@@ -14,7 +14,7 @@
 		"ru": "Смотрите аниме онлайн на русском"
 	},
 	"url": "anilib.me",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeLib/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeLib/assets/thumbnail.png",
 	"color": "#A020F0",

--- a/websites/A/AnimeLib/presence.ts
+++ b/websites/A/AnimeLib/presence.ts
@@ -48,6 +48,8 @@ presence.on("UpdateData", async () => {
 			largeImageKey: Assets.Logo,
 			type: ActivityType.Watching,
 			startTimestamp: browsingTimestamp,
+			largeImageText: "AnimeLib",
+			smallImageText: "AnimeLib",
 		},
 		[privacySetting, buttonsSetting] = await Promise.all([
 			presence.getSetting<boolean>("privacy"),
@@ -81,22 +83,20 @@ presence.on("UpdateData", async () => {
 				break;
 			}
 
-			if (animeData.toast) {
-				const cover =
-						document.querySelector<HTMLImageElement>(".cover__img")?.src,
-					title = document.querySelector("h1")?.textContent,
-					altTitle = document.querySelector("h2")?.textContent;
+			if (path.endsWith("/watch")) {
+				if (animeData.toast) {
+					presenceData.details = "Смотрит лицензированное аниме";
+					presenceData.state = "Информация пока что не доступна";
+					presenceData.buttons = [
+						{
+							label: "Открыть аниме",
+							url: cleanUrl(document.location),
+						},
+					];
 
-				if (cover && title && altTitle) {
-					presenceData.details = "Страница лицензированного аниме";
-					presenceData.state = `${title} (${altTitle})`;
-					presenceData.largeImageKey = cover;
+					break;
 				}
 
-				break;
-			}
-
-			if (path.endsWith("/watch")) {
 				const video = document.querySelector("video"),
 					dub =
 						document
@@ -109,14 +109,18 @@ presence.on("UpdateData", async () => {
 				if (dub) {
 					presenceData.details = animeData.rus_name;
 					presenceData.state = `${
-						document.querySelector("[id^='episode'][class*=' ']")
+						document.querySelector("[id^='episode'][class*=' '] > span")
 							?.textContent ??
 						document
 							.querySelectorAll(".btn.is-outline")[6]
 							?.querySelector("span")?.textContent ??
+						document
+							.querySelectorAll(".btn.is-outline")[7]
+							?.querySelector("span")?.textContent ??
 						"Фильм"
 					} | ${dub}`;
 					presenceData.largeImageKey = animeData.cover.default;
+					presenceData.largeImageText = animeData.rus_name;
 					presenceData.buttons = [
 						{
 							label: "Открыть аниме",
@@ -160,11 +164,34 @@ presence.on("UpdateData", async () => {
 					}
 				}
 			} else {
+				if (animeData.toast) {
+					const cover =
+							document.querySelector<HTMLImageElement>(".cover__img")?.src,
+						title = document.querySelector("h1")?.textContent,
+						altTitle = document.querySelector("h2")?.textContent;
+
+					if (cover && title && altTitle) {
+						presenceData.details = "Страница лицензированного аниме";
+						presenceData.state = `${title} (${altTitle})`;
+						presenceData.largeImageKey = cover;
+						presenceData.largeImageText = title;
+						presenceData.buttons = [
+							{
+								label: "Открыть аниме",
+								url: cleanUrl(document.location),
+							},
+						];
+					}
+
+					break;
+				}
+
 				presenceData.details = "Страница аниме";
 				presenceData.state = `${animeData.rus_name} (${
 					animeData.eng_name ?? animeData.name
 				})`;
 				presenceData.largeImageKey = animeData.cover.default;
+				presenceData.largeImageText = animeData.rus_name;
 				presenceData.buttons = [
 					{
 						label: "Открыть аниме",
@@ -187,6 +214,8 @@ presence.on("UpdateData", async () => {
 					presenceData.details = "Страница персонажа";
 					presenceData.state = `${characterData.rus_name} (${characterData.name})`;
 					presenceData.largeImageKey = characterData.cover.default;
+					presenceData.largeImageText = characterData.rus_name;
+					presenceData.smallImageKey = Assets.Logo;
 					presenceData.buttons = [
 						{
 							label: "Oткрыть персoнажа",
@@ -210,15 +239,18 @@ presence.on("UpdateData", async () => {
 						path.split("/")[3].split("-")[0]
 					).then(response => <PersonData>response.data);
 
-					presenceData.details = "Страница человека";
-					presenceData.state = `${
+					const name =
 						peopleData.rus_name !== ""
 							? peopleData.rus_name
 							: peopleData.alt_name !== ""
 							? peopleData.alt_name
-							: peopleData.name
-					} (${peopleData.name})`;
+							: peopleData.name;
+
+					presenceData.details = "Страница человека";
+					presenceData.state = `${name} (${peopleData.name})`;
 					presenceData.largeImageKey = peopleData.cover.default;
+					presenceData.largeImageText = name;
+					presenceData.smallImageKey = Assets.Logo;
 					presenceData.buttons = [
 						{
 							label: "Открыть человека",
@@ -248,6 +280,7 @@ presence.on("UpdateData", async () => {
 					presenceData.details = "Страница пользователя";
 					presenceData.state = userData.username;
 					presenceData.largeImageKey = userData.avatar.url;
+					presenceData.largeImageText = userData.username;
 					presenceData.smallImageKey = Assets.Logo;
 					presenceData.buttons = [
 						{
@@ -275,9 +308,30 @@ presence.on("UpdateData", async () => {
 						path.split("/")[3]
 					).then(response => <CollectionData>response.data);
 
-					presenceData.details = "Страница коллекции";
+					// Show collection viewing in privacy mode if it's enabled, or enforce it when collection was marked as for adults
+					if (privacySetting || collectionData.adult) {
+						setPrivacyMode(presenceData);
+						break;
+					}
+
+					let collectionType: string;
+					switch (collectionData.type) {
+						case "titles":
+							collectionType = "тайтлам";
+							break;
+						case "character":
+							collectionType = "персонажам";
+							break;
+						case "people":
+							collectionType = "людям";
+							break;
+					}
+
+					presenceData.details = `Коллекция по ${collectionType}`;
 					presenceData.state = `${collectionData.name} от ${collectionData.user.username}`;
-					presenceData.largeImageKey = collectionData.user.avatar.url;
+					presenceData.largeImageKey = Assets.Logo;
+					presenceData.smallImageKey = collectionData.user.avatar.url;
+					presenceData.smallImageText = collectionData.user.username;
 					presenceData.buttons = [
 						{
 							label: "Oткрыть кoллекцию",
@@ -308,9 +362,10 @@ presence.on("UpdateData", async () => {
 						break;
 					}
 
-					presenceData.details = `Страница отзыва на ${reviewData.related.rus_name}`;
+					presenceData.details = `Отзыв на ${reviewData.related.rus_name}`;
 					presenceData.state = `${reviewData.title} от ${reviewData.user.username}`;
 					presenceData.largeImageKey = reviewData.related.cover.default;
+					presenceData.largeImageText = reviewData.related.rus_name;
 					presenceData.smallImageKey = reviewData.user.avatar.url;
 					presenceData.smallImageText = reviewData.user.username;
 					presenceData.buttons = [
@@ -423,8 +478,9 @@ presence.on("UpdateData", async () => {
 				if (avatar && username && title) {
 					presenceData.details = "Читает новость";
 					presenceData.state = `${title} от ${username}`;
-					presenceData.largeImageKey = avatar;
-					presenceData.smallImageKey = Assets.Logo;
+					presenceData.largeImageKey = Assets.Logo;
+					presenceData.smallImageKey = avatar;
+					presenceData.smallImageText = username;
 					presenceData.buttons = [
 						{
 							label: "Открыть новость",


### PR DESCRIPTION
feat(AnimeLib): privacy mode for 'collections' case

feat(AnimeLib): add collection type in 'collections' case

Collection type is shown in the details and follows this format: "Коллекция по <type>" ("<type> collection")

feat(AnimeLib): add placeholder for unavailability to display info when watching a licensed anime

fix(AnimeLib): fail to get current episode number in specific window size

## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

> style(AnimeLib): change activity styling
> feat(AnimeLib): add collection type in 'collections' case
![image](https://github.com/user-attachments/assets/c7c2e63d-2923-4a9d-9171-3a5764aac382)
![image](https://github.com/user-attachments/assets/eba16bc4-32b2-467d-9742-23ab466bb8e1)
![image](https://github.com/user-attachments/assets/5c4d29d7-e0f6-442b-81b9-d4065e26f864)
![image](https://github.com/user-attachments/assets/3045dc08-a9d3-4d5e-9c86-6be9fd3572b5)

> feat(AnimeLib): add placeholder for unavailability to display info when watching a licensed anime
![image](https://github.com/user-attachments/assets/b0aead7b-463d-4332-8d8b-9af648103ca4)
![image](https://github.com/user-attachments/assets/cf4a1bf6-a4e5-49c8-a2db-e605ee8eeb6a)


</details>
