### PR TITLE
feat(Mapple.tv): add episode info and series images for TV shows

### DIFF
--- a/websites/M/Mapple.tv/metadata.json
+++ b/websites/M/Mapple.tv/metadata.json
@@ -12,9 +12,10 @@
   "url": [
     "mapple.tv",
     "mapple.mov",
-    "mapple.uk"
+    "mapple.uk",
+    "mapple.site"
   ],
-  "version": "1.0.3",
+  "version": "1.0.4",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/M/Mapple.tv/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/M/Mapple.tv/assets/thumbnail.jpg",
   "color": "#000000",

--- a/websites/M/Mapple.tv/presence.ts
+++ b/websites/M/Mapple.tv/presence.ts
@@ -54,6 +54,15 @@ function getStatus(): string {
     return `${book} by ${author}`
   }
 
+  // TV Series: extract season and episode from URL
+  if (url.includes('/watch/tv/')) {
+    const tvMatch = url.match(/\/tv\/(\d+)-(\d+)-(\d+)/)
+    if (tvMatch) {
+      const [, tmdbId, season, episode] = tvMatch
+      return `${rawTitle} S${season}E${episode}`
+    }
+  }
+
   // Live TV: remove 'Streaming - ' prefix
   if (url.includes('/watch/channel/')) {
     return rawTitle.replace(/^Streaming\s*-\s*/i, '').trim()
@@ -116,6 +125,16 @@ async function updatePresence() {
   const presenceData: PresenceData = {
     largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/M/Mapple.tv/assets/logo.png',
     details: constructAction[action],
+  }
+
+  // For TV shows, use the series image
+  if (action === 'tv') {
+    const url = window.location.href
+    const tvMatch = url.match(/\/tv\/(\d+)-(\d+)-(\d+)/)
+    if (tvMatch) {
+      const tmdbId = tvMatch[1]
+      presenceData.largeImageKey = `https://premid-mapple-series-image-api.vercel.app/api/getImage?tmdb=${tmdbId}`
+    }
   }
 
   // Show 'Browsing' only if it's allowed


### PR DESCRIPTION
## Description

This PR adds enhanced TV series support for Mapple.tv with the following improvements:

### Changes:
1. **Season and Episode Extraction**: Extracts season and episode numbers from the URL pattern `/tv/{tmdb_id}-{season}-{episode}` and displays them in S1E1 format in the presence state
2. **Series Images**: Fetches and displays series-specific images using TMDB ID from a Vercel-hosted proxy API (`https://premid-mapple-series-image-api.vercel.app/api/getImage?tmdb={tmdb_id}`)
3. **Privacy Mode Respect**: Series images are only displayed when privacy mode is disabled, maintaining user privacy preferences

### Technical Notes:
The Vercel API is used as a proxy to TVDB's API to avoid exposing the API key in client-side code. This ensures secure access to series images while maintaining the functionality of the presence.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img width="361" height="160" alt="image" src="https://github.com/user-attachments/assets/65c03042-4ff0-489e-874e-4ea7fca984be" />

</details>