### PR TITLE
feat(YouTube Music): statusDisplayType and links

### DIFF
--- a/websites/Y/YouTube Music/dataGetter.ts
+++ b/websites/Y/YouTube Music/dataGetter.ts
@@ -13,6 +13,7 @@ export interface MediaDataGetter {
   getRepeatMode: () => string | null
   getVideoElement: () => HTMLMediaElement | null
   getAlbumArtistLink: () => string | undefined
+  getArtistLink: () => string | undefined
   getCurrentAndTotalTime: () => [string, string] | null
   hasValidPlaybackState: () => boolean
   isPlaying: () => boolean
@@ -99,6 +100,10 @@ export class YouTubeMusicDataGetter implements MediaDataGetter {
       return links.at(-1)?.href
     }
 
+    return document.querySelector<HTMLAnchorElement>('.byline a')?.href
+  }
+
+  getArtistLink(): string | undefined {
     return document.querySelector<HTMLAnchorElement>('.byline a')?.href
   }
 

--- a/websites/Y/YouTube Music/listeningPresence.ts
+++ b/websites/Y/YouTube Music/listeningPresence.ts
@@ -1,7 +1,7 @@
 import type { MediaData, MediaDataGetter } from './dataGetter.js'
 import type { Strings } from './i18n.js'
 import type { Settings } from './utils.js'
-import { ActivityType, Assets } from 'premid'
+import { ActivityType, Assets, StatusDisplayType } from 'premid'
 import { ActivityAssets } from './constants.js'
 
 export function createListeningPresence(
@@ -17,10 +17,11 @@ export function createListeningPresence(
     showButtons,
     showTimestamps,
     showCover,
-    showAsListening,
+    displayType,
   } = settings
 
   const albumArtistBtnLink = dataGetter.getAlbumArtistLink()
+  const artistLink = dataGetter.getArtistLink()
   const buttons: [ButtonData, ButtonData?] = [
     {
       label: strings.listenAlong,
@@ -37,14 +38,30 @@ export function createListeningPresence(
 
   const presenceData: PresenceData = {
     type: ActivityType.Listening,
-    name: showAsListening
-      ? mediaData.title
-      : 'YouTube Music',
     largeImageKey: showCover
       ? mediaData.artwork ?? ActivityAssets.Logo
       : ActivityAssets.Logo,
     details: mediaData.title,
     state: mediaData.artist,
+  }
+
+  if (settings.links) {
+    presenceData.detailsUrl = `https://music.youtube.com/watch?v=${watchID}`
+    if (albumArtistBtnLink) {
+      presenceData.largeImageUrl = albumArtistBtnLink
+    }
+    if (artistLink) {
+      presenceData.stateUrl = artistLink
+    }
+  }
+
+  switch (displayType) {
+    case 1:
+      presenceData.statusDisplayType = StatusDisplayType.State
+      break
+    case 2:
+      presenceData.statusDisplayType = StatusDisplayType.Details
+      break
   }
 
   if (mediaData.album) {

--- a/websites/Y/YouTube Music/metadata.json
+++ b/websites/Y/YouTube Music/metadata.json
@@ -20,7 +20,7 @@
     "zh-tw": "一個支援 Android，iOS 和 PC 的音樂平台。官方專輯，單曲，視頻，混音，現場表演都在這裡！"
   },
   "url": "music.youtube.com",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube%20Music/assets/thumbnail.png",
   "color": "#E40813",
@@ -41,13 +41,15 @@
       "value": false
     },
     {
-      "id": "showAsListening",
-      "title": "Show song in status",
-      "icon": "fad fa-music",
-      "if": {
-        "privacy": false
-      },
-      "value": false
+      "id": "displayType",
+      "title": "Pick Status Display",
+      "icon": "fad fa-user-edit",
+      "value": 1,
+      "values": [
+        "Activity Name",
+        "Artist Name",
+        "Song Title"
+      ]
     },
     {
       "id": "cover",
@@ -90,6 +92,12 @@
       "if": {
         "privacy": false
       }
+    },
+    {
+      "id": "links",
+      "title": "Link to Song/Album/Artist",
+      "icon": "fas fa-arrow-up-right-from-square",
+      "value": true
     }
   ]
 }

--- a/websites/Y/YouTube Music/utils.ts
+++ b/websites/Y/YouTube Music/utils.ts
@@ -8,7 +8,8 @@ export interface Settings {
   hidePaused: boolean
   showBrowsing: boolean
   privacyMode: boolean
-  showAsListening: boolean
+  displayType: number
+  links: boolean
 }
 
 export function updateSongTimestamps(
@@ -48,7 +49,8 @@ export async function getSettings(presence: Presence): Promise<Settings> {
     hidePaused,
     showBrowsing,
     privacyMode,
-    showAsListening,
+    displayType,
+    links,
   ] = await Promise.all([
     presence.getSetting<boolean>('buttons'),
     presence.getSetting<boolean>('timestamps'),
@@ -56,7 +58,8 @@ export async function getSettings(presence: Presence): Promise<Settings> {
     presence.getSetting<boolean>('hidePaused'),
     presence.getSetting<boolean>('browsing'),
     presence.getSetting<boolean>('privacy'),
-    presence.getSetting<boolean>('showAsListening'),
+    presence.getSetting<number>('displayType'),
+    presence.getSetting<boolean>('links'),
   ])
 
   return {
@@ -66,6 +69,7 @@ export async function getSettings(presence: Presence): Promise<Settings> {
     hidePaused,
     showBrowsing,
     privacyMode,
-    showAsListening,
+    displayType,
+    links,
   }
 }


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
added statusDisplayType setting for activity name/artist/song
added links to the text

Wasn't sure if I should be removing buttons from activities if the links make them redundant/point to the same pages, would like input from the reviewers on this.

Resolves #10023 
Resolves #10043 
Resolves #10048

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![Discord_NWAW6OUext](https://github.com/user-attachments/assets/e557d94c-8f92-416c-82fa-49f4f17f271a)
<img width="420" height="600" alt="Hiuzw0E2eC" src="https://github.com/user-attachments/assets/309d7cde-7628-404f-aacd-199a5b579422" />
<img width="251" height="57" alt="Discord_pODNsR5Y5r" src="https://github.com/user-attachments/assets/fbf4b50b-86ff-4817-8126-d3073d462553" />
<img width="247" height="44" alt="Discord_bgin3lXmfK" src="https://github.com/user-attachments/assets/b65477f5-b602-4d28-aa99-3e4865ade92c" />



</details>
