### PR TITLE
fix(YT:M): support for audio-only playback

### DIFF
--- a/websites/Y/YouTube Music/metadata.json
+++ b/websites/Y/YouTube Music/metadata.json
@@ -20,7 +20,7 @@
 		"vi": "Một dịch vụ phát nhạc với các album, đĩa đơn, video, bản remix, và các tiết mục trực tiếp chính thức và hơn nữa cho Android, iOS và máy tính. Tất cả đều tại đây."
 	},
 	"url": "music.youtube.com",
-	"version": "3.0.29",
+	"version": "3.0.30",
 	"logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/logo.png",
 	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/thumbnail.png",
 	"color": "#E40813",

--- a/websites/Y/YouTube Music/presence.ts
+++ b/websites/Y/YouTube Music/presence.ts
@@ -40,8 +40,7 @@ presence.on("UpdateData", async () => {
 		repeatMode = document
 			.querySelector('ytmusic-player-bar[slot="player-bar"]')
 			?.getAttribute("repeat-mode"),
-		videoElement =
-			document.querySelector<HTMLMediaElement>(".video-stream");
+		videoElement = document.querySelector<HTMLMediaElement>(".video-stream");
 
 	if (useTimeLeftChanged !== useTimeLeft && !privacyMode) {
 		useTimeLeftChanged = useTimeLeft;

--- a/websites/Y/YouTube Music/presence.ts
+++ b/websites/Y/YouTube Music/presence.ts
@@ -41,7 +41,7 @@ presence.on("UpdateData", async () => {
 			.querySelector('ytmusic-player-bar[slot="player-bar"]')
 			?.getAttribute("repeat-mode"),
 		videoElement =
-			document.querySelector<HTMLVideoElement>("video.video-stream");
+			document.querySelector<HTMLMediaElement>(".video-stream");
 
 	if (useTimeLeftChanged !== useTimeLeft && !privacyMode) {
 		useTimeLeftChanged = useTimeLeft;


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
This fixes the YT:M pressence to work when playing in audio-only mode, when this happens, YT:M mounts an audio element, not video element, breaking the pressence

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
![image](https://github.com/user-attachments/assets/e888a44b-d80f-4d21-b7ff-26aefed8ede7)



</details>
