### PR TITLE
fix(Sketchful.io): force presence type to playing instead of voice activity

### DIFF
--- a/websites/S/Sketchful.io/presence.ts
+++ b/websites/S/Sketchful.io/presence.ts
@@ -112,5 +112,12 @@ presence.on('UpdateData', async () => {
     }
   }
 
-  presence.setActivity(presenceData)
+if (!presenceData.details || presenceData.details.trim() === "") {
+	presenceData.details = "Browsing Sketchful.io";
+}
+
+// Force 'Playing' activity type
+presenceData.type = 0;
+
+presence.setActivity(presenceData);
 })


### PR DESCRIPTION


## Description
When playing sketchful, the presence is shown as a "Voice activity" in your friends discord. 

this is because when you join a game, the presence sends {name: "Sketchful.io", application_id: "503557087041683458", parent_application_id: null,type: 5,…}

the type should be 0. The type:5 is not voice activity but for whatever reason discord reverts to showing as a voice activity (to friends.) 

To reproduce the conditions for this follow the instructions in Issue link: (https://github.com/PreMiD/Activities/issues/10126)

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
how the presence is viewed from a friend account before the fix

<img width="796" height="274" alt="image" src="https://github.com/user-attachments/assets/d2a0117a-fdff-4a25-9c0a-24eef006e1ee" />

how the presence is viewed from a friend account after the fix
<img width="945" height="275" alt="image" src="https://github.com/user-attachments/assets/885d3d34-d0dd-4c06-b394-d028319afcb0" />



<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
