### PR TITLE
feat: auto-apply labels to DNS check PRs

### DIFF
--- a/.github/workflows/dns-check.yml
+++ b/.github/workflows/dns-check.yml
@@ -52,3 +52,8 @@ jobs:
           title: 'chore: remove activities with failed DNS checks'
           body-path: ${{ steps.dns-check.outputs.summary_path }}
           sign-commits: true
+          labels: |
+            repo maintenance
+            ${{ steps.dns-check.outputs.has_deletions == 'true' && 'activity deletion' || '' }}
+            ${{ steps.dns-check.outputs.has_updates == 'true' && 'activity update' || '' }}
+            ${{ steps.dns-check.outputs.has_multiple_activities == 'true' && 'multiple activities' || '' }}

--- a/cli/src/commands/checkDns.ts
+++ b/cli/src/commands/checkDns.ts
@@ -92,6 +92,9 @@ export async function checkDns(
         await writeFile(summaryPath, body)
         core.setOutput('has_changes', 'true')
         core.setOutput('summary_path', summaryPath)
+        core.setOutput('has_deletions', changes.removed.length > 0 ? 'true' : 'false')
+        core.setOutput('has_updates', changes.updated.length > 0 ? 'true' : 'false')
+        core.setOutput('has_multiple_activities', (changes.removed.length + changes.updated.length >= 2) ? 'true' : 'false')
       }
 
       success(


### PR DESCRIPTION
## Summary
Automatically applies appropriate labels to PRs created by the DNS check workflow based on what changes were made.

## Changes
- Enhanced CLI to output metadata about DNS check results (deletions, updates, multiple activities)
- Updated DNS check workflow to use the built-in `labels` parameter from peter-evans/create-pull-request

## Label Logic
- **repo maintenance** - Always applied (automated maintenance)
- **activity deletion** - Applied when activities are removed
- **activity update** - Applied when activities are updated  
- **multiple activities** - Applied when 2+ activities are affected

## Examples
| Scenario | Labels Applied |
|----------|----------------|
| 1 activity deleted | `repo maintenance`, `activity deletion` |
| 1 activity updated | `repo maintenance`, `activity update` |
| 2+ activities affected | All relevant labels + `multiple activities` |