### PR TITLE
fix(Reddit): empty smallImageKey causes presence bug

### DIFF
--- a/websites/R/Reddit/metadata.json
+++ b/websites/R/Reddit/metadata.json
@@ -40,7 +40,7 @@
     "new.reddit.com",
     "old.reddit.com"
   ],
-  "version": "3.1.16",
+  "version": "3.1.17",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/R/Reddit/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/R/Reddit/assets/thumbnail.png",
   "color": "#ff4500",

--- a/websites/R/Reddit/presence.ts
+++ b/websites/R/Reddit/presence.ts
@@ -66,7 +66,7 @@ presence.on('UpdateData', async () => {
     largeImageKey: !pathname.includes('/r/netflix')
       ? ActivityAssets.Logo
       : ActivityAssets.NetflixLogo,
-    smallImageKey: pathname.includes('/r/netflix') ? ActivityAssets.Logo : '',
+    smallImageKey: pathname.includes('/r/netflix') ? ActivityAssets.Logo : null,
     startTimestamp,
   }
 


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
This PR fixes #9283, where the Reddit presence's setActivity call is ignored due to an empty `smallImageKey` value.

note: this might've been introduced in a breaking change for the extension, in which case i'm happy to open a PR for all affected presences :)

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
![image](https://github.com/user-attachments/assets/fd3f403f-88d4-41b1-89fd-e8fe6b83f8cf)



</details>
