### PR TITLE
chore: improve GitHub workflow file names

### DIFF
--- a/.github/workflows/assets-updater.yml
+++ b/.github/workflows/assets-updater.yml
@@ -1,4 +1,4 @@
-name: pmd
+name: Assets Updater
 
 on:
   push:

--- a/.github/workflows/pmd.yml
+++ b/.github/workflows/pmd.yml
@@ -1,4 +1,4 @@
-name: pmd
+name: Validate
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: pmd
+name: Release
 on:
   push:
     branches:


### PR DESCRIPTION
This pull request includes changes to the workflow configuration files to update the names of the workflows for better clarity.

Workflow name updates:

* [`.github/workflows/assets-updater.yml`](diffhunk://#diff-07c679f10bffd54861ad48e7d7629fb050a37f36e751eaef128ecc9e58102392L1-R1): Changed the workflow name from `pmd` to `Assets Updater`.
* [`.github/workflows/pmd.yml`](diffhunk://#diff-be8f5db58413faadcbdf204b62bd366ed47d9f86f86b184c621fb4f50f885bf0L1-R1): Changed the workflow name from `pmd` to `Validate`.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L1-R1): Changed the workflow name from `pmd` to `Release`.