### PR TITLE
fix(update-assets): run on push instead of pr

### DIFF
--- a/.github/workflows/assets-updater.yml
+++ b/.github/workflows/assets-updater.yml
@@ -1,10 +1,12 @@
 name: pmd
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
-  pull_request_review:
-    types: [submitted]
+  push:
+    branches:
+      - main
+    paths:
+      - '**.ts'
+      - '**.json'
 
 jobs:
   check-and-run:
@@ -12,7 +14,6 @@ jobs:
     name: Update assets
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
       contents: write
       statuses: write
 
@@ -35,7 +36,6 @@ jobs:
         env:
           CDN_TOKEN: ${{ secrets.CDN_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           # Configure git
           git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/cli/src/classes/AssetsManager.test.ts
+++ b/cli/src/classes/AssetsManager.test.ts
@@ -745,7 +745,7 @@ describe('assetsManager', () => {
           return Promise.resolve(`const img = "https://example.com/new-asset.png"`)
         }
         if (filePath.endsWith('metadata.json')) {
-          return Promise.resolve(`{"image": "https://example.com/new-asset.png"}`)
+          return Promise.resolve(`{"image": "https://example.com/new-asset.png", "version": "1.0.0"}`)
         }
         return Promise.resolve('')
       })
@@ -769,7 +769,14 @@ describe('assetsManager', () => {
       )
       expect(mocks.writeFile).toHaveBeenCalledWith(
         expect.stringMatching(/metadata\.json$/),
-        `{"image": "${assetsManager.baseUrl}/0.png"}`,
+        `{"image": "${assetsManager.baseUrl}/0.png", "version": "1.0.0"}`,
+        'utf-8',
+      )
+
+      //* With old image as we didn't actually write it due to the mocking
+      expect(mocks.writeFile).toHaveBeenCalledWith(
+        expect.stringMatching(/metadata\.json$/),
+        `{\n  "image": "https://example.com/new-asset.png",\n  "version": "1.0.1"\n}`,
         'utf-8',
       )
     })

--- a/cli/src/commands/updateAssets.ts
+++ b/cli/src/commands/updateAssets.ts
@@ -15,15 +15,10 @@ function hasGitChanges(): boolean {
   return output.length > 0
 }
 
