### PR TITLE
fix(YouTube Music): only set largeImageText when needed

### DIFF
--- a/websites/Y/YouTube Music/metadata.json
+++ b/websites/Y/YouTube Music/metadata.json
@@ -20,7 +20,7 @@
 		"vi_VN": "Một dịch vụ phát nhạc với các album, đĩa đơn, video, bản remix, và các tiết mục trực tiếp chính thức và hơn nữa cho Android, iOS và máy tính. Tất cả đều tại đây."
 	},
 	"url": "music.youtube.com",
-	"version": "3.0.27",
+	"version": "3.0.28",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/thumbnail.png",
 	"color": "#E40813",

--- a/websites/Y/YouTube Music/presence.ts
+++ b/websites/Y/YouTube Music/presence.ts
@@ -131,7 +131,9 @@ presence.on("UpdateData", async () => {
 				: "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/1.png",
 			details: mediaSession.metadata.title,
 			state: mediaSession.metadata.artist,
-			largeImageText: mediaSession.metadata.album,
+			...(mediaSession.metadata.album && {
+				largeImageText: mediaSession.metadata.album,
+			}),
 			...(showButtons && {
 				buttons,
 			}),


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/user-attachments/assets/e947ed41-a5e3-492e-942b-5f26a18ede51)


</details>
