### PR TITLE
feat(VLC): Add support for "Watching" and "Listening" statuses and add Album art as largeImageKey.

### DIFF
--- a/websites/V/VLC/metadata.json
+++ b/websites/V/VLC/metadata.json
@@ -22,7 +22,7 @@
     "localhost",
     "127.0.0.1"
   ],
-  "version": "1.4.43",
+  "version": "1.5.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/V/VLC/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/V/VLC/assets/thumbnail.png",
   "color": "#ff7c00",

--- a/websites/V/VLC/metadata.json
+++ b/websites/V/VLC/metadata.json
@@ -1,28 +1,28 @@
 {
-  "$schema": "https://schemas.premid.app/metadata/1.13",
-  "apiVersion": 1,
-  "author": {
-    "name": "fror",
-    "id": "515668127829458945"
-  },
-  "service": "VLC",
-  "description": {
-    "en": "VLC presence for PreMiD! Please read [this page](https://github.com/PreMiD/Presences/blob/master/websites/V/VLC/readme.md) to get started!",
-    "ga": "Láithreacht VLC do PreMiD! Léigh [an leathanach seo] le do thoil (https://github.com/PreMiD/Presences/blob/master/websites/V/VLC/readme.md) chun tosú",
-    "nl": "VLC aanwezigheid voor PreMiD! Lees [deze pagina] (https://github.com/PreMiD/Presences/blob/master/websites/V/VLC/readme.md) om te beginnen!",
-    "vi": "Presence VLC dành cho PreMiD! Hãy đọc [trang này](https://github.com/PreMiD/Presences/blob/master/websites/V/VLC/readme.md) để bắt đầu!"
-  },
-  "url": [
-    "localhost",
-    "127.0.0.1"
-  ],
-  "version": "1.4.44",
-  "logo": "https://cdn.rcd.gg/PreMiD/websites/V/VLC/assets/logo.png",
-  "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/V/VLC/assets/thumbnail.png",
-  "color": "#ff7c00",
-  "category": "videos",
-  "tags": [
-    "videolan",
-    "media-player"
-  ]
+	"$schema": "https://schemas.premid.app/metadata/1.13",
+	"apiVersion": 1,
+	"author": {
+		"name": "fror",
+		"id": "515668127829458945"
+	},
+	"service": "VLC",
+	"description": {
+		"en": "VLC presence for PreMiD! Please read [this page](https://github.com/PreMiD/Presences/blob/master/websites/V/VLC/readme.md) to get started!",
+		"ga": "Láithreacht VLC do PreMiD! Léigh [an leathanach seo] le do thoil (https://github.com/PreMiD/Presences/blob/master/websites/V/VLC/readme.md) chun tosú",
+		"nl": "VLC aanwezigheid voor PreMiD! Lees [deze pagina] (https://github.com/PreMiD/Presences/blob/master/websites/V/VLC/readme.md) om te beginnen!",
+		"vi": "Presence VLC dành cho PreMiD! Hãy đọc [trang này](https://github.com/PreMiD/Presences/blob/master/websites/V/VLC/readme.md) để bắt đầu!"
+	},
+	"url": [
+		"localhost",
+		"127.0.0.1"
+	],
+	"version": "1.5.0",
+	"logo": "https://cdn.rcd.gg/PreMiD/websites/V/VLC/assets/logo.png",
+	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/V/VLC/assets/thumbnail.png",
+	"color": "#ff7c00",
+	"category": "videos",
+	"tags": [
+		"videolan",
+		"media-player"
+	]
 }

--- a/websites/V/VLC/metadata.json
+++ b/websites/V/VLC/metadata.json
@@ -1,28 +1,34 @@
 {
-	"$schema": "https://schemas.premid.app/metadata/1.13",
-	"apiVersion": 1,
-	"author": {
-		"name": "fror",
-		"id": "515668127829458945"
-	},
-	"service": "VLC",
-	"description": {
-		"en": "VLC presence for PreMiD! Please read [this page](https://github.com/PreMiD/Presences/blob/master/websites/V/VLC/readme.md) to get started!",
-		"ga": "Láithreacht VLC do PreMiD! Léigh [an leathanach seo] le do thoil (https://github.com/PreMiD/Presences/blob/master/websites/V/VLC/readme.md) chun tosú",
-		"nl": "VLC aanwezigheid voor PreMiD! Lees [deze pagina] (https://github.com/PreMiD/Presences/blob/master/websites/V/VLC/readme.md) om te beginnen!",
-		"vi": "Presence VLC dành cho PreMiD! Hãy đọc [trang này](https://github.com/PreMiD/Presences/blob/master/websites/V/VLC/readme.md) để bắt đầu!"
-	},
-	"url": [
-		"localhost",
-		"127.0.0.1"
-	],
-	"version": "1.5.0",
-	"logo": "https://cdn.rcd.gg/PreMiD/websites/V/VLC/assets/logo.png",
-	"thumbnail": "https://cdn.rcd.gg/PreMiD/websites/V/VLC/assets/thumbnail.png",
-	"color": "#ff7c00",
-	"category": "videos",
-	"tags": [
-		"videolan",
-		"media-player"
-	]
+  "$schema": "https://schemas.premid.app/metadata/1.13",
+  "apiVersion": 1,
+  "author": {
+    "name": "fror",
+    "id": "515668127829458945"
+  },
+  "contributors": [
+    {
+      "name": "creeper",
+      "id": "529707020937461760"
+    }
+  ],
+  "service": "VLC",
+  "description": {
+    "en": "VLC presence for PreMiD! Please read [this page](https://github.com/PreMiD/Presences/blob/master/websites/V/VLC/readme.md) to get started!",
+    "ga": "Láithreacht VLC do PreMiD! Léigh [an leathanach seo] le do thoil (https://github.com/PreMiD/Presences/blob/master/websites/V/VLC/readme.md) chun tosú",
+    "nl": "VLC aanwezigheid voor PreMiD! Lees [deze pagina] (https://github.com/PreMiD/Presences/blob/master/websites/V/VLC/readme.md) om te beginnen!",
+    "vi": "Presence VLC dành cho PreMiD! Hãy đọc [trang này](https://github.com/PreMiD/Presences/blob/master/websites/V/VLC/readme.md) để bắt đầu!"
+  },
+  "url": [
+    "localhost",
+    "127.0.0.1"
+  ],
+  "version": "1.4.43",
+  "logo": "https://cdn.rcd.gg/PreMiD/websites/V/VLC/assets/logo.png",
+  "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/V/VLC/assets/thumbnail.png",
+  "color": "#ff7c00",
+  "category": "videos",
+  "tags": [
+    "videolan",
+    "media-player"
+  ]
 }

