### PR TITLE
fix(GitHub Codespaces): fix presence updates in editor

### DIFF
--- a/websites/G/GitHub Codespaces/metadata.json
+++ b/websites/G/GitHub Codespaces/metadata.json
@@ -20,7 +20,7 @@
   },
   "url": "github.dev",
   "regExp": "(.*[.])?github.dev",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/G/GitHub%20Codespaces/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/G/GitHub%20Codespaces/assets/thumbnail.png",
   "color": "#000000",

--- a/websites/G/GitHub Codespaces/presence.ts
+++ b/websites/G/GitHub Codespaces/presence.ts
@@ -610,7 +610,7 @@ presence.on('UpdateData', async () => {
       presenceData.details = 'Inactive Codespace'
     // Idle/Start Screen
   }
-  else if (activeTab && editorMode) {
+  else if (activeTab?.getAttribute('data-resource-name') && editorMode?.getAttribute('aria-label')) {
     const branch = scmTab?.textContent?.trim()
     const workspace = scmTab!.getAttribute('aria-label')!.split('(Git)')[0]
     const filename = activeTab.getAttribute('data-resource-name')


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
For some reason, the if check used to see if the codespace is in an editor did not update out of "Idling..." for me, changing it to check the specific element attributes and if they exist fixed it. Something something codepaths, I don't know.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/user-attachments/assets/08bdf134-e43f-4a7b-93d5-a9ede1e02159)
![image](https://github.com/user-attachments/assets/f1715c29-fa22-403e-be52-13b7417397b2)

</details>

