### PR TITLE
fix(url): replace .lol URL with .bid

### DIFF
--- a/websites/F/FMHY/metadata.json
+++ b/websites/F/FMHY/metadata.json
@@ -15,6 +15,7 @@
   "url": [
     "fmhy.net",
     "fmhy.pages.dev",
+    "fmhyclone.pages.dev",
     "fmhy.bid",
     "fmhy.xyz",
     "fmhy.jbugel.xyz"


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Replaced the expired .lol domain with the new .bid domain

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="1919" height="965" alt="image" src="https://github.com/user-attachments/assets/1cf56510-7892-46bb-b72a-e3200d3e078a" />
<img width="1919" height="966" alt="image" src="https://github.com/user-attachments/assets/a52b584e-4b53-4f60-8feb-54b83c7f5db3" />



</details>