--- a/websites/V/VLC/presence.ts
+++ b/websites/V/VLC/presence.ts
@@ -1,354 +1,359 @@
-import { Assets } from 'premid'
-
 const presence = new Presence({
-  clientId: '721748388143562852',
-})
-const strings = presence.getStrings({
-  play: 'general.playing',
-  pause: 'general.paused',
-  browsing: 'general.browsing',
-})
-const media: MediaObj = {
-  // anyone is welcome to suggest more metadata via GH issues
-  time: undefined,
-  length: undefined,
-  state: 'stopped',
-  loop: undefined,
-  repeat: undefined,
-  filename: undefined,
-  title: undefined,
-  album: undefined,
-  artist: undefined,
-  trackNumber: undefined,
-  showName: undefined,
-  seasonNumber: undefined,
-  episodeNumber: undefined,
-}
-let isShow = false
-let isSong = false
-let prev: string | undefined
-let elapsed: number
-let i: number
+		clientId: "721748388143562852",
+	}),
+	strings = presence.getStrings({
+		play: "general.playing",
+		pause: "general.paused",
+		browsing: "general.browsing",
+	}),
+	media: MediaObj = {
+		// anyone is welcome to suggest more metadata via GH issues
+		time: null,
+		length: null,
+		state: "stopped",
+		loop: null,
+		repeat: null,
+		filename: null,
+		title: null,
+		album: null,
+		artist: null,
+		trackNumber: null,
+		showName: null,
+		seasonNumber: null,
+		episodeNumber: null,
+		Type: null,
+	};
+let isShow = false,
+	isSong = false,
+	prev: string,
+	elapsed: number,
+	i: number;
 
 function setLoop(f: () => void, ms: number): number {
-  f()
-  return setInterval(f, ms)
+	f();
+	return setInterval(f, ms);
 }
 
