### PR TITLE
feat(Itaku): add activity

### DIFF
--- a/websites/I/Itaku/Itaku.json
+++ b/websites/I/Itaku/Itaku.json
@@ -1,8 +1,4 @@
 {
-  "itaku.browsingHome": {
-    "description": "Browsing the Itaku home page",
-    "message": "Browsing Home"
-  },
   "itaku.browsingPosts": {
     "description": "Browsing posts on Itaku",
     "message": "Browsing Posts"
@@ -23,49 +19,25 @@
     "description": "Browsing tags",
     "message": "Browsing Tags"
   },
-  "itaku.viewingHelp": {
-    "description": "Viewing help section",
-    "message": "Viewing Help"
-  },
-  "itaku.viewingRules": {
-    "description": "Reading site rules",
-    "message": "Reading Rules"
-  },
-  "itaku.viewingBadges": {
-    "description": "Viewing badges",
-    "message": "Viewing Badges"
-  },
-  "itaku.viewingRoadmap": {
-    "description": "Viewing site roadmap",
-    "message": "Viewing Roadmap"
-  },
-  "itaku.viewingProfile": {
-    "description": "Viewing a profile",
-    "message": "Viewing Profile"
-  },
   "itaku.viewingGallery": {
-    "description": "Viewing user gallery",
+    "description": "Viewing user's gallery",
     "message": "Viewing Gallery"
   },
-  "itaku.viewingUserPosts": {
-    "description": "Viewing user posts",
-    "message": "Viewing Posts"
-  },
   "itaku.viewingFollowers": {
-    "description": "Viewing followers",
+    "description": "Viewing user's followers",
     "message": "Viewing Followers"
   },
   "itaku.viewingFollowing": {
-    "description": "Viewing following list",
+    "description": "Viewing user's following list",
     "message": "Viewing Following"
+  },
+  "itaku.viewingUserPosts": {
+    "description": "Viewing user's posts",
+    "message": "Viewing Posts"
   },
   "itaku.viewingCommissionPage": {
     "description": "Viewing user commissions",
     "message": "Viewing Commissions"
-  },
-  "itaku.viewingDMs": {
-    "description": "Viewing direct messages",
-    "message": "Viewing Messages"
   },
   "itaku.viewingCommissionInbox": {
     "description": "Viewing commission inbox",
@@ -78,9 +50,5 @@
   "itaku.viewingSubmissionInbox": {
     "description": "Viewing submission inbox",
     "message": "Submission Inbox"
-  },
-  "itaku.viewingSettings": {
-    "description": "Viewing settings",
-    "message": "Settings"
   }
 }

--- a/websites/I/Itaku/metadata.json
+++ b/websites/I/Itaku/metadata.json
@@ -13,7 +13,7 @@
     "uk": "Itaku - це соціальна платформа для художників, де вони можуть ділитися своїми роботами, приймати замовлення та спілкуватися з іншими авторами."
   },
   "url": "itaku.ee",
-  "regExp": "^https?:\\/\\/(www\\.)?itaku\\.ee[/]?",
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*itaku[.]ee[/]",
   "version": "1.0.0",
   "logo": "https://i.imgur.com/od6sCq6.png",
   "thumbnail": "https://i.imgur.com/UnCwDtS.png",

--- a/websites/I/Itaku/presence.ts
+++ b/websites/I/Itaku/presence.ts
@@ -10,27 +10,25 @@ let currentTimestamp = browsingTimestamp
 async function getStrings() {
   return presence.getStrings({
     browsing: 'general.browsing',
-    browsingHome: 'itaku.browsingHome',
+    viewingHome: 'general.viewHome',
     browsingPosts: 'itaku.browsingPosts',
     browsingImages: 'itaku.browsingImages',
     browsingCommissions: 'itaku.browsingCommissions',
     browsingUsers: 'itaku.browsingUsers',
     browsingTags: 'itaku.browsingTags',
-    viewingHelp: 'itaku.viewingHelp',
-    viewingRules: 'itaku.viewingRules',
-    viewingBadges: 'itaku.viewingBadges',
-    viewingRoadmap: 'itaku.viewingRoadmap',
-    viewingProfile: 'itaku.viewingProfile',
+    viewingHelp: 'general.viewAHelpPage',
+    readingRules: 'general.reading',
+    viewingProfile: 'general.viewAProfile',
     viewingGallery: 'itaku.viewingGallery',
     viewingUserPosts: 'itaku.viewingUserPosts',
     viewingFollowers: 'itaku.viewingFollowers',
     viewingFollowing: 'itaku.viewingFollowing',
     viewingCommissionPage: 'itaku.viewingCommissionPage',
-    viewingDMs: 'itaku.viewingDMs',
+    viewingDMs: 'general.readingADM',
     viewingCommissionInbox: 'itaku.viewingCommissionInbox',
     viewingTagSuggestions: 'itaku.viewingTagSuggestions',
     viewingSubmissionInbox: 'itaku.viewingSubmissionInbox',
-    viewingSettings: 'itaku.viewingSettings',
+    viewingSettings: 'general.viewAccount',
   })
 }
 
@@ -55,7 +53,7 @@ presence.on('UpdateData', async () => {
   }
 
   if (pathname === '/' || pathname === '/home' || pathname === '/home/') {
-    presenceData.details = strings.browsingHome
+    presenceData.details = strings.viewingHome
   }
   else if (pathname.startsWith('/home/posts')) {
     presenceData.details = strings.browsingPosts
@@ -76,13 +74,7 @@ presence.on('UpdateData', async () => {
     presenceData.details = strings.viewingHelp
   }
   else if (pathname.startsWith('/help/rules')) {
-    presenceData.details = strings.viewingRules
-  }
-  else if (pathname.startsWith('/help/badges')) {
-    presenceData.details = strings.viewingBadges
-  }
-  else if (pathname.startsWith('/about/roadmap')) {
-    presenceData.details = strings.viewingRoadmap
+    presenceData.details = strings.readingRules
   }
   else if (pathname.startsWith('/profile/')) {
     const pathParts = pathname.split('/').filter(Boolean)


### PR DESCRIPTION
## Description
This PR adds support for Itaku, an art-focused social platform where artists can share their work, accept commissions, and connect with other creators.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://docs.premid.app/dev/presence/guidelines)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Features
- Browsing home, posts, images, commissions, users, tags
- Viewing profiles, galleries, posts
- Viewing followers, following lists
- Multilanguage support
