### PR TITLE
feat(Brave Search): use strings

### DIFF
--- a/websites/B/Brave Search/Brave Search.json
+++ b/websites/B/Brave Search/Brave Search.json
@@ -1,0 +1,42 @@
+{
+  "bravesearch.settings": {
+    "description": "Page name",
+    "message": "Viewing their settings..."
+  },
+  "bravesearch.help": {
+    "description": "Page name",
+    "message": "Help Center"
+  },
+  "bravesearch.searchImgFor": {
+	"description": "Displayed when the user is searching for an image. The search query will be displayed below.",
+	"message": "Searching images for:"
+  },
+  "bravesearch.searchImgSomething": {
+	"description": "Displayed when the user is searching for an image.",
+	"message": "Searching up images..."
+  },
+  "bravesearch.searchNewsFor": {
+	"description": "Displayed when the user is searching for a news. The search query will be displayed below.",
+	"message": "Searching news for:"
+  },
+  "bravesearch.searchNewsSomething": {
+	"description": "Displayed when the user is searching for a news.",
+	"message": "Searching up news..."
+  },
+  "bravesearch.searchGogglesFor": {
+	"description": "Displayed when the user is searching for an goggle. The search query will be displayed below.",
+	"message": "Searching goggles for:"
+  },
+  "bravesearch.searchGogglesSomething": {
+	"description": "Displayed when the user is searching for an goggle.",
+	"message": "Searching up goggles..."
+  },
+  "bravesearch.searchVidFor": {
+	"description": "Displayed when the user is searching for an video. The search query will be displayed below.",
+	"message": "Searching videos for:"
+  },
+  "bravesearch.searchVidSomething": {
+	"description": "Displayed when the user is searching for an video.",
+	"message": "Searching up videos..."
+  }
+}

--- a/websites/B/Brave Search/Brave Search.json
+++ b/websites/B/Brave Search/Brave Search.json
@@ -8,35 +8,35 @@
     "message": "Help Center"
   },
   "bravesearch.searchImgFor": {
-	"description": "Displayed when the user is searching for an image. The search query will be displayed below.",
-	"message": "Searching images for:"
+	  "description": "Displayed when the user is searching for an image. The search query will be displayed below.",
+	  "message": "Searching images for:"
   },
   "bravesearch.searchImgSomething": {
-	"description": "Displayed when the user is searching for an image.",
-	"message": "Searching up images..."
+	  "description": "Displayed when the user is searching for an image.",
+	  "message": "Searching up images..."
   },
   "bravesearch.searchNewsFor": {
-	"description": "Displayed when the user is searching for a news. The search query will be displayed below.",
-	"message": "Searching news for:"
+	  "description": "Displayed when the user is searching for a news. The search query will be displayed below.",
+	  "message": "Searching news for:"
   },
   "bravesearch.searchNewsSomething": {
-	"description": "Displayed when the user is searching for a news.",
-	"message": "Searching up news..."
+	  "description": "Displayed when the user is searching for a news.",
+	  "message": "Searching up news..."
   },
   "bravesearch.searchGogglesFor": {
-	"description": "Displayed when the user is searching for an goggle. The search query will be displayed below.",
-	"message": "Searching goggles for:"
+	  "description": "Displayed when the user is searching for an goggle. The search query will be displayed below.",
+	  "message": "Searching goggles for:"
   },
   "bravesearch.searchGogglesSomething": {
-	"description": "Displayed when the user is searching for an goggle.",
-	"message": "Searching up goggles..."
+	  "description": "Displayed when the user is searching for an goggle.",
+	  "message": "Searching up goggles..."
   },
   "bravesearch.searchVidFor": {
-	"description": "Displayed when the user is searching for an video. The search query will be displayed below.",
-	"message": "Searching videos for:"
+	  "description": "Displayed when the user is searching for an video. The search query will be displayed below.",
+	  "message": "Searching videos for:"
   },
   "bravesearch.searchVidSomething": {
-	"description": "Displayed when the user is searching for an video.",
-	"message": "Searching up videos..."
+	  "description": "Displayed when the user is searching for an video.",
+	  "message": "Searching up videos..."
   }
 }

--- a/websites/B/Brave Search/metadata.json
+++ b/websites/B/Brave Search/metadata.json
@@ -10,7 +10,7 @@
 		"en": "Search the Web. Privately. Truly useful results, AI-powered answers, & more. All from an independent index. No profiling, no bias, no Big Tech."
 	},
 	"url": "search.brave.com",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/B/Brave%20Search/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/B/Brave%20Search/assets/thumbnail.png",
 	"color": "#FB542B",

--- a/websites/B/Brave Search/metadata.json
+++ b/websites/B/Brave Search/metadata.json
@@ -24,6 +24,10 @@
 			"title": "Privacy Mode",
 			"icon": "fad fa-user-secret",
 			"value": false
