### PR TITLE
fix(Prime Video): change regex

### DIFF
--- a/websites/P/Prime Video/metadata.json
+++ b/websites/P/Prime Video/metadata.json
@@ -14,13 +14,14 @@
 	"service": "Prime Video",
 	"description": {
 		"en": "Enjoy exclusive Amazon Originals as well as popular movies and TV shows. Watch anytime, anywhere. Start your free trial.",
+		"fr": "Découvrez les programmes Amazon Original exclusifs et de nombreux films et séries populaires. Regardez quand vous voulez, où vous voulez. Commencez votre essai gratuit.",
 		"de": "Spielfilme und Serien online streamen, als Einzelabruf online leihen oder kaufen bei Prime Video, Amazons großer Video on Demand Online-Videothek.",
 		"nl": "Geniet van exclusieve Amazon Originals en populaire films en tv-programma's. Bekijk altijd en overal. Start uw gratis proefperiode.",
 		"ja_JP": "ここでしか見れない、先行や独占配信作品が続々追加！まずは30日間無料でお試し"
 	},
 	"url": "www.primevideo.com",
-	"regExp": "(([a-z0-9-]+[.])*amazon([.][a-z]+)+([/](-[/]([a-z0-9]+)[/])?(Prime-Video|Prime-Instant-Video|Amazon-Video|gp[/]video)?)?)|([a-z0-9-]+[.])*primevideo([.][a-z]+)+([/]?)?",
-	"version": "2.1.30",
+	"regExp": "(([a-z0-9-]+[.])*amazon([.][a-z]+)+[/]((-[/])?(([a-z0-9]+)[/])?)?Prime-Video|Prime-Instant-Video|Amazon-Video|gp[/]video)|([a-z0-9-]+[.])*primevideo([.][a-z]+)+([/]?)?",
+	"version": "2.1.31",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/P/Prime%20Video/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/P/Prime%20Video/assets/thumbnail.jpg",
 	"color": "#FFFFFF",


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
fix #9058 
Change regex to include only Prime-related links and no longer include links such as amazon.com only


## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

Example of a URL captured :

![image](https://github.com/user-attachments/assets/bf8a0375-79a7-4935-844d-096bf8406a23)


</details>
