### PR TITLE
fix(bilibili): set default presence type to watching

### DIFF
--- a/websites/B/bilibili/metadata.json
+++ b/websites/B/bilibili/metadata.json
@@ -31,7 +31,7 @@
     "biligame.com"
   ],
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*(bilibili|biligame)[.]com[/]",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/B/bilibili/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/B/bilibili/assets/thumbnail.jpg",
   "color": "#05acff",

--- a/websites/B/bilibili/presence.ts
+++ b/websites/B/bilibili/presence.ts
@@ -36,6 +36,7 @@ presence.on('UpdateData', async () => {
       ? CustomAssets.Logo
       : navigator.mediaSession.metadata?.artwork[0]?.src
         ?? CustomAssets.Logo,
+    type: ActivityType.Watching,
   }
   const strings = await presence.getStrings({
     watchingVideo: 'general.watchingVid',


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
The vast majority of content on Bilibili consists of video and live-streaming media, so the default type should be set to Watching.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
