### PR TITLE
chore: update activities

### DIFF
--- a/@types/premid/index.d.ts
+++ b/@types/premid/index.d.ts
@@ -102,17 +102,17 @@ interface BasePresenceData {
 	buttons?: [ButtonData, ButtonData?];
 }
 
-interface ListeningPresenceData extends BasePresenceData {
-	type: ActivityType.Listening;
+interface MediaPresenceData extends BasePresenceData {
+	type: ActivityType.Listening | ActivityType.Watching;
 	largeImageText?: string | Node;
 }
 
-interface NonListeningPresenceData extends BasePresenceData {
+interface NonMediaPresenceData extends BasePresenceData {
 	type?: Exclude<ActivityType, ActivityType.Listening>;
 	largeImageText?: never;
 }
 
-type PresenceData = ListeningPresenceData | NonListeningPresenceData;
+type PresenceData = MediaPresenceData | NonMediaPresenceData;
 
 interface ButtonData {
 	/**

--- a/@types/premid/index.d.ts
+++ b/@types/premid/index.d.ts
@@ -108,7 +108,7 @@ interface MediaPresenceData extends BasePresenceData {
 }
 
 interface NonMediaPresenceData extends BasePresenceData {
-	type?: Exclude<ActivityType, ActivityType.Listening>;
+	type?: Exclude<ActivityType, ActivityType.Listening | ActivityType.Watching>;
 	largeImageText?: never;
 }
 

--- a/websites/D/Disney+/metadata.json
+++ b/websites/D/Disney+/metadata.json
@@ -5,6 +5,12 @@
 		"name": "Tiemen",
 		"id": "152164749868662784"
 	},
+	"contributors": [
+		{
+			"name": "Timeraa",
+			"id": "223238938716798978"
+		}
+	],
 	"service": "Disney+",
 	"description": {
 		"en": "Disney+ is the exclusive home for your favorite movies and TV shows from Disney, Pixar, Marvel, Star Wars, National Geographic, and Star. Start streaming today.",
@@ -22,7 +28,7 @@
 	},
 	"url": "www.disneyplus.com",
 	"regExp": "([a-z0-9-]+[.])*disneyplus[.]com[/]|([a-z0-9-]+[.])*hotstar[.]com[/]",
-	"version": "1.6.5",
+	"version": "1.7.0",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/D/Disney+/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/D/Disney+/assets/thumbnail.png",
 	"color": "#233778",

--- a/websites/D/Disney+/presence.ts
+++ b/websites/D/Disney+/presence.ts
@@ -1,3 +1,16 @@
+//* I think this is a browser bug because the custom element does not have any properties when accessing it directly...
+window.addEventListener("message", e => {
+	if (e.data.type === "pmd-receive-image-id") ({ imageId } = e.data);
+});
+
+const script = document.createElement("script");
+script.textContent = `
+setInterval(() => {
+	window.postMessage({ type: "pmd-receive-image-id", imageId: document.querySelector("disney-web-player")?.mediaPlayer?.mediaPlaybackCriteria?.metadata?.images_experience?.standard?.tile["1.00"]?.imageId }, "*");
+}, 100);
+`;
+document.head.appendChild(script);
+
 const presence: Presence = new Presence({
 		clientId: "630236276829716483",
 	}),
@@ -22,7 +35,8 @@ async function getStrings() {
 let strings: Awaited<ReturnType<typeof getStrings>>,
 	oldLang: string = null,
 	title: string,
-	subtitle: string;
+	subtitle: string,
+	imageId: string;
 
 presence.on("UpdateData", async () => {
 	const [newLang, privacy, time, buttons] = await Promise.all([
@@ -48,34 +62,54 @@ presence.on("UpdateData", async () => {
 				"https://cdn.rcd.gg/PreMiD/websites/D/Disney+/assets/logo.png";
 			switch (true) {
 				case pathname.includes("play"): {
+					const video =
+						document.querySelector<HTMLVideoElement>("video#hivePlayer");
+
+					//* Wait for elements to load to prevent setactivity spam
+					if (!imageId || !video) return;
+
+					presenceData.largeImageKey = `https://disney.images.edge.bamgrid.com/ripcut-delivery/v2/variant/disney/${imageId}/compose?format=png&width=512`;
+
 					if (!privacy) {
 						if (presenceData.startTimestamp) delete presenceData.startTimestamp;
 						presenceData.details = document.querySelector(
 							".title-field.body-copy"
 						)?.textContent;
-						presenceData.state =
-							document.querySelector(".subtitle-field")?.textContent;
 
-						const paused = !!document.querySelector("[aria-label='Play']"),
-							timeRemaining = document.querySelector(
-								".time-remaining-label"
-							)?.textContent;
+						const { paused } = video;
 
-						presenceData.smallImageKey = paused ? Assets.Pause : Assets.Play;
-						presenceData.smallImageText = paused ? strings.pause : strings.play;
-
-						if (!paused && timeRemaining) {
-							presenceData.endTimestamp =
-								Date.now() / 1000 + presence.timestampFromFormat(timeRemaining);
+						if (!paused) {
+							const sliderEl = document.querySelector(
+									".progress-bar .slider-container"
+								),
+								timestamps = presence.getTimestamps(
+									parseInt(sliderEl.getAttribute("aria-valuenow")),
+									parseInt(sliderEl.getAttribute("aria-valuemax"))
+								);
+							presenceData.startTimestamp = timestamps[0];
+							presenceData.endTimestamp = timestamps[1];
+						} else {
+							presenceData.smallImageKey = Assets.Pause;
+							presenceData.smallImageText = strings.pause;
 						}
-					} else presenceData.details = "Watching content";
 
-					presenceData.buttons = [
-						{
-							label: "Watch Content",
-							url: href,
-						},
-					];
+						const parts = document
+							.querySelector(".subtitle-field")
+							?.textContent.match(/S(\d+):E(\d+) /);
+						if (parts.length > 2)
+							presenceData.largeImageText = `Season ${parts[1]}, Episode ${parts[2]}`;
+
+						presenceData.state = document
+							.querySelector(".subtitle-field")
+							?.textContent.replace(/S(\d+):E(\d+) /, "");
+
+						presenceData.buttons = [
+							{
+								label: parts.length > 2 ? "Watch Episode" : "Watch Movie",
+								url: href,
+							},
+						];
+					} else presenceData.details = "Watching content";
 					break;
 				}
 				case pathname.includes("entity"): {

--- a/websites/D/Disney+/presence.ts
+++ b/websites/D/Disney+/presence.ts
@@ -105,7 +105,7 @@ presence.on("UpdateData", async () => {
 
 						presenceData.buttons = [
 							{
-								label: parts.length > 2 ? "Watch Episode" : "Watch Movie",
+								label: parts?.length > 2 ? "Watch Episode" : "Watch Movie",
 								url: href,
 							},
 						];

--- a/websites/D/Disney+/presence.ts
+++ b/websites/D/Disney+/presence.ts
@@ -96,7 +96,7 @@ presence.on("UpdateData", async () => {
 						const parts = document
 							.querySelector(".subtitle-field")
 							?.textContent.match(/S(\d+):E(\d+) /);
-						if (parts.length > 2)
+						if (parts?.length > 2)
 							presenceData.largeImageText = `Season ${parts[1]}, Episode ${parts[2]}`;
 
 						presenceData.state = document

--- a/websites/Y/YouTube Music/metadata.json
+++ b/websites/Y/YouTube Music/metadata.json
@@ -20,7 +20,7 @@
 		"vi_VN": "Một dịch vụ phát nhạc với các album, đĩa đơn, video, bản remix, và các tiết mục trực tiếp chính thức và hơn nữa cho Android, iOS và máy tính. Tất cả đều tại đây."
 	},
 	"url": "music.youtube.com",
-	"version": "3.0.25",
+	"version": "3.0.26",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/thumbnail.png",
 	"color": "#E40813",
@@ -34,6 +34,15 @@
 			"id": "privacy",
 			"title": "Privacy Mode",
 			"icon": "fad fa-shield-alt",
+			"value": false
+		},
+		{
+			"id": "showAsListening",
+			"title": "Show song in status",
+			"icon": "fad fa-music",
+			"if": {
+				"privacy": false
+			},
 			"value": false
 		},
 		{

--- a/websites/Y/YouTube Music/presence.ts
+++ b/websites/Y/YouTube Music/presence.ts
@@ -20,6 +20,7 @@ presence.on("UpdateData", async () => {
 			showBrowsing,
 			privacyMode,
 			useTimeLeft,
+			showAsListening,
 		] = await Promise.all([
 			presence.getSetting<boolean>("buttons"),
 			presence.getSetting<boolean>("timestamps"),
@@ -28,6 +29,7 @@ presence.on("UpdateData", async () => {
 			presence.getSetting<boolean>("browsing"),
 			presence.getSetting<boolean>("privacy"),
 			presence.getSetting<boolean>("useTimeLeft"),
+			presence.getSetting<boolean>("showAsListening"),
 		]),
 		{ mediaSession } = navigator,
 		watchID =
@@ -122,7 +124,7 @@ presence.on("UpdateData", async () => {
 
 		presenceData = {
 			type: ActivityType.Listening,
-			name: mediaSession.metadata.title,
+			name: showAsListening ? mediaSession.metadata.title : "YouTube Music",
 			largeImageKey: showCover
 				? mediaSession?.metadata?.artwork?.at(-1)?.src ??
 				  "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/1.png"


### PR DESCRIPTION
closes #9146
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

Update multiple activities and allow setting largeImageText for `Watching`.

YouTube music by default doesn't show the title but has an option

Disney+ got a lot of niche features, see Screenshot

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/user-attachments/assets/96ccc6fb-4dfa-40d6-ba0c-d456bfbaf3f6)


</details>
