### PR TITLE
feat(Shopee): add regional domains

### DIFF
--- a/websites/S/Shopee/metadata.json
+++ b/websites/S/Shopee/metadata.json
@@ -22,7 +22,7 @@
     "shopee.com.co",
     "shopee.cl"
   ],
-  "regExp": "^https?://shopee\\.(co\\.id|com\\.my|sg|com\\.br|ph|co\\.th|vn|tw|com\\.mx|com\\.co|cl)/",
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*shopee[.](co[.]id|com[.]my|sg|com[.]br|ph|co[.]th|vn|tw|com[.]mx|com[.]co|cl)[/]",
   "version": "1.2.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/S/Shopee/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/S/Shopee/assets/thumbnail.jpeg",


### PR DESCRIPTION
## Description
Adds support for several regional Shopee domains to expand the activity's reach. 
Specifically, the following domains have been added:
- Brazil (.com.br)
- Philippines (.ph)
- Thailand (.co.th)
- Vietnam (.vn)
- Taiwan (.tw)
- Mexico (.com.mx)
- Colombia (.com.co)
- Chile (.cl)
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
