### PR TITLE
feat(Deezer): add option to hide activity when paused

### DIFF
--- a/websites/D/Deezer/metadata.json
+++ b/websites/D/Deezer/metadata.json
@@ -25,7 +25,7 @@
   },
   "url": "www.deezer.com",
   "regExp": "^https?[:][/][/](www[.])?deezer[.]com[/]",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/D/Deezer/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/D/Deezer/assets/thumbnail.png",
   "color": "#a238ff",
@@ -57,7 +57,12 @@
       "icon": "fad fa-user-large",
       "value": true
     },
-
+    {
+      "id": "hidePaused",
+      "title": "Hide Paused",
+      "icon": "fad fa-pause-circle",
+      "value": false
+    },
     {
       "id": "showBrowsing",
       "title": "Show Browsing Info",

--- a/websites/D/Deezer/presence.ts
+++ b/websites/D/Deezer/presence.ts
@@ -41,13 +41,14 @@ presence.on('UpdateData', async () => {
   let strings = await getStrings()
   let paused = false
 
-  const [buttons, newLang, cover, browseInfo, artistAsTitle, showBrowsing] = await Promise.all([
+  const [buttons, newLang, cover, browseInfo, artistAsTitle, showBrowsing, hidePaused] = await Promise.all([
     presence.getSetting<boolean>('buttons'),
     presence.getSetting<string>('lang').catch(() => 'en'),
     presence.getSetting<boolean>('cover'),
     presence.getSetting<boolean>('browseInfo'),
     presence.getSetting<boolean>('artistAsTitle'),
     presence.getSetting<boolean>('showBrowsing'),
+    presence.getSetting<boolean>('hidePaused'),
   ])
   const { pathname, hostname } = document.location
   const remainingTest = document.querySelector(
@@ -121,6 +122,9 @@ presence.on('UpdateData', async () => {
 
   if (document.querySelector('[data-testid="play_button_play"]'))
     paused = true
+
+  if (hidePaused && paused)
+    return presence.clearActivity()
 
   presenceData.details = document.querySelector(
     '[data-testid="item_title"]',


### PR DESCRIPTION
## Description
Added a "Hide Paused" setting to allow users to hide their Deezer activity on Discord when the music is paused.
## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

<img width="406" height="338" alt="image" src="https://github.com/user-attachments/assets/ac5153a5-7fda-4f53-a4d8-19cd2c50d9d7" />

When off:
<img width="1072" height="346" alt="image" src="https://github.com/user-attachments/assets/30e94594-8e1c-4b51-a1ca-7fce788da1e5" />

When on:
<img width="1073" height="336" alt="image" src="https://github.com/user-attachments/assets/e750f617-71a0-4fc6-ab01-6ab7757c0c7a" />

</details>