-function decodeReq(entity: Element) {
-  // decoding HTML entities the stackoverflow way
-  const txt = document.createElement('textarea')
-  txt.textContent = entity.textContent
-  return txt.textContent
+function decodeReq(entity: Element): string {
+	// decoding HTML entities the stackoverflow way
+	const txt = document.createElement("textarea");
+	txt.textContent = entity.textContent;
+	return txt.textContent;
 }
 
-function getTag(collection: NodeListOf<Element>, tagName: string) {
-  for (const tag of collection) {
-    if (tag.getAttribute('name') === tagName)
-      return tag
-  }
+function getTag(collection: NodeListOf<Element>, tagName: string): Element {
+	for (const tag of collection)
+		if (tag.getAttribute("name") === tagName) return tag;
 }
 
-presence.on('UpdateData', async () => {
-  if (
-    document.querySelector('.footer')
-    && document.querySelector('.footer')?.textContent?.includes('VLC')
-  ) {
-    const presenceData: PresenceData = {
-      largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/V/VLC/assets/logo.png',
-    }
+presence.on("UpdateData", async () => {
+	if (
+		document.querySelector(".footer") &&
+		document.querySelector(".footer").textContent.includes("VLC")
+	) {
+		const presenceData: PresenceData = {
+			largeImageKey: "https://cdn.rcd.gg/PreMiD/websites/V/VLC/assets/logo.png",
+			type: ActivityType.Watching,
+		};
 
-    if (media.state !== prev) {
-      prev = media.state
-      elapsed = Math.floor(Date.now() / 1000)
-    }
+		if (media.state !== prev) {
+			prev = media.state;
+			elapsed = Math.floor(Date.now() / 1000);
+		}
 
-    if (media.state === 'playing' || media.state === 'paused') {
-      if (isSong) {
-        if (media.title && media.album && media.title === media.album)
-          media.album = undefined
+		if (media.Type === "Audio") presenceData.type = ActivityType.Listening;
+		else if (media.Type === "Video") presenceData.type = ActivityType.Watching;
 
-        presenceData.details = ((media.title ?? '')
-          + (media.trackNumber ? ` Track N°${media.trackNumber}` : '')
-          || 'A song') + (media.album ? ` on ${media.album}` : '')
-        media.artist
-          ? (presenceData.state = `by ${media.artist}`)
-          : media.filename
-            ? (presenceData.state = media.filename)
-            : delete presenceData.state
-      }
-      else if (isShow) {
-        media.showName
-          ? (presenceData.details = media.showName)
-          : media.title
-            ? (presenceData.details = media.title)
-            : media.filename
-              ? (presenceData.details = media.filename)
-              : (presenceData.details = 'some TV')
-        presenceData.state = `S${media.seasonNumber}E${media.episodeNumber}`
-      }
-      else {
-        media.showName
-          ? (presenceData.details = media.showName)
-          : media.title
-            ? (presenceData.details = media.title)
-            : media.filename
-              ? (presenceData.details = media.filename)
-              : (presenceData.details = 'something')
-        media.seasonNumber
-          ? (presenceData.state = `season ${media.seasonNumber}`)
-          : media.episodeNumber
-            ? (presenceData.state = `episode ${media.episodeNumber}`)
-            : delete presenceData.state
-      }
+		if (media.state === "playing" || media.state === "paused") {
+			if (isSong) {
+				if (media.title && media.album && media.title === media.album)
+					media.album = null;
 
-      if (presenceData.details && presenceData.details.length > 100)
-        presenceData.details = presenceData.details.substring(0, 127)
-      if (
-        typeof presenceData.state === 'string'
-        && presenceData.state.length > 100
-      ) {
-        presenceData.state = presenceData.state.substring(0, 127)
-      }
+				presenceData.details =
+					((media.title ?? "") +
+						(media.trackNumber ? ` Track N°${media.trackNumber}` : "") ||
+						"A song") + (media.album ? ` on ${media.album}` : "");
+				media.artist
+					? (presenceData.state = `by ${media.artist}`)
+					: media.filename
+					? (presenceData.state = media.filename)
+					: delete presenceData.state;
+			} else if (isShow) {
+				media.showName
+					? (presenceData.details = media.showName)
+					: media.title
+					? (presenceData.details = media.title)
+					: media.filename
+					? (presenceData.details = media.filename)
+					: (presenceData.details = "some TV");
+				presenceData.state = `S${media.seasonNumber}E${media.episodeNumber}`;
+			} else {
+				media.showName
+					? (presenceData.details = media.showName)
+					: media.title
+					? (presenceData.details = media.title)
+					: media.filename
+					? (presenceData.details = media.filename)
+					: (presenceData.details = "something");
+				media.seasonNumber
+					? (presenceData.state = `season ${media.seasonNumber}`)
+					: media.episodeNumber
+					? (presenceData.state = `episode ${media.episodeNumber}`)
+					: delete presenceData.state;
+			}
 
-      presenceData.smallImageKey = media.state === 'paused'
-        ? Assets.Pause
-        : media.loop === 'true' && media.repeat === 'false'
-          ? Assets.Repeat
-          : media.repeat === 'true' && media.loop === 'false'
-            ? Assets.RepeatOne
-            : media.state === 'playing'
-              ? Assets.Play
-              : Assets.Pause
+			if (presenceData.details && presenceData.details.length > 100)
+				presenceData.details = presenceData.details.substring(0, 127);
+			if (
+				typeof presenceData.state === "string" &&
+				presenceData.state.length > 100
+			)
+				presenceData.state = presenceData.state.substring(0, 127);
 
-      presenceData.smallImageText = media.state === 'paused'
-        ? (await strings).pause
-        : media.loop === 'true' && media.repeat === 'false'
-          ? 'All on loop'
-          : media.repeat === 'true' && media.loop === 'false'
-            ? 'On loop'
-            : media.state === 'playing'
-              ? (await strings).play
-              : (await strings).pause;
+			presenceData.smallImageKey =
+				media.state === "paused"
+					? Assets.Pause
+					: media.loop === "true" && media.repeat === "false"
+					? Assets.Repeat
+					: media.repeat === "true" && media.loop === "false"
+					? Assets.RepeatOne
+					: media.state === "playing"
+					? Assets.Play
+					: Assets.Pause;
 
-      [presenceData.startTimestamp, presenceData.endTimestamp] = presence.getTimestamps(Number(media.time), Number(media.length))
+			presenceData.smallImageText =
+				media.state === "paused"
+					? (await strings).pause
+					: media.loop === "true" && media.repeat === "false"
+					? "All on loop"
+					: media.repeat === "true" && media.loop === "false"
+					? "On loop"
+					: media.state === "playing"
+					? (await strings).play
+					: (await strings).pause;
 
-      if (media.state === 'playing') {
-        presence.setActivity(presenceData, true)
-      }
-      else {
-        delete presenceData.startTimestamp
-        delete presenceData.endTimestamp
-        presence.setActivity(presenceData, false)
-      }
-    }
-    else if (media.state === 'stopped') {
-      presenceData.details = 'standby'
-      delete presenceData.state
-      delete presenceData.smallImageKey
-      delete presenceData.smallImageText
-      presenceData.startTimestamp = elapsed
-      delete presenceData.endTimestamp
+			[presenceData.startTimestamp, presenceData.endTimestamp] =
+				presence.getTimestamps(Number(media.time), Number(media.length));
 
-      presence.setActivity(presenceData, false)
-    }
-  }
-})
+			if (media.state === "playing") presence.setActivity(presenceData, true);
+			else {
+				delete presenceData.startTimestamp;
+				delete presenceData.endTimestamp;
+				presence.setActivity(presenceData, false);
+			}
+		} else if (media.state === "stopped") {
+			presenceData.details = "standby";
+			delete presenceData.state;
+			delete presenceData.smallImageKey;
+			delete presenceData.smallImageText;
+			presenceData.startTimestamp = elapsed;
+			delete presenceData.endTimestamp;
 
-const getStatus = setLoop(() => {
-  if (
-    document.querySelector('.footer')
-    && document.querySelector('.footer')?.textContent?.includes('VLC')
-  ) {
-    const req = new XMLHttpRequest()
-    // jquery sucks!!!
+			presence.setActivity(presenceData, false);
+		}
+	}
+});
 
-    req.onload = function (): void {
-      if (req.readyState === req.DONE) {
-        if (req.status === 200) {
-          if (i > 0)
-            i = 0;
+const getStatus = setLoop(function () {
+	if (
+		document.querySelector(".footer") &&
+		document.querySelector(".footer").textContent.includes("VLC")
+	) {
+		const req = new XMLHttpRequest();
+		// jquery sucks!!!
 
-          (req.responseXML?.querySelectorAll('state')[0]?.textContent?.length ?? 0) > 0
-            ? (media.state = req.responseXML?.querySelectorAll('state')[0]?.textContent ?? undefined)
-            : (media.state = 'stopped')
+		req.onload = function (): void {
+			if (req.readyState === req.DONE) {
+				if (req.status === 200) {
+					if (i > 0) i = 0;
 
-          if (media.state !== 'stopped') {
-            media.time = req.responseXML?.querySelectorAll('time')[0]?.textContent ?? undefined
-            media.length = req.responseXML?.querySelectorAll('length')[0]?.textContent ?? undefined
-            media.loop = req.responseXML?.querySelectorAll('loop')[0]?.textContent ?? undefined
-            media.repeat = req.responseXML?.querySelectorAll('repeat')[0]?.textContent ?? undefined
-          }
-          else {
-            media.time = undefined
-            media.length = undefined
-            media.loop = undefined
-            media.repeat = undefined
-          }
+					req.responseXML.querySelectorAll("state")[0].textContent.length > 0
+						? (media.state =
+								req.responseXML.querySelectorAll("state")[0].textContent)
+						: (media.state = "stopped");
 
-          if (navigator.userAgent.toLowerCase().includes('firefox')) {
-            const collection = req.responseXML!.querySelectorAll('info')!
+					if (media.state !== "stopped") {
+						media.time =
+							req.responseXML.querySelectorAll("time")[0].textContent;
+						media.length =
+							req.responseXML.querySelectorAll("length")[0].textContent;
+						media.loop =
+							req.responseXML.querySelectorAll("loop")[0].textContent;
+						media.repeat =
+							req.responseXML.querySelectorAll("repeat")[0].textContent;
+					} else {
+						media.time = null;
+						media.length = null;
+						media.loop = null;
+						media.repeat = null;
+					}
 
-            // basically the same thing but with a Firefox workaround because it's annoying
+					if (navigator.userAgent.toLowerCase().includes("firefox")) {
+						const collection = req.responseXML.querySelectorAll("info");
 
-            getTag(collection, 'filename')
-              ? (media.filename = decodeReq(getTag(collection, 'filename')!) ?? undefined)
-              : (media.filename = undefined)
-            getTag(collection, 'title')
-              ? (media.title = decodeReq(getTag(collection, 'title')!) ?? undefined)
-              : (media.title = undefined)
-            getTag(collection, 'showName')
-              ? (media.showName = decodeReq(getTag(collection, 'showName')!) ?? undefined)
-              : (media.showName = undefined)
+						// basically the same thing but with a Firefox workaround because it's annoying
 
-            if (getTag(collection, 'artist') || getTag(collection, 'album')) {
-              isSong = true
-              getTag(collection, 'artist')
-                ? (media.artist = decodeReq(getTag(collection, 'artist')!) ?? undefined)
-                : (media.artist = undefined)
-              getTag(collection, 'album')
-                ? (media.album = decodeReq(getTag(collection, 'album')!) ?? undefined)
-                : (media.album = undefined)
-            }
-            else {
-              isSong = false
-              media.artist = undefined
-              media.album = undefined
-            }
+						getTag(collection, "filename")
+							? (media.filename = decodeReq(getTag(collection, "filename")))
+							: (media.filename = null);
+						getTag(collection, "title")
+							? (media.title = decodeReq(getTag(collection, "title")))
+							: (media.title = null);
+						getTag(collection, "showName")
+							? (media.showName = decodeReq(getTag(collection, "showName")))
+							: (media.showName = null);
+						getTag(collection, "Type")
+							? (media.Type = decodeReq(getTag(collection, "Type")))
+							: (media.Type = null);
 
-            getTag(collection, 'trackNumber')
-              ? (media.trackNumber = decodeReq(
-                  getTag(collection, 'trackNumber')!,
-                ) ?? undefined)
-              : (media.trackNumber = undefined)
+						if (getTag(collection, "artist") || getTag(collection, "album")) {
+							isSong = true;
+							getTag(collection, "artist")
+								? (media.artist = decodeReq(getTag(collection, "artist")))
+								: (media.artist = null);
+							getTag(collection, "album")
+								? (media.album = decodeReq(getTag(collection, "album")))
+								: (media.album = null);
+						} else {
+							isSong = false;
+							media.artist = null;
+							media.album = null;
+						}
 
-            if (
-              getTag(collection, 'seasonNumber')
-              && getTag(collection, 'episodeNumber')
-            ) {
-              isShow = true
-              media.seasonNumber = decodeReq(
-                getTag(collection, 'seasonNumber')!,
-              ) ?? undefined
-              media.episodeNumber = decodeReq(
-                getTag(collection, 'episodeNumber')!,
-              ) ?? undefined
-            }
-            else {
-              isShow = false
-              media.seasonNumber = undefined
-              media.episodeNumber = undefined
-            }
-          }
-          else {
-            req.responseXML!.getElementsByName('filename')[0]
-              ? (media.filename = decodeReq(
-                  req.responseXML!.getElementsByName('filename')[0]!,
-                ) ?? undefined)
-              : (media.filename = undefined)
-            req.responseXML!.getElementsByName('title')[0]
-              ? (media.title = decodeReq(
-                  req.responseXML!.getElementsByName('title')[0]!,
-                ) ?? undefined)
-              : (media.title = undefined)
-            req.responseXML!.getElementsByName('showName')[0]
-              ? (media.showName = decodeReq(
-                  req.responseXML!.getElementsByName('showName')[0]!,
-                ) ?? undefined)
-              : (media.showName = undefined)
+						getTag(collection, "trackNumber")
+							? (media.trackNumber = decodeReq(
+									getTag(collection, "trackNumber")
+							  ))
+							: (media.trackNumber = null);
 
-            if (
-              req.responseXML!.getElementsByName('artist')[0]
-              || req.responseXML!.getElementsByName('album')[0]
-            ) {
-              isSong = true
-              req.responseXML!.getElementsByName('artist')[0]
-                ? (media.artist = decodeReq(
-                    req.responseXML!.getElementsByName('artist')[0]!,
-                  ) ?? undefined)
-                : (media.artist = undefined)
-              req.responseXML!.getElementsByName('album')[0]
-                ? (media.album = decodeReq(
-                    req.responseXML!.getElementsByName('album')[0]!,
-                  ) ?? undefined)
-                : (media.album = undefined)
-            }
-            else {
-              isSong = false
-              media.artist = undefined
-              media.album = undefined
-            }
+						if (
+							getTag(collection, "seasonNumber") &&
+							getTag(collection, "episodeNumber")
+						) {
+							isShow = true;
+							media.seasonNumber = decodeReq(
+								getTag(collection, "seasonNumber")
+							);
+							media.episodeNumber = decodeReq(
+								getTag(collection, "episodeNumber")
+							);
+						} else {
+							isShow = false;
+							media.seasonNumber = null;
+							media.episodeNumber = null;
+						}
+					} else {
+						req.responseXML.getElementsByName("filename")[0]
+							? (media.filename = decodeReq(
+									req.responseXML.getElementsByName("filename")[0]
+							  ))
+							: (media.filename = null);
+						req.responseXML.getElementsByName("title")[0]
+							? (media.title = decodeReq(
+									req.responseXML.getElementsByName("title")[0]
+							  ))
+							: (media.title = null);
+						req.responseXML.getElementsByName("showName")[0]
+							? (media.showName = decodeReq(
+									req.responseXML.getElementsByName("showName")[0]
+							  ))
+							: (media.showName = null);
+						req.responseXML.getElementsByName("Type")[0]
+							? (media.Type = decodeReq(
+									req.responseXML.getElementsByName("Type")[0]
+							  ))
+							: (media.Type = null);
 
-            req.responseXML!.getElementsByName('track_number')[0]
-              ? (media.trackNumber = decodeReq(
-                  req.responseXML!.getElementsByName('track_number')[0]!,
-                ) ?? undefined)
-              : (media.trackNumber = undefined)
+						if (
+							req.responseXML.getElementsByName("artist")[0] ||
+							req.responseXML.getElementsByName("album")[0]
+						) {
+							isSong = true;
+							req.responseXML.getElementsByName("artist")[0]
+								? (media.artist = decodeReq(
+										req.responseXML.getElementsByName("artist")[0]
+								  ))
+								: (media.artist = null);
+							req.responseXML.getElementsByName("album")[0]
+								? (media.album = decodeReq(
+										req.responseXML.getElementsByName("album")[0]
+								  ))
+								: (media.album = null);
+						} else {
+							isSong = false;
+							media.artist = null;
+							media.album = null;
+						}
 
-            if (
-              req.responseXML!.getElementsByName('seasonNumber')[0]
-              && req.responseXML!.getElementsByName('episodeNumber')[0]
-            ) {
-              isShow = true
-              media.seasonNumber = decodeReq(
-                req.responseXML!.getElementsByName('seasonNumber')[0]!,
-              ) ?? undefined
-              media.episodeNumber = decodeReq(
-                req.responseXML!.getElementsByName('episodeNumber')[0]!,
-              ) ?? undefined
-            }
-            else {
-              isShow = false
-              media.seasonNumber = undefined
-              media.episodeNumber = undefined
-            }
-          }
-          for (const key of Object.keys(media))
-            media[key] = media[key]?.replace('&#39;', '\'')
-        }
-        else {
-          i++
-          if (i > 4) {
-            i = 0
+						req.responseXML.getElementsByName("track_number")[0]
+							? (media.trackNumber = decodeReq(
+									req.responseXML.getElementsByName("track_number")[0]
+							  ))
+							: (media.trackNumber = null);
 
-            clearInterval(getStatus)
-            media.state = 'stopped'
-            presence.error(
-              `Something went wrong with the request, please contact other people at https://discord.premid.app with the following infos (RES: ${req.status} / S: ${req.readyState})`,
-            )
-          }
-        }
-      }
-    }
+						if (
+							req.responseXML.getElementsByName("seasonNumber")[0] &&
+							req.responseXML.getElementsByName("episodeNumber")[0]
+						) {
+							isShow = true;
+							media.seasonNumber = decodeReq(
+								req.responseXML.getElementsByName("seasonNumber")[0]
+							);
+							media.episodeNumber = decodeReq(
+								req.responseXML.getElementsByName("episodeNumber")[0]
+							);
+						} else {
+							isShow = false;
+							media.seasonNumber = null;
+							media.episodeNumber = null;
+						}
+					}
+					for (const key of Object.keys(media))
+						media[key] = media[key]?.replace("&#39;", "'");
+				} else {
+					i++;
+					if (i > 4) {
+						i = 0;
 
-    req.onerror = function (): void {
-      media.state = 'stopped'
-    }
+						clearInterval(getStatus);
+						media.state = "stopped";
+						alert(
+							`Something went wrong with the request, please contact other people at https://discord.premid.app with the following infos (RES: ${req.status} / S: ${req.readyState})`
+						);
+					}
+				}
+			}
+		};
 
-    req.open(
-      'GET',
-      `${document.location.protocol}//${document.location.hostname}:${
-        document.location.port ?? ''
-      }/requests/status.xml`,
-      true,
-    )
-    req.send()
-  }
-}, (navigator.userAgent.toLowerCase().includes('firefox') ? 5 : 2) * 1000)
+		req.onerror = function (): void {
+			media.state = "stopped";
+		};
+
+		req.open(
+			"GET",
+			`${document.location.protocol}//${document.location.hostname}:${
+				document.location.port ?? ""
+			}/requests/status.xml`,
+			true
+		);
+		req.send();
+	}
+}, (navigator.userAgent.toLowerCase().includes("firefox") ? 5 : 2) * 1000);
 
 interface MediaObj {
-  time?: string
-  length?: string
-  state?: string
-  loop?: string
-  repeat?: string
-  filename?: string
-  title?: string
-  album?: string
-  artist?: string
-  trackNumber?: string
-  showName?: string
-  seasonNumber?: string
-  episodeNumber?: string
-  [key: string]: string | undefined
+	time?: string;
+	length?: string;
+	state?: string;
+	loop?: string;
+	repeat?: string;
+	filename?: string;
+	title?: string;
+	album?: string;
+	artist?: string;
+	trackNumber?: string;
+	showName?: string;
+	seasonNumber?: string;
+	episodeNumber?: string;
+	Type?: string;
+	[key: string]: string;
 }

--- a/websites/V/VLC/presence.ts
+++ b/websites/V/VLC/presence.ts
@@ -1,359 +1,390 @@
+import { ActivityType, Assets } from 'premid'
+
 const presence = new Presence({
-		clientId: "721748388143562852",
-	}),
-	strings = presence.getStrings({
-		play: "general.playing",
-		pause: "general.paused",
-		browsing: "general.browsing",
-	}),
-	media: MediaObj = {
-		// anyone is welcome to suggest more metadata via GH issues
-		time: null,
-		length: null,
-		state: "stopped",
-		loop: null,
-		repeat: null,
-		filename: null,
-		title: null,
-		album: null,
-		artist: null,
-		trackNumber: null,
-		showName: null,
-		seasonNumber: null,
-		episodeNumber: null,
-		Type: null,
-	};
-let isShow = false,
-	isSong = false,
-	prev: string,
-	elapsed: number,
-	i: number;
+  clientId: '721748388143562852',
+})
+const strings = presence.getStrings({
+  play: 'general.playing',
+  pause: 'general.paused',
+  browsing: 'general.browsing',
+})
+const media: MediaObj = {
+  // anyone is welcome to suggest more metadata via GH issues
+  time: undefined,
+  length: undefined,
+  state: 'stopped',
+  loop: undefined,
+  repeat: undefined,
+  filename: undefined,
+  title: undefined,
+  album: undefined,
+  artist: undefined,
+  trackNumber: undefined,
+  showName: undefined,
+  seasonNumber: undefined,
+  episodeNumber: undefined,
+  Type: undefined,
+}
+let isShow = false
+let isSong = false
+let prev: string | undefined
+let elapsed: number
+let i: number
+let oldArt = ''
+let dataURL = ''
 
 function setLoop(f: () => void, ms: number): number {
-	f();
-	return setInterval(f, ms);
+  f()
+  return setInterval(f, ms)
 }
 
