### PR TITLE
fix(Asura Scans): Activity was broken when reading a chapter

### DIFF
--- a/websites/A/Asura Scans/metadata.json
+++ b/websites/A/Asura Scans/metadata.json
@@ -9,6 +9,10 @@
     {
       "name": "rois2coeurs",
       "id": "234647775621414912"
+    },
+    {
+      "name": "lucialv",
+      "id": "300969054649450496"
     }
   ],
   "service": "Asura Scans",
@@ -28,7 +32,7 @@
     "asuracomic.net"
   ],
   "regExp": "asura.*?[.].*?[/]",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/A/Asura%20Scans/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/Asura%20Scans/assets/thumbnail.png",
   "color": "#6E3CAA",


### PR DESCRIPTION
## Description
This PR fixes the Asura Scans activity not detecting chapter pages correctly.

Asura Scans changed the structure and classes of the chapter container, causing the selector used by the activity to return `null`. Because of this:

- The chapter progress calculation threw an error.
- The activity update stopped mid-execution.
- Discord kept showing “Viewing Comic Home Page” even when the user was actually reading a chapter.

Image of the error:
<img width="1258" height="120" alt="image" src="https://github.com/user-attachments/assets/998ef7df-49bd-4f52-abea-aad9c7759be8" />


This PR updates the logic to match the new HTML structure and adds a safe fallback system:

- Replaces the old single selector with a set of valid selectors matching the current and legacy layouts.
- Adds `getChapterContainer()` to reliably detect the chapter wrapper.
- Rewrites `getChapterProgress()` so it never throws errors and only returns progress when the container exists.
- Updates the chapter route detection so chapter URLs are consistently recognised.

Overall, the activity now correctly displays chapter name, chapter number, and (when available) reading progress and without any console errors.


## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)


## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

<img width="287" height="116" alt="image" src="https://github.com/user-attachments/assets/e26cfc42-0ddf-4070-800c-8b56b332b836" />

<img width="584" height="236" alt="image" src="https://github.com/user-attachments/assets/1ebc67e3-01fa-4473-8332-cd2299640363" />


</details>
