### PR TITLE
feat(Twitch): clear activity when lacking details

### DIFF
--- a/websites/T/Twitch/metadata.json
+++ b/websites/T/Twitch/metadata.json
@@ -51,7 +51,7 @@
     "status.twitch.tv"
   ],
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*twitch[.]tv[/]",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/T/Twitch/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/T/Twitch/assets/thumbnail.png",
   "color": "#9146FF",

--- a/websites/T/Twitch/presence.ts
+++ b/websites/T/Twitch/presence.ts
@@ -971,5 +971,5 @@ presence.on('UpdateData', async () => {
 
   if (presenceData.details)
     presence.setActivity(presenceData)
-  else presence.setActivity()
+  else presence.clearActivity()
 })


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Currently the Twitch activity shows a generic "Playing Twitch" if it has nothing to show, e.g. on the Twitch home page with Show Browsing Status disabled, which is both unpleasant to see, pointless, and, at least for me, unwanted.

This PR makes it so nothing is shown in such a case, akin to the YT Music activity if Hide Paused is enabled.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
Previous Behaviour on Twitch home page with Show Browsing Status disabled
<img width="337" height="197" alt="before" src="https://github.com/user-attachments/assets/432b2080-ece0-468b-90d1-415fea77779e" />

New Behaviour on Twitch home page with Show Browsing Status disabled
<img width="339" height="108" alt="after" src="https://github.com/user-attachments/assets/f0c7a4ad-a7ed-4550-8ecc-6d5e5c6ae0d2" />

</details>