+		},
+		{
+			"id": "lang",
+			"multiLanguage": true
 		}
 	]
 }

--- a/websites/B/Brave Search/presence.ts
+++ b/websites/B/Brave Search/presence.ts
@@ -5,9 +5,17 @@ const presence = new Presence({
 		search: "general.searchFor",
 		searchPrivate: "general.searchSomething",
 		home: "general.viewHome",
-		settings: "discord.settings",
-		help: "twitch.help",
 		viewPage: "general.viewPage",
+		settings: "bravesearch.settings",
+		help: "bravesearch.help",
+		searchNews: "bravesearch.searchNewsFor",
+		searchNewsPrivate: "bravesearch.searchNewsSomething",
+		searchVid: "bravesearch.searchVidFor",
+		searchVidPrivate: "bravesearch.searchVidSomething",
+		searchImg: "bravesearch.searchImgFor",
+		searchImgPrivate: "bravesearch.searchImgSomething",
+		searchGoggles: "bravesearch.searchNewsFor",
+		searchGogglesPrivate: "bravesearch.searchNewsSomething",
 	}),
 	browsingTimestamp = Math.floor(Date.now() / 1000);
 
@@ -48,19 +56,27 @@ presence.on("UpdateData", async () => {
 			break;
 		}
 		case "images": {
-			presenceData.details = `Searching images${!privacy ? ":" : "..."}`;
+			presenceData.details = !privacy
+				? (await strings).searchImg
+				: (await strings).searchImgPrivate;
 			break;
 		}
 		case "news": {
-			presenceData.details = `Searching news${!privacy ? ":" : "..."}`;
+			presenceData.details = !privacy
+				? (await strings).searchNews
+				: (await strings).searchNewsPrivate;
 			break;
 		}
 		case "videos": {
-			presenceData.details = `Searching videos${!privacy ? ":" : "..."}`;
+			presenceData.details = !privacy
+				? (await strings).searchVid
+				: (await strings).searchVidPrivate;
 			break;
 		}
 		case "goggles": {
-			presenceData.details = `Searching goggles${!privacy ? ":" : "..."}`;
+			presenceData.details = !privacy
+				? (await strings).searchGoggles
+				: (await strings).searchGogglesPrivate;
 			break;
 		}
 		default: {

--- a/websites/B/Brave Search/presence.ts
+++ b/websites/B/Brave Search/presence.ts
@@ -1,6 +1,14 @@
 const presence = new Presence({
 		clientId: "1293341957141303307",
 	}),
+	strings = presence.getStrings({
+		search: "general.searchFor",
+		searchPrivate: "general.searchSomething",
+		home: "general.viewHome",
+		settings: "discord.settings",
+		help: "twitch.help",
+		viewPage: "general.viewPage",
+	}),
 	browsingTimestamp = Math.floor(Date.now() / 1000);
 
 const enum Assets {
@@ -13,7 +21,7 @@ presence.on("UpdateData", async () => {
 		presenceData: PresenceData = {
 			largeImageKey: Assets.Logo,
 			startTimestamp: browsingTimestamp,
-			details: "In Home",
+			details: (await strings).home,
 			state: privacy
 				? // eslint-disable-next-line no-undefined
 				  undefined
@@ -22,21 +30,21 @@ presence.on("UpdateData", async () => {
 
 	switch (pathname.split("/")[1]) {
 		case "settings": {
-			presenceData.details = "Viewing Settings";
+			presenceData.details = (await strings).settings;
 			delete presenceData.state;
 			break;
 		}
 		case "help": {
-			if (!privacy) {
-				presenceData.details = "Viewing Help Page:";
-				presenceData.state = document
-					.querySelector(".post-title")
-					?.textContent?.trim();
-			} else presenceData.details = "Viewing Help Pages";
+			presenceData.details = (await strings).viewPage;
+			presenceData.state = !privacy
+				? document.querySelector(".post-title")?.textContent?.trim()
+				: (await strings).help;
 			break;
 		}
 		case "search": {
-			presenceData.details = `Searching${!privacy ? ":" : "..."}`;
+			presenceData.details = !privacy
+				? (await strings).search
+				: (await strings).searchPrivate;
 			break;
 		}
 		case "images": {


### PR DESCRIPTION
## Description 
Making Brave Search use strings to be a little multilanguage

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/user-attachments/assets/0da60e0a-d8ec-45e0-b589-c0db2d79df8e)
![image](https://github.com/user-attachments/assets/ddc19c89-05be-4f9a-b94c-44c56b345a72)
![image](https://github.com/user-attachments/assets/ccc66233-57b9-4258-8f84-f5259b9fb2a8)
![image](https://github.com/user-attachments/assets/af3dd087-77c1-4fee-b349-ea0e9a9dc492)



</details>
