### PR TITLE
feat(bilibili): show avatar

### DIFF
--- a/websites/B/bilibili/metadata.json
+++ b/websites/B/bilibili/metadata.json
@@ -31,7 +31,7 @@
     "biligame.com"
   ],
   "regExp": "([a-z0-9-]+[.])*(bilibili|biligame)[.]com[/]",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/B/bilibili/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/B/bilibili/assets/thumbnail.jpg",
   "color": "#05acff",

--- a/websites/B/bilibili/presence.ts
+++ b/websites/B/bilibili/presence.ts
@@ -44,6 +44,7 @@ presence.on('UpdateData', async () => {
     readingAPost: 'general.readingAPost',
     browsingMyFeed: 'bilibili.browsingMyFeed',
     viewingMessages: 'bilibili.viewingMessages',
+    viewingAnUser: 'general.viewAnUser',
     viewingUserSpace: 'general.viewUser',
     watchingStream: 'bilibili.watchingStream',
     searchingFor: 'bilibili.searchingFor',
@@ -246,6 +247,10 @@ presence.on('UpdateData', async () => {
       break
     }
     case 'space.bilibili.com': {
+      if (privacy) {
+        presenceData.details = strings.viewingAnUser
+        break
+      }
       uploader = document.querySelector('.nickname')
       presenceData.details = strings.viewingUserSpace
       presenceData.state = `${uploader?.textContent} | UID:${urlpath[1]}`


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
1. When visiting a user's profile page or reading posts they have published, their profile picture will be displayed.
2. Visiting a user's profile page supports incognito mode, which does not reveal whose profile page is being accessed.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

<img width="1920" height="948" alt="Snipaste_2025-10-26_13-59-08" src="https://github.com/user-attachments/assets/5a2277dd-522e-4cce-bec5-5732025cbbe6" />
<img width="335" height="139" alt="Snipaste_2025-10-27_08-57-36" src="https://github.com/user-attachments/assets/75e7b89a-f55c-4188-baa1-42e5b23413f9" />


</details>
