### PR TITLE
feat(e-typing): add e-typing presence

### DIFF
--- a/websites/E/e-typing/metadata.json
+++ b/websites/E/e-typing/metadata.json
@@ -6,7 +6,8 @@
   },
   "service": "e-typing",
   "description": {
-    "en": "e-typing"
+    "en": "Japanese typing practice service. Improving your typing skills even a little can expand your possibilities.",
+    "ja": "タイピングが少しうまくなると可能性が広がる。"
   },
   "url": "www.e-typing.ne.jp",
   "version": "1.0.0",

--- a/websites/E/e-typing/metadata.json
+++ b/websites/E/e-typing/metadata.json
@@ -15,7 +15,6 @@
   "color": "#fb9d2c",
   "category": "games",
   "tags": ["game", "typing"],
-  "iframe": false,
   "settings": [
     {
       "id": "privacy",

--- a/websites/E/e-typing/metadata.json
+++ b/websites/E/e-typing/metadata.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.7",
+  "author": {
+    "name": "Toshi",
+    "id": "548698164874575875"
+  },
+  "service": "e-typing",
+  "description": {
+    "en": "e-typing"
+  },
+  "url": "www.e-typing.ne.jp",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/FbaFi9M.png",
+  "thumbnail": "https://i.imgur.com/ynvp2J1.png",
+  "color": "#fb9d2c",
+  "category": "games",
+  "tags": ["game", "typing"],
+  "iframe": false,
+  "settings": [
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "icon": "fad fa-user-secret",
+      "value": false
+    }
+  ]
+}

--- a/websites/E/e-typing/metadata.json
+++ b/websites/E/e-typing/metadata.json
@@ -15,13 +15,5 @@
   "thumbnail": "https://i.imgur.com/ynvp2J1.png",
   "color": "#fb9d2c",
   "category": "games",
-  "tags": ["game", "typing"],
-  "settings": [
-    {
-      "id": "privacy",
-      "title": "Privacy Mode",
-      "icon": "fad fa-user-secret",
-      "value": false
-    }
-  ]
+  "tags": ["game", "typing"]
 }

