### PR TITLE
fix(hackthebox): Update selectors, add settings, fix routing logic

### DIFF
--- a/websites/H/HackTheBox/metadata.json
+++ b/websites/H/HackTheBox/metadata.json
@@ -5,13 +5,19 @@
     "id": "937757295453044806",
     "name": "Atsukoro1"
   },
+  "contributors": [
+    {
+      "name": "firstoften",
+      "id": "339316517558681610"
+    }
+  ],
   "service": "HackTheBox",
   "description": {
     "en": "Hack The Box is a massive, online cybersecurity training platform, allowing individuals, companies, universities and all kinds of organizations around the world to level up their hacking skills."
   },
   "url": "app.hackthebox.com",
   "regExp": "^https?[:][/][/]app[.]hackthebox[.]com[/]",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/H/HackTheBox/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/H/HackTheBox/assets/thumbnail.jpeg",
   "color": "#9fef00",

--- a/websites/H/HackTheBox/presence.ts
+++ b/websites/H/HackTheBox/presence.ts
@@ -104,10 +104,16 @@ function getProlabDetails() {
 }
 
 presence.on('UpdateData', async () => {
+  const [showRank, showGlobalRanking, showFlags] = await Promise.all([
+    presence.getSetting<boolean>('showRank'),
+    presence.getSetting<boolean>('showGlobalRanking'),
+    presence.getSetting<boolean>('showFlags'),
+  ])
+
   const settings: DashboardSettings = {
-    showRank: await presence.getSetting<boolean>('showRank'),
-    showGlobalRanking: await presence.getSetting<boolean>('showGlobalRanking'),
-    showFlags: await presence.getSetting<boolean>('showFlags'),
+    showRank,
+    showGlobalRanking,
+    showFlags,
   }
 
   const path = window.location.pathname
@@ -115,7 +121,7 @@ presence.on('UpdateData', async () => {
   const root = parts[0]
   const resource = parts[1]
 
-  const presenceData = {
+  const presenceData: PresenceData = {
     largeImageKey: ASSETS.logo,
     largeImageText: 'HackTheBox',
   } as PresenceData


### PR DESCRIPTION
## Description
This PR significantly refines the HackTheBox activity to support the website's latest structural changes (SPA routing) and introduces high-efficiency logic for dynamic asset rendering.

Key Changes:

Architectural Overhaul: Replaced the O(n) regex-loop routing with a high-speed switch-based router, reducing processing overhead during DOM updates.

User Identity Integration: Implemented a targeted scraper to display the operative's username `(Username: {name})` on the homepage instead of a generic "Homepage" string.

Dynamic Asset Scraping:

Added support for Machine Avatars: The presence now dynamically scrapes the Machine's unique avatar URL from the HTB S3 bucket when viewing a specific machine page.

Implemented a specificity-hardened selector (`.avatar-icon-name-details`) to prevent accidental scraping of the user's profile picture.

Asset Logic: Introduced `smallImageKey` support for specific sections (Tracks, Fortresses, Challenges, etc.) utilizing a centralized asset map.

Routing Logic: Consolidated redundant state-checkers into a single `getBrowsingState` helper that dynamically reads `?tab=` query parameters.

Settings Integration: Added support for user-configurable toggles for Rank, Global Ranking, and Flags on the Dashboard via `PresenceSettings`.

Type Safety: Resolved TypeScript union-type conflicts (`PresenceData` vs `MediaPresenceData`) using explicit type casting for more robust builds.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

<img width="437" height="152" alt="image" src="https://github.com/user-attachments/assets/2177ea44-69c7-4ae1-9fab-df498598428b" />

<img width="455" height="159" alt="image" src="https://github.com/user-attachments/assets/7901955c-d3a6-49cd-86d5-9acba3cd400b" />

<img width="430" height="150" alt="image" src="https://github.com/user-attachments/assets/e95ef7c4-1d25-4498-98a0-afa9afd358da" />


</details>