### PR TITLE
feat(SoundCloud): add statusdisplaytype and linking

### DIFF
--- a/websites/S/SoundCloud/metadata.json
+++ b/websites/S/SoundCloud/metadata.json
@@ -27,7 +27,7 @@
     "zh-tw": "SoundCloud是一個線上音樂分享平臺，它允許人們合作、交流和分享原創音樂錄音。"
   },
   "url": "soundcloud.com",
-  "version": "2.5.8",
+  "version": "2.6.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/S/SoundCloud/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/S/SoundCloud/assets/thumbnail.jpg",
   "color": "#FF7E30",
@@ -72,22 +72,21 @@
       "value": true
     },
     {
-      "id": "buttons",
-      "title": "Show Buttons",
-      "icon": "fas fa-compress-arrows-alt",
+      "id": "links",
+      "title": "Link to Song/Artist",
+      "icon": "fas fa-arrow-up-right-from-square",
       "value": true
     },
     {
-      "id": "usePresenceTitle",
-      "title": "Show Title as Presence",
+      "id": "displayType",
+      "title": "Pick Status Display",
       "icon": "fad fa-user-edit",
-      "value": false
-    },
-    {
-      "id": "usePresenceArtist",
-      "title": "Show Artist as Presence",
-      "icon": "fad fa-user-edit",
-      "value": false
+      "value": 1,
+      "values": [
+        "Activity Name",
+        "Artist Name",
+        "Song Title"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

Changed the usage of presenceData.name to using statusDisplayType instead to be more consistent with discords way of doing things.
Changed buttons to links
Merged the two separate display type settings into one list setting
Changed some wording in the settings

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

<img width="568" height="427" alt="Discord_fhEKMqNH0W" src="https://github.com/user-attachments/assets/1738130f-d53a-4c5c-83d5-53b657d4e5a2" />
<img width="420" height="600" alt="EIXZ4fHIgl" src="https://github.com/user-attachments/assets/47727e70-e327-479f-87d2-68c5d93efeeb" />

![Discord_N0l8GEIBNQ](https://github.com/user-attachments/assets/4a892f7d-cac6-409d-86d7-4a9fbfc5209b)

</details>