--- a/websites/E/e-typing/presence.ts
+++ b/websites/E/e-typing/presence.ts
@@ -29,7 +29,7 @@ function getMode() {
   else if (search.includes('kana.1')) {
     return 'kana'
   }
-  else if (search.includes('kana.1')) {
+  else if (search.includes('.0')) {
     return 'roma'
   }
 

--- a/websites/E/e-typing/presence.ts
+++ b/websites/E/e-typing/presence.ts
@@ -79,12 +79,6 @@ function generatePresenceData() {
     state: wordTitle,
     startTimestamp: browsingTimestamp,
     type: ActivityType.Playing,
-    buttons: [
-      {
-        url: 'https://www.e-typing.ne.jp',
-        label: 'e-typingを開く',
-      },
-    ],
   }
 
   if (mode === 'english') {

--- a/websites/E/e-typing/presence.ts
+++ b/websites/E/e-typing/presence.ts
@@ -10,11 +10,6 @@ const kanaLargeImageKey = 'https://i.imgur.com/gJwNzqB.png'
 const browsingTimestamp = Math.floor(Date.now() / 1000)
 
 presence.on('UpdateData', async () => {
-  const privacy = await presence.getSetting<boolean>('privacy')
-  if (privacy) {
-    return presence.clearActivity()
-  }
-
   const presenceData = generatePresenceData()
 
   presence.setActivity(presenceData)

--- a/websites/E/e-typing/presence.ts
+++ b/websites/E/e-typing/presence.ts
@@ -61,7 +61,6 @@ function getTypingContentWindowInfo() {
     const sessionStorageWordTitle = sessionStorage.getItem('presence:wordTitle') ?? ''
 
     if (!sessionStorageWordTitle) {
-      console.log(sessionStorageWordTitle)
       sessionStorage.setItem('presence:wordTitle', wordTitle)
       return { windowTitle, wordTitle: `お題: ${wordTitle}` }
     }
@@ -70,7 +69,6 @@ function getTypingContentWindowInfo() {
 
       return { windowTitle: replacedWindowTitle, wordTitle: `お題: ${sessionStorageWordTitle}` }
     }
-
   }
 
   sessionStorage.setItem('presence:wordTitle', '')

--- a/websites/E/e-typing/presence.ts
+++ b/websites/E/e-typing/presence.ts
@@ -1,0 +1,118 @@
+import { ActivityType } from 'premid'
+
+const presence = new Presence({
+  clientId: '1343107487477399592',
+})
+
+const romaLargeImageKey = 'https://i.imgur.com/FbaFi9M.png'
+const englishLargeImageKey = 'https://i.imgur.com/55iKGjg.png'
+const kanaLargeImageKey = 'https://i.imgur.com/gJwNzqB.png'
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+presence.on('UpdateData', async () => {
+  const privacy = await presence.getSetting<boolean>('privacy')
+  if (privacy) {
+    return presence.clearActivity()
+  }
+
+  const presenceData = generatePresenceData()
+
+  presence.setActivity(presenceData)
+})
+
+function getMode() {
+  const { search } = location
+
+  if (search.includes('.2')) {
+    return 'english'
+  }
+  else if (search.includes('kana.1')) {
+    return 'kana'
+  }
+  else if (search.includes('kana.1')) {
+    return 'roma'
+  }
+
+  const headerImgSrc = document.querySelector<HTMLImageElement>('#etyping img')?.src ?? ''
+  const paths = headerImgSrc.split('/').filter(i => i !== '')
+  const mode = paths[3]
+
+  if (mode === 'eng') {
+    return 'english'
+  }
+  else if (mode === 'kana') {
+    return 'kana'
+  }
+  else {
+    return 'roma'
+  }
+}
+
+function getTypingContentWindowInfo() {
+  const typingContent = document.querySelector<HTMLIFrameElement>('#typing_content')
+  const appElement = typingContent?.contentDocument?.querySelector<HTMLDivElement>('#start_view > .title') ?? document.getElementById('app')
+
+  if (typingContent || appElement) {
+    const windowTitleElement = document.querySelector<HTMLParagraphElement>('.pp_description') ?? window.parent.document.querySelector<HTMLParagraphElement>('.pp_description')
+    const windowTitle = windowTitleElement?.textContent ?? ''
+
+    const wordTitleElement = typingContent?.contentDocument?.querySelector<HTMLDivElement>('#start_view > .title') ?? document.querySelector<HTMLDivElement>('#start_view > .title')
+    const wordTitle = wordTitleElement?.textContent ?? ''
+    const sessionStorageWordTitle = sessionStorage.getItem('presence:wordTitle') ?? ''
+
+    if (!sessionStorageWordTitle) {
+      console.log(sessionStorageWordTitle)
+      sessionStorage.setItem('presence:wordTitle', wordTitle)
+      return { windowTitle, wordTitle: `お題: ${wordTitle}` }
+    }
+    else {
+      const replacedWindowTitle = location.search.includes('trysc.trysc.trysc') ? '腕試しレベルチェック' : windowTitle.replace(sessionStorageWordTitle, '')
+
+      return { windowTitle: replacedWindowTitle, wordTitle: `お題: ${sessionStorageWordTitle}` }
+    }
+
+  }
+
+  sessionStorage.setItem('presence:wordTitle', '')
+  return { windowTitle: '', wordTitle: '' }
+}
+
+function generatePresenceData() {
+  const mode = getMode()
+
+  const { windowTitle: categoryTitle, wordTitle } = getTypingContentWindowInfo()
+
+  const presenceData: PresenceData = {
+    state: wordTitle,
+    startTimestamp: browsingTimestamp,
+    type: ActivityType.Playing,
+    buttons: [
+      {
+        url: 'https://www.e-typing.ne.jp',
+        label: 'e-typingを開く',
+      },
+    ],
+  }
+
+  if (mode === 'english') {
+    presenceData.largeImageKey = englishLargeImageKey
+
+    if (categoryTitle) {
+      presenceData.details = `${categoryTitle} (英語)`
+    }
+  }
+  else if (mode === 'kana') {
+    presenceData.largeImageKey = kanaLargeImageKey
+    if (categoryTitle) {
+      presenceData.details = `${categoryTitle} (かな)`
+    }
+  }
+  else {
+    presenceData.largeImageKey = romaLargeImageKey
+    if (categoryTitle) {
+      presenceData.details = `${categoryTitle} (ローマ字)`
+    }
+  }
+
+  return presenceData
+}


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Add the e-typing presence for https://www.e-typing.ne.jp/.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

<img width="250" src="https://github.com/user-attachments/assets/fef5d755-1eb5-4325-a4e2-f73e42225e4f" />

<img width="250" src="https://github.com/user-attachments/assets/a1b84ff4-544b-4c08-b194-2342adbb3d02" />


</details>
