### PR TITLE
fix(Granblue Fantasy): handle no alive boss

### DIFF
--- a/websites/G/Granblue Fantasy/metadata.json
+++ b/websites/G/Granblue Fantasy/metadata.json
@@ -22,7 +22,7 @@
 		"vi_VN": "Trò chơi đóng vai Nhật Bản"
 	},
 	"url": "game.granbluefantasy.jp",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/G/Granblue%20Fantasy/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/G/Granblue%20Fantasy/assets/thumbnail.jpg",
 	"color": "#2F4F7A",

--- a/websites/G/Granblue Fantasy/presence.ts
+++ b/websites/G/Granblue Fantasy/presence.ts
@@ -153,7 +153,11 @@ presence.on("UpdateData", async () => {
 	} else if (href.includes("/#result"))
 		presenceData.details = "In a Quest result screen";
 	else if (href.includes("/#raid") || href.includes("/#raid_multi")) {
-		const boss = gameStatus?.boss?.param.find(x => x.alive);
+		const bosses = gameStatus?.boss?.param.sort(
+				(a, b) => parseInt(b.hpmax) - parseInt(a.hpmax)
+			),
+			boss = bosses?.find(x => x.alive) || bosses?.[0];
+
 		if (boss) {
 			if (boss.name.ja !== boss.name.en)
 				presenceData.details = `${boss.name.en} (${boss.name.ja})`;
@@ -180,8 +184,10 @@ presence.on("UpdateData", async () => {
 			).toFixed(2)}%]`;
 		}
 
-		if (turn && gameStatus?.turn)
-			presenceData.state += ` | Turn ${gameStatus.turn}`;
+		if (turn && gameStatus?.turn) {
+			if (!presenceData.state) presenceData.state = `Turn ${gameStatus.turn}`;
+			else presenceData.state += ` | Turn ${gameStatus.turn}`;
+		}
 
 		if (djeeta && gameStatus?.player) {
 			const charaAlive = gameStatus.player.param.find(x => x.leader);


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
- Get the highest Max HP boss of the stage (aka. the actual "boss")
- Handle not being able to find "alive" bosses when stage is cleared and user does not move to results page, making the concatenation of activity state `undefined | Turn x`
## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/user-attachments/assets/65bd3c4d-7244-4f08-8299-740a856ca174)

</details>
