### PR TITLE
feat(types): allow setting largeImageKey for listening activites

### DIFF
--- a/@types/premid/index.d.ts
+++ b/@types/premid/index.d.ts
@@ -2,7 +2,7 @@
 /**
  * @link https://docs.premid.app/dev/presence/class#presencedata-interface
  */
-interface PresenceData {
+interface BasePresenceData {
 	/**
 	 * Name to show in activity
 	 * @example "YouTube"
@@ -101,6 +101,18 @@ interface PresenceData {
 	 */
 	buttons?: [ButtonData, ButtonData?];
 }
+
+interface ListeningPresenceData extends BasePresenceData {
+	type: ActivityType.Listening;
+	largeImageText?: string | Node;
+}
+
+interface NonListeningPresenceData extends BasePresenceData {
+	type?: Exclude<ActivityType, ActivityType.Listening>;
+	largeImageText?: never;
+}
+
+type PresenceData = ListeningPresenceData | NonListeningPresenceData;
 
 interface ButtonData {
 	/**


### PR DESCRIPTION
## Description 
Allow setting largeImageText for listening activity types as Discord fixed design inconsistencies across mobile & desktop versions with it now consistently showing as a third line