### PR TITLE
fix(cli): watch string files and metadata.json for changes

### DIFF
--- a/cli/src/classes/ActivityCompiler.ts
+++ b/cli/src/classes/ActivityCompiler.ts
@@ -156,6 +156,14 @@ export class ActivityCompiler {
 
         await this.ts.restart(this.compileAndSend.bind(this, { validate, zip, sarif }))
       }
+
+      // Handle string file and metadata.json changes
+      if (
+        event === 'change'
+        && (basename(path) === `${this.activity.service}.json` || basename(path) === 'metadata.json')
+      ) {
+        return this.compileAndSend({ validate, zip, sarif })
+      }
     })
 
     this.ts.watch(this.compileAndSend.bind(this, { validate, zip, sarif }))


### PR DESCRIPTION
## Summary
- Fixed file watcher not triggering updates when string files (`{service}.json`) or `metadata.json` are modified during dev mode
- Added handler in chokidar watcher to detect changes to these JSON files and call `compileAndSend()`

## Test plan
- [ ] Run `npm run dev` on an activity with a string file (e.g., PreMiD)
- [ ] Modify the string file and verify the CLI outputs "Compiling..." and sends update to extension
- [ ] Modify `metadata.json` and verify the same behavior