-function decodeReq(entity: Element): string {
-	// decoding HTML entities the stackoverflow way
-	const txt = document.createElement("textarea");
-	txt.textContent = entity.textContent;
-	return txt.textContent;
+function decodeReq(entity: Element) {
+  // decoding HTML entities the stackoverflow way
+  const txt = document.createElement('textarea')
+  txt.textContent = entity.textContent
+  return txt.textContent
 }
 
-function getTag(collection: NodeListOf<Element>, tagName: string): Element {
-	for (const tag of collection)
-		if (tag.getAttribute("name") === tagName) return tag;
+function getTag(collection: NodeListOf<Element>, tagName: string) {
+  for (const tag of collection) {
+    if (tag.getAttribute('name') === tagName)
+      return tag
+  }
 }
 
-presence.on("UpdateData", async () => {
-	if (
-		document.querySelector(".footer") &&
-		document.querySelector(".footer").textContent.includes("VLC")
-	) {
-		const presenceData: PresenceData = {
-			largeImageKey: "https://cdn.rcd.gg/PreMiD/websites/V/VLC/assets/logo.png",
-			type: ActivityType.Watching,
-		};
+presence.on('UpdateData', async () => {
+  if (
+    document.querySelector('.footer')
+    && document.querySelector('.footer')?.textContent?.includes('VLC')
+  ) {
+    const presenceData: PresenceData = {
+      largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/V/VLC/assets/logo.png',
+    }
 
-		if (media.state !== prev) {
-			prev = media.state;
-			elapsed = Math.floor(Date.now() / 1000);
-		}
+    if (media.state !== prev) {
+      prev = media.state
+      elapsed = Math.floor(Date.now() / 1000)
+    }
 
-		if (media.Type === "Audio") presenceData.type = ActivityType.Listening;
-		else if (media.Type === "Video") presenceData.type = ActivityType.Watching;
+    if (media.Type === 'Audio')
+      presenceData.type = ActivityType.Listening
+    else if (media.Type === 'Video')
+      presenceData.type = ActivityType.Watching
 
-		if (media.state === "playing" || media.state === "paused") {
-			if (isSong) {
-				if (media.title && media.album && media.title === media.album)
-					media.album = null;
+    if (media.state === 'playing' || media.state === 'paused') {
+      const img = document.querySelector<HTMLImageElement>('#albumArt')
+      if (!img)
+        return
+      if (img.src !== oldArt) {
+        const artCanvas = document.createElement('canvas')
+        const ctx = artCanvas.getContext('2d')
+        if (!ctx)
+          return
+        artCanvas.height = 256
+        artCanvas.width = 256
 
-				presenceData.details =
-					((media.title ?? "") +
-						(media.trackNumber ? ` Track N°${media.trackNumber}` : "") ||
-						"A song") + (media.album ? ` on ${media.album}` : "");
-				media.artist
-					? (presenceData.state = `by ${media.artist}`)
-					: media.filename
-					? (presenceData.state = media.filename)
-					: delete presenceData.state;
-			} else if (isShow) {
-				media.showName
-					? (presenceData.details = media.showName)
-					: media.title
-					? (presenceData.details = media.title)
-					: media.filename
-					? (presenceData.details = media.filename)
-					: (presenceData.details = "some TV");
-				presenceData.state = `S${media.seasonNumber}E${media.episodeNumber}`;
-			} else {
-				media.showName
-					? (presenceData.details = media.showName)
-					: media.title
-					? (presenceData.details = media.title)
-					: media.filename
-					? (presenceData.details = media.filename)
-					: (presenceData.details = "something");
-				media.seasonNumber
-					? (presenceData.state = `season ${media.seasonNumber}`)
-					: media.episodeNumber
-					? (presenceData.state = `episode ${media.episodeNumber}`)
-					: delete presenceData.state;
-			}
+        ctx.drawImage(img, 0, 0, artCanvas.width, artCanvas.height)
+        dataURL = artCanvas.toDataURL()
+        oldArt = img.src
+      }
 
-			if (presenceData.details && presenceData.details.length > 100)
-				presenceData.details = presenceData.details.substring(0, 127);
-			if (
-				typeof presenceData.state === "string" &&
-				presenceData.state.length > 100
-			)
-				presenceData.state = presenceData.state.substring(0, 127);
+      if (!img.src.includes('/images/') && dataURL.includes('image'))
+        presenceData.largeImageKey = dataURL
 
-			presenceData.smallImageKey =
-				media.state === "paused"
-					? Assets.Pause
-					: media.loop === "true" && media.repeat === "false"
-					? Assets.Repeat
-					: media.repeat === "true" && media.loop === "false"
-					? Assets.RepeatOne
-					: media.state === "playing"
-					? Assets.Play
-					: Assets.Pause;
+      if (isSong) {
+        if (media.title && media.album && media.title === media.album)
+          media.album = undefined
 
-			presenceData.smallImageText =
-				media.state === "paused"
-					? (await strings).pause
-					: media.loop === "true" && media.repeat === "false"
-					? "All on loop"
-					: media.repeat === "true" && media.loop === "false"
-					? "On loop"
-					: media.state === "playing"
-					? (await strings).play
-					: (await strings).pause;
+        presenceData.details = ((media.title ?? '')
+          + (media.trackNumber ? ` Track N°${media.trackNumber}` : '')
+          || 'A song') + (media.album ? ` on ${media.album}` : '')
+        media.artist
+          ? (presenceData.state = `by ${media.artist}`)
+          : media.filename
+            ? (presenceData.state = media.filename)
+            : delete presenceData.state
+      }
+      else if (isShow) {
+        media.showName
+          ? (presenceData.details = media.showName)
+          : media.title
+            ? (presenceData.details = media.title)
+            : media.filename
+              ? (presenceData.details = media.filename)
+              : (presenceData.details = 'some TV')
+        presenceData.state = `S${media.seasonNumber}E${media.episodeNumber}`
+      }
+      else {
+        media.showName
+          ? (presenceData.details = media.showName)
+          : media.title
+            ? (presenceData.details = media.title)
+            : media.filename
+              ? (presenceData.details = media.filename)
+              : (presenceData.details = 'something')
+        media.seasonNumber
+          ? (presenceData.state = `season ${media.seasonNumber}`)
+          : media.episodeNumber
+            ? (presenceData.state = `episode ${media.episodeNumber}`)
+            : delete presenceData.state
+      }
 
-			[presenceData.startTimestamp, presenceData.endTimestamp] =
-				presence.getTimestamps(Number(media.time), Number(media.length));
+      if (presenceData.details && presenceData.details.length > 100)
+        presenceData.details = presenceData.details.substring(0, 127)
+      if (
+        typeof presenceData.state === 'string'
+        && presenceData.state.length > 100
+      ) {
+        presenceData.state = presenceData.state.substring(0, 127)
+      }
 
-			if (media.state === "playing") presence.setActivity(presenceData, true);
-			else {
-				delete presenceData.startTimestamp;
-				delete presenceData.endTimestamp;
-				presence.setActivity(presenceData, false);
-			}
-		} else if (media.state === "stopped") {
-			presenceData.details = "standby";
-			delete presenceData.state;
-			delete presenceData.smallImageKey;
-			delete presenceData.smallImageText;
-			presenceData.startTimestamp = elapsed;
-			delete presenceData.endTimestamp;
+      presenceData.smallImageKey = media.state === 'paused'
+        ? Assets.Pause
+        : media.loop === 'true' && media.repeat === 'false'
+          ? Assets.Repeat
+          : media.repeat === 'true' && media.loop === 'false'
+            ? Assets.RepeatOne
+            : media.state === 'playing'
+              ? Assets.Play
+              : Assets.Pause
 
-			presence.setActivity(presenceData, false);
-		}
-	}
-});
+      presenceData.smallImageText = media.state === 'paused'
+        ? (await strings).pause
+        : media.loop === 'true' && media.repeat === 'false'
+          ? 'All on loop'
+          : media.repeat === 'true' && media.loop === 'false'
+            ? 'On loop'
+            : media.state === 'playing'
+              ? (await strings).play
+              : (await strings).pause;
 
-const getStatus = setLoop(function () {
-	if (
-		document.querySelector(".footer") &&
-		document.querySelector(".footer").textContent.includes("VLC")
-	) {
-		const req = new XMLHttpRequest();
-		// jquery sucks!!!
+      [presenceData.startTimestamp, presenceData.endTimestamp] = presence.getTimestamps(Number(media.time), Number(media.length))
 
-		req.onload = function (): void {
-			if (req.readyState === req.DONE) {
-				if (req.status === 200) {
-					if (i > 0) i = 0;
+      if (media.state === 'playing') {
+        presence.setActivity(presenceData, true)
+      }
+      else {
+        delete presenceData.startTimestamp
+        delete presenceData.endTimestamp
+        presence.setActivity(presenceData, false)
+      }
+    }
+    else if (media.state === 'stopped') {
+      presenceData.details = 'standby'
+      delete presenceData.state
+      delete presenceData.smallImageKey
+      delete presenceData.smallImageText
+      presenceData.startTimestamp = elapsed
+      delete presenceData.endTimestamp
 
-					req.responseXML.querySelectorAll("state")[0].textContent.length > 0
-						? (media.state =
-								req.responseXML.querySelectorAll("state")[0].textContent)
-						: (media.state = "stopped");
+      presence.setActivity(presenceData, false)
+    }
+  }
+})
 
-					if (media.state !== "stopped") {
-						media.time =
-							req.responseXML.querySelectorAll("time")[0].textContent;
-						media.length =
-							req.responseXML.querySelectorAll("length")[0].textContent;
-						media.loop =
-							req.responseXML.querySelectorAll("loop")[0].textContent;
-						media.repeat =
-							req.responseXML.querySelectorAll("repeat")[0].textContent;
-					} else {
-						media.time = null;
-						media.length = null;
-						media.loop = null;
-						media.repeat = null;
-					}
+const getStatus = setLoop(() => {
+  if (
+    document.querySelector('.footer')
+    && document.querySelector('.footer')?.textContent?.includes('VLC')
+  ) {
+    const req = new XMLHttpRequest()
+    // jquery sucks!!!
 
-					if (navigator.userAgent.toLowerCase().includes("firefox")) {
-						const collection = req.responseXML.querySelectorAll("info");
+    req.onload = function (): void {
+      if (req.readyState === req.DONE) {
+        if (req.status === 200) {
+          if (i > 0)
+            i = 0;
 
-						// basically the same thing but with a Firefox workaround because it's annoying
+          (req.responseXML?.querySelectorAll('state')[0]?.textContent?.length ?? 0) > 0
+            ? (media.state = req.responseXML?.querySelectorAll('state')[0]?.textContent ?? undefined)
+            : (media.state = 'stopped')
 
-						getTag(collection, "filename")
-							? (media.filename = decodeReq(getTag(collection, "filename")))
-							: (media.filename = null);
-						getTag(collection, "title")
-							? (media.title = decodeReq(getTag(collection, "title")))
-							: (media.title = null);
-						getTag(collection, "showName")
-							? (media.showName = decodeReq(getTag(collection, "showName")))
-							: (media.showName = null);
-						getTag(collection, "Type")
-							? (media.Type = decodeReq(getTag(collection, "Type")))
-							: (media.Type = null);
+          if (media.state !== 'stopped') {
+            media.time = req.responseXML?.querySelectorAll('time')[0]?.textContent ?? undefined
+            media.length = req.responseXML?.querySelectorAll('length')[0]?.textContent ?? undefined
+            media.loop = req.responseXML?.querySelectorAll('loop')[0]?.textContent ?? undefined
+            media.repeat = req.responseXML?.querySelectorAll('repeat')[0]?.textContent ?? undefined
+          }
+          else {
+            media.time = undefined
+            media.length = undefined
+            media.loop = undefined
+            media.repeat = undefined
+          }
 
-						if (getTag(collection, "artist") || getTag(collection, "album")) {
-							isSong = true;
-							getTag(collection, "artist")
-								? (media.artist = decodeReq(getTag(collection, "artist")))
-								: (media.artist = null);
-							getTag(collection, "album")
-								? (media.album = decodeReq(getTag(collection, "album")))
-								: (media.album = null);
-						} else {
-							isSong = false;
-							media.artist = null;
-							media.album = null;
-						}
+          if (navigator.userAgent.toLowerCase().includes('firefox')) {
+            const collection = req.responseXML!.querySelectorAll('info')!
 
-						getTag(collection, "trackNumber")
-							? (media.trackNumber = decodeReq(
-									getTag(collection, "trackNumber")
-							  ))
-							: (media.trackNumber = null);
+            // basically the same thing but with a Firefox workaround because it's annoying
 
-						if (
-							getTag(collection, "seasonNumber") &&
-							getTag(collection, "episodeNumber")
-						) {
-							isShow = true;
-							media.seasonNumber = decodeReq(
-								getTag(collection, "seasonNumber")
-							);
-							media.episodeNumber = decodeReq(
-								getTag(collection, "episodeNumber")
-							);
-						} else {
-							isShow = false;
-							media.seasonNumber = null;
-							media.episodeNumber = null;
-						}
-					} else {
-						req.responseXML.getElementsByName("filename")[0]
-							? (media.filename = decodeReq(
-									req.responseXML.getElementsByName("filename")[0]
-							  ))
-							: (media.filename = null);
-						req.responseXML.getElementsByName("title")[0]
-							? (media.title = decodeReq(
-									req.responseXML.getElementsByName("title")[0]
-							  ))
-							: (media.title = null);
-						req.responseXML.getElementsByName("showName")[0]
-							? (media.showName = decodeReq(
-									req.responseXML.getElementsByName("showName")[0]
-							  ))
-							: (media.showName = null);
-						req.responseXML.getElementsByName("Type")[0]
-							? (media.Type = decodeReq(
-									req.responseXML.getElementsByName("Type")[0]
-							  ))
-							: (media.Type = null);
+            getTag(collection, 'filename')
+              ? (media.filename = decodeReq(getTag(collection, 'filename')!) ?? undefined)
+              : (media.filename = undefined)
+            getTag(collection, 'title')
+              ? (media.title = decodeReq(getTag(collection, 'title')!) ?? undefined)
+              : (media.title = undefined)
+            getTag(collection, 'showName')
+              ? (media.showName = decodeReq(getTag(collection, 'showName')!) ?? undefined)
+              : (media.showName = undefined)
+            getTag(collection, 'Type')
+              ? (media.Type = decodeReq(getTag(collection, 'Type')!) ?? undefined)
+              : (media.Type = undefined)
 
-						if (
-							req.responseXML.getElementsByName("artist")[0] ||
-							req.responseXML.getElementsByName("album")[0]
-						) {
-							isSong = true;
-							req.responseXML.getElementsByName("artist")[0]
-								? (media.artist = decodeReq(
-										req.responseXML.getElementsByName("artist")[0]
-								  ))
-								: (media.artist = null);
-							req.responseXML.getElementsByName("album")[0]
-								? (media.album = decodeReq(
-										req.responseXML.getElementsByName("album")[0]
-								  ))
-								: (media.album = null);
-						} else {
-							isSong = false;
-							media.artist = null;
-							media.album = null;
-						}
+            if (getTag(collection, 'artist') || getTag(collection, 'album')) {
+              isSong = true
+              getTag(collection, 'artist')
+                ? (media.artist = decodeReq(getTag(collection, 'artist')!) ?? undefined)
+                : (media.artist = undefined)
+              getTag(collection, 'album')
+                ? (media.album = decodeReq(getTag(collection, 'album')!) ?? undefined)
+                : (media.album = undefined)
+            }
+            else {
+              isSong = false
+              media.artist = undefined
+              media.album = undefined
+            }
 
-						req.responseXML.getElementsByName("track_number")[0]
-							? (media.trackNumber = decodeReq(
-									req.responseXML.getElementsByName("track_number")[0]
-							  ))
-							: (media.trackNumber = null);
+            getTag(collection, 'trackNumber')
+              ? (media.trackNumber = decodeReq(
+                  getTag(collection, 'trackNumber')!,
+                ) ?? undefined)
+              : (media.trackNumber = undefined)
 
-						if (
-							req.responseXML.getElementsByName("seasonNumber")[0] &&
-							req.responseXML.getElementsByName("episodeNumber")[0]
-						) {
-							isShow = true;
-							media.seasonNumber = decodeReq(
-								req.responseXML.getElementsByName("seasonNumber")[0]
-							);
-							media.episodeNumber = decodeReq(
-								req.responseXML.getElementsByName("episodeNumber")[0]
-							);
-						} else {
-							isShow = false;
-							media.seasonNumber = null;
-							media.episodeNumber = null;
-						}
-					}
-					for (const key of Object.keys(media))
-						media[key] = media[key]?.replace("&#39;", "'");
-				} else {
-					i++;
-					if (i > 4) {
-						i = 0;
+            if (
+              getTag(collection, 'seasonNumber')
+              && getTag(collection, 'episodeNumber')
+            ) {
+              isShow = true
+              media.seasonNumber = decodeReq(
+                getTag(collection, 'seasonNumber')!,
+              ) ?? undefined
+              media.episodeNumber = decodeReq(
+                getTag(collection, 'episodeNumber')!,
+              ) ?? undefined
+            }
+            else {
+              isShow = false
+              media.seasonNumber = undefined
+              media.episodeNumber = undefined
+            }
+          }
+          else {
+            req.responseXML!.getElementsByName('filename')[0]
+              ? (media.filename = decodeReq(
+                  req.responseXML!.getElementsByName('filename')[0]!,
+                ) ?? undefined)
+              : (media.filename = undefined)
+            req.responseXML!.getElementsByName('title')[0]
+              ? (media.title = decodeReq(
+                  req.responseXML!.getElementsByName('title')[0]!,
+                ) ?? undefined)
+              : (media.title = undefined)
+            req.responseXML!.getElementsByName('showName')[0]
+              ? (media.showName = decodeReq(
+                  req.responseXML!.getElementsByName('showName')[0]!,
+                ) ?? undefined)
+              : (media.showName = undefined)
+            req.responseXML!.getElementsByName('showName')[0]
+              ? (media.Type = decodeReq(
+                  req.responseXML!.getElementsByName('Type')[0]!,
+                ) ?? undefined)
+              : (media.Type = undefined)
 
-						clearInterval(getStatus);
-						media.state = "stopped";
-						alert(
-							`Something went wrong with the request, please contact other people at https://discord.premid.app with the following infos (RES: ${req.status} / S: ${req.readyState})`
-						);
-					}
-				}
-			}
-		};
+            if (
+              req.responseXML!.getElementsByName('artist')[0]
+              || req.responseXML!.getElementsByName('album')[0]
+            ) {
+              isSong = true
+              req.responseXML!.getElementsByName('artist')[0]
+                ? (media.artist = decodeReq(
+                    req.responseXML!.getElementsByName('artist')[0]!,
+                  ) ?? undefined)
+                : (media.artist = undefined)
+              req.responseXML!.getElementsByName('album')[0]
+                ? (media.album = decodeReq(
+                    req.responseXML!.getElementsByName('album')[0]!,
+                  ) ?? undefined)
+                : (media.album = undefined)
+            }
+            else {
+              isSong = false
+              media.artist = undefined
+              media.album = undefined
+            }
 
-		req.onerror = function (): void {
-			media.state = "stopped";
-		};
+            req.responseXML!.getElementsByName('track_number')[0]
+              ? (media.trackNumber = decodeReq(
+                  req.responseXML!.getElementsByName('track_number')[0]!,
+                ) ?? undefined)
+              : (media.trackNumber = undefined)
 
-		req.open(
-			"GET",
-			`${document.location.protocol}//${document.location.hostname}:${
-				document.location.port ?? ""
-			}/requests/status.xml`,
-			true
-		);
-		req.send();
-	}
-}, (navigator.userAgent.toLowerCase().includes("firefox") ? 5 : 2) * 1000);
+            if (
+              req.responseXML!.getElementsByName('seasonNumber')[0]
+              && req.responseXML!.getElementsByName('episodeNumber')[0]
+            ) {
+              isShow = true
+              media.seasonNumber = decodeReq(
+                req.responseXML!.getElementsByName('seasonNumber')[0]!,
+              ) ?? undefined
+              media.episodeNumber = decodeReq(
+                req.responseXML!.getElementsByName('episodeNumber')[0]!,
+              ) ?? undefined
+            }
+            else {
+              isShow = false
+              media.seasonNumber = undefined
+              media.episodeNumber = undefined
+            }
+          }
+          for (const key of Object.keys(media))
+            media[key] = media[key]?.replace('&#39;', '\'')
+        }
+        else {
+          i++
+          if (i > 4) {
+            i = 0
+
+            clearInterval(getStatus)
+            media.state = 'stopped'
+            presence.error(
+              `Something went wrong with the request, please contact other people at https://discord.premid.app with the following infos (RES: ${req.status} / S: ${req.readyState})`,
+            )
+          }
+        }
+      }
+    }
+
+    req.onerror = function (): void {
+      media.state = 'stopped'
+    }
+
+    req.open(
+      'GET',
+      `${document.location.protocol}//${document.location.hostname}:${
+        document.location.port ?? ''
+      }/requests/status.xml`,
+      true,
+    )
+    req.send()
+  }
+}, (navigator.userAgent.toLowerCase().includes('firefox') ? 5 : 2) * 1000)
 
 interface MediaObj {
-	time?: string;
-	length?: string;
-	state?: string;
-	loop?: string;
-	repeat?: string;
-	filename?: string;
-	title?: string;
-	album?: string;
-	artist?: string;
-	trackNumber?: string;
-	showName?: string;
-	seasonNumber?: string;
-	episodeNumber?: string;
-	Type?: string;
-	[key: string]: string;
+  time?: string
+  length?: string
+  state?: string
+  loop?: string
+  repeat?: string
+  filename?: string
+  title?: string
+  album?: string
+  artist?: string
+  trackNumber?: string
+  showName?: string
+  seasonNumber?: string
+  episodeNumber?: string
+  Type?: string
+  [key: string]: string | undefined
 }


### PR DESCRIPTION
## Description 
This adds the "Type" variable from the xml, which detects whether the currently loaded file is a Audio or Video, then switches the current ActivityType based on this. 

I was finished working on putting the Album art as the "largeImageKey", but was gonna wait before putting it in, since I had to modernize the presence.ts might as well implement that as well.

## Acknowledgements
- [ x ] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [ x ] I linted the code by running `yarn format`
- [ x ] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>


![image](https://github.com/user-attachments/assets/04ba3c77-d489-41d6-b81d-5ccfd108ebf8)
![image](https://github.com/user-attachments/assets/e7928bde-a75a-43d5-a2b8-d369dbca9e52)


</details>
