### PR TITLE
feat(Freek): implement season and episode text through largeImageText

### DIFF
--- a/websites/F/Freek/metadata.json
+++ b/websites/F/Freek/metadata.json
@@ -10,7 +10,7 @@
 		"en": "Freek.to is a free movie, tv show and more streaming application, supporting high quality streams and friendly UI and UX experiences."
 	},
 	"url": "freek.to",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/F/Freek/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/F/Freek/assets/thumbnail.png",
 	"color": "#121212",

--- a/websites/F/Freek/presence.ts
+++ b/websites/F/Freek/presence.ts
@@ -127,9 +127,12 @@ presence.on("UpdateData", async () => {
 				presenceData.details = steamTitle;
 				presenceData.state = `📺 ${
 					episodeName
-						? `${episodeNumber}. ${episodeName?.textContent}`
+						? `${episodeName?.textContent}`
 						: `Episode ${episodeNumber}`
 				}`;
+				presenceData.largeImageText = `Season ${
+					href.includes("?season=") ? href.split("?season=")[1] : 1
+				}, Episode ${episodeNumber}`;
 				presenceData.largeImageKey = document
 					.querySelector(
 						"div.flex > div.false > span.lazy-load-image-background > img"

--- a/websites/F/Freek/presence.ts
+++ b/websites/F/Freek/presence.ts
@@ -73,7 +73,8 @@ presence.on("UpdateData", async () => {
 	};
 
 	for (const [path, data] of Object.entries(pages))
-		if (pathname.includes(path)) presenceData = { ...presenceData, ...data, type: ActivityType.Watching };
+		if (pathname.includes(path))
+			presenceData = { ...presenceData, ...data, type: ActivityType.Watching };
 
 	const pageNumber = href.includes("?page=") ? href.split("?page=")[1] : 1,
 		searchInput = document.querySelector("input")

--- a/websites/F/Freek/presence.ts
+++ b/websites/F/Freek/presence.ts
@@ -72,9 +72,10 @@ presence.on("UpdateData", async () => {
 		},
 	};
 
-	for (const [path, data] of Object.entries(pages))
+	for (const [path, data] of Object.entries(pages)) {
 		if (pathname.includes(path))
 			presenceData = { ...presenceData, ...data, type: ActivityType.Watching };
+	}
 
 	const pageNumber = href.includes("?page=") ? href.split("?page=")[1] : 1,
 		searchInput = document.querySelector("input")

--- a/websites/F/Freek/presence.ts
+++ b/websites/F/Freek/presence.ts
@@ -37,7 +37,6 @@ presence.on("UpdateData", async () => {
 	let presenceData: PresenceData = {
 		largeImageKey: Assets.Logo,
 		startTimestamp: browsingTimestamp,
-		type: ActivityType.Watching,
 		details: "Unsupported Page",
 	};
 
@@ -74,7 +73,7 @@ presence.on("UpdateData", async () => {
 	};
 
 	for (const [path, data] of Object.entries(pages))
-		if (pathname.includes(path)) presenceData = { ...presenceData, ...data };
+		if (pathname.includes(path)) presenceData = { ...presenceData, ...data, type: ActivityType.Watching };
 
 	const pageNumber = href.includes("?page=") ? href.split("?page=")[1] : 1,
 		searchInput = document.querySelector("input")


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
This pr implements the following:
- Implements season and episode details through largeImageText to utilise the Discord functionality of it.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/user-attachments/assets/9acc9f64-768b-4561-8d28-5e6d20571ebe)
![image](https://github.com/user-attachments/assets/5e931e7c-43f1-4fb0-9c84-e352aaed2856)

*Looking at this I am questioning how they have the exact same episode length 🤔*


</details>