-//* Command to update assets and manage GitHub status checks in PRs
+//* Command to update assets and manage GitHub status checks for push events
 export async function updateAssets() {
   if (!isCI) {
     return exit(MESSAGES.ciOnly)
-  }
-
-  const pullRequest = github.context.payload.pull_request
-  if (!pullRequest) {
-    return exit(MESSAGES.noPullRequest)
   }
 
   //* Only run for PreMiD/Presences repository
@@ -40,13 +35,9 @@ export async function updateAssets() {
     return exit(MESSAGES.noCdnToken)
   }
 
-  const headRef = process.env.HEAD_REF
-  if (!headRef) {
-    return exit(MESSAGES.noHeadRef)
-  }
-
   const octokit = github.getOctokit(token)
   const context = github.context
+  const sha = context.sha
 
   const { changed, deleted } = await getChangedActivities()
 
@@ -56,7 +47,7 @@ export async function updateAssets() {
   if (changed.length === 0 && deleted.length === 0) {
     await octokit.rest.repos.createCommitStatus({
       ...context.repo,
-      sha: pullRequest.head.sha,
+      sha,
       state: 'success',
       description: MESSAGES.noActivities,
       context: NAME,
@@ -65,66 +56,13 @@ export async function updateAssets() {
     return success(MESSAGES.noActivities)
   }
 
-  //* Fetch all pages of reviews
-  const reviews = await octokit.paginate(octokit.rest.pulls.listReviews, {
-    ...context.repo,
-    pull_number: pullRequest.number,
-  })
-
-  core.info(`Found ${reviews.length} reviews for PR #${pullRequest.number}`)
-
-  //* Count only approved reviews from reviewers with write access (excluding PR author)
-  const uniqueApprovers = new Set(
-    reviews
-      .filter(review =>
-        review.state === 'APPROVED'
-        && review.user?.login !== pullRequest.user.login,
-      )
-      .map(review => review.user?.login)
-      .filter((login): login is string => login !== undefined),
-  )
-
-  core.debug(`Found ${uniqueApprovers.size} unique approvers`)
-
-  let approvalCount = 0
-  for (const reviewer of uniqueApprovers) {
-    try {
-      const { data: permission } = await octokit.rest.repos.getCollaboratorPermissionLevel({
-        ...context.repo,
-        username: reviewer,
-      })
-
-      if (['admin', 'write'].includes(permission.permission)) {
-        approvalCount++
-      }
-    }
-    catch {
-      //* Skip if we can't get permissions (user no longer has access, etc.)
-      continue
-    }
-  }
-
-  core.info(`Approval count: ${approvalCount}`)
-
-  if (approvalCount < 2) {
-    await octokit.rest.repos.createCommitStatus({
-      ...context.repo,
-      sha: pullRequest.head.sha,
-      state: 'pending',
-      description: MESSAGES.waitingForApprovals,
-      context: NAME,
-    })
-
-    return success(MESSAGES.waitingForApprovals)
-  }
-
-  core.info('Approvals found, checking and updating assets...')
+  core.info('Checking and updating assets...')
 
   try {
     //* Create pending status while we process
     await octokit.rest.repos.createCommitStatus({
       ...context.repo,
-      sha: pullRequest.head.sha,
+      sha,
       state: 'pending',
       description: MESSAGES.checkingAndUpdatingAssets,
       context: NAME,
@@ -147,7 +85,7 @@ export async function updateAssets() {
     if (!valid) {
       await octokit.rest.repos.createCommitStatus({
         ...context.repo,
-        sha: pullRequest.head.sha,
+        sha,
         state: 'failure',
         description: MESSAGES.someInvalidAssets,
         context: NAME,
@@ -187,7 +125,7 @@ export async function updateAssets() {
       core.info('No changes to commit')
       await octokit.rest.repos.createCommitStatus({
         ...context.repo,
-        sha: pullRequest.head.sha,
+        sha,
         state: 'success',
         description: MESSAGES.assetsUpdatedCount(count),
         context: NAME,
@@ -209,7 +147,7 @@ export async function updateAssets() {
       core.info('No changes to commit')
       await octokit.rest.repos.createCommitStatus({
         ...context.repo,
-        sha: pullRequest.head.sha,
+        sha,
         state: 'success',
         description: MESSAGES.assetsUpdatedCount(count),
         context: NAME,
@@ -221,13 +159,13 @@ export async function updateAssets() {
     core.info('Committing and pushing changes')
     execSync('git add .')
     execSync('git commit -m "chore: update assets"')
-    execSync(`git push origin HEAD:"${headRef}"`)
+    execSync('git push')
 
     await octokit.rest.repos.createCommitStatus({
       ...context.repo,
-      sha: pullRequest.head.sha,
-      state: 'pending',
-      description: MESSAGES.assetsUpdatedCount(count, true),
+      sha,
+      state: 'success',
+      description: MESSAGES.assetsUpdatedCount(count),
       context: NAME,
     })
   }
@@ -235,7 +173,7 @@ export async function updateAssets() {
     //* Update status to failure if something goes wrong
     await octokit.rest.repos.createCommitStatus({
       ...context.repo,
-      sha: pullRequest.head.sha,
+      sha,
       state: 'failure',
       description: error instanceof Error ? error.message : MESSAGES.error,
       context: NAME,

--- a/cli/src/util/log.ts
+++ b/cli/src/util/log.ts
@@ -28,7 +28,6 @@ export const MESSAGES = {
   noMongoUrl: 'MONGO_URL environment variable is required',
   noMongoConnection: 'Failed to connect to MongoDB',
   noActivities: 'No activities changed',
-  waitingForApprovals: 'Waiting for 2 approvals...',
   checkingAndUpdatingAssets: 'Checking and updating assets...',
   someInvalidAssets: 'Some invalid assets were found, check the logs for more details',
   assetsUpdated: 'Assets have been updated successfully',

--- a/cli/src/util/log.ts
+++ b/cli/src/util/log.ts
@@ -23,11 +23,9 @@ export function info(message: string) {
 
 export const MESSAGES = {
   ciOnly: 'This command can only be run in a CI environment',
-  noPullRequest: 'This command can only be run in a pull request',
   noToken: 'GITHUB_TOKEN environment variable is required',
   noCdnToken: 'CDN_TOKEN environment variable is required',
   noMongoUrl: 'MONGO_URL environment variable is required',
-  noHeadRef: 'HEAD_REF environment variable is required',
   noMongoConnection: 'Failed to connect to MongoDB',
   noActivities: 'No activities changed',
   waitingForApprovals: 'Waiting for 2 approvals...',
@@ -36,5 +34,5 @@ export const MESSAGES = {
   assetsUpdated: 'Assets have been updated successfully',
   error: 'An error occurred',
   wrongRepository: 'This command can only be run in PreMiD/Presences repository',
-  assetsUpdatedCount: (count: number, committing = false) => count === 0 ? 'No assets updated' : `${count} assets updated successfully${committing ? ' and pushed to GitHub' : ''}`,
+  assetsUpdatedCount: (count: number) => count === 0 ? 'No assets updated' : `${count} assets updated successfully`,
 }


### PR DESCRIPTION
This pull request includes significant changes to the workflow configuration and the `AssetsManager` class, along with updates to the `updateAssets` command. The most important changes involve modifying the workflow triggers, enhancing the asset versioning process, and simplifying the `updateAssets` command by removing pull request specific logic.

### Workflow Configuration Updates:

* [`.github/workflows/assets-updater.yml`](diffhunk://#diff-07c679f10bffd54861ad48e7d7629fb050a37f36e751eaef128ecc9e58102392L4-L15): Changed the workflow trigger from pull request events to push events on the main branch and specific file paths.

### Enhancements to Asset Versioning:

* [`cli/src/classes/AssetsManager.ts`](diffhunk://#diff-e1a5bb40359efc5a6ffb6bc1fe5186a9e2794df3c431726c3f8bdc8ff86eb0beR443-R461): Added logic to increment the version in `metadata.json` when assets are replaced or uploaded. [[1]](diffhunk://#diff-e1a5bb40359efc5a6ffb6bc1fe5186a9e2794df3c431726c3f8bdc8ff86eb0beR443-R461) [[2]](diffhunk://#diff-e1a5bb40359efc5a6ffb6bc1fe5186a9e2794df3c431726c3f8bdc8ff86eb0beR516) [[3]](diffhunk://#diff-e1a5bb40359efc5a6ffb6bc1fe5186a9e2794df3c431726c3f8bdc8ff86eb0beR525) [[4]](diffhunk://#diff-e1a5bb40359efc5a6ffb6bc1fe5186a9e2794df3c431726c3f8bdc8ff86eb0beR539-R545)
* [`cli/src/classes/AssetsManager.test.ts`](diffhunk://#diff-01a3f09c8eb6439cff778e9e7d7bfe128b43b7022d0408655a5f95d6c22a0491L748-R748): Updated tests to include versioning in `metadata.json`. [[1]](diffhunk://#diff-01a3f09c8eb6439cff778e9e7d7bfe128b43b7022d0408655a5f95d6c22a0491L748-R748) [[2]](diffhunk://#diff-01a3f09c8eb6439cff778e9e7d7bfe128b43b7022d0408655a5f95d6c22a0491L772-R779)

### Simplification of `updateAssets` Command:

* [`cli/src/commands/updateAssets.ts`](diffhunk://#diff-e0d7b17faff57a0f37d4262c53253e9c8b73d8a73610910b4ed1047252ecfbaeL18-L28): Removed pull request specific checks and logic, adapting the command to handle push events instead. [[1]](diffhunk://#diff-e0d7b17faff57a0f37d4262c53253e9c8b73d8a73610910b4ed1047252ecfbaeL18-L28) [[2]](diffhunk://#diff-e0d7b17faff57a0f37d4262c53253e9c8b73d8a73610910b4ed1047252ecfbaeL43-R40) [[3]](diffhunk://#diff-e0d7b17faff57a0f37d4262c53253e9c8b73d8a73610910b4ed1047252ecfbaeL59-R50) [[4]](diffhunk://#diff-e0d7b17faff57a0f37d4262c53253e9c8b73d8a73610910b4ed1047252ecfbaeL68-R65) [[5]](diffhunk://#diff-e0d7b17faff57a0f37d4262c53253e9c8b73d8a73610910b4ed1047252ecfbaeL150-R88) [[6]](diffhunk://#diff-e0d7b17faff57a0f37d4262c53253e9c8b73d8a73610910b4ed1047252ecfbaeL190-R128) [[7]](diffhunk://#diff-e0d7b17faff57a0f37d4262c53253e9c8b73d8a73610910b4ed1047252ecfbaeL212-R150) [[8]](diffhunk://#diff-e0d7b17faff57a0f37d4262c53253e9c8b73d8a73610910b4ed1047252ecfbaeL224-R176)
* [`cli/src/util/log.ts`](diffhunk://#diff-59f1116c77d9af1e578bb60b0a4e894ae2619b1bdf8e193dc66e02fc079fe3a1L26-R36): Updated messages to reflect the removal of pull request specific logic.

These changes streamline the asset update process and ensure proper versioning of assets in the repository.