### PR TITLE
fix(Bunpro): support "Hide Review's Level" functionality

### DIFF
--- a/websites/B/Bunpro/metadata.json
+++ b/websites/B/Bunpro/metadata.json
@@ -33,7 +33,7 @@
     "community.bunpro.jp"
   ],
   "regExp": "^https?[:][/][/]((www|community)[.])?bunpro[.]jp[/]",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/B/Bunpro/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/B/Bunpro/assets/thumbnail.png",
   "color": "#5e6266",

--- a/websites/B/Bunpro/presence.ts
+++ b/websites/B/Bunpro/presence.ts
@@ -38,10 +38,28 @@ function applyItemDetails(presenceData: PresenceData) {
 }
 
 function applyReviewDetails(presenceData: PresenceData) {
-  const details = document.querySelector<HTMLDivElement>(
+  const details = document.querySelector(
     '#js-tour-quiz-info',
-  )?.firstChild?.childNodes
-  presenceData.state = `${details?.[1]?.textContent} correct | ${details?.[2]?.textContent} remaining`
+  )
+  const correctElement = details?.querySelector('li:has(> svg[data-name="CHECK"])')
+  const remainingElement = details?.querySelector('li:has(> svg[data-name="INBOX"])')
+  const wrapUpElement = details?.querySelector('li:has(> svg[data-name="WRAPUP"])')
+
+  const stateDetails = []
+  if (correctElement) {
+    stateDetails.push(`${correctElement?.textContent} correct`)
+  }
+
+  if (remainingElement) {
+    stateDetails.push(`${remainingElement.textContent} remaining`)
+  }
+  else if (wrapUpElement) {
+    presenceData.details = `${presenceData.details} (Wrapping up)`
+
+    stateDetails.push(wrapUpElement.textContent)
+  }
+
+  presenceData.state = stateDetails.filter(x => !!x).join(' | ')
 }
 
 function removeRubyCharacters(element: HTMLElement) {


### PR DESCRIPTION
## Description
This change supports Bunpro's "Hide Review's Level" functionality, which fixes #10413. More details on the bug.

We now find the relevant sections with more accurate CSS selectors rather than relying on their index in the parent element.

Additionally, the method for showing the details during wrap-up is changed to be explicit as it previously sort of worked by default.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary>During Reviews</summary>
Hide review's level enabled: <br>
<img width="417" height="107" alt="image" src="https://github.com/user-attachments/assets/974d365e-8d57-4f3f-b2d8-7a4733b6a5c1" />
<img width="453" height="185" alt="image" src="https://github.com/user-attachments/assets/9cdd7ea2-7ead-4e25-bde1-3afe2b1a24f9" />
 <br> <br>
Hide review's level disabled: <br>
<img width="628" height="127" alt="image" src="https://github.com/user-attachments/assets/11d59ee8-f0c9-4894-b39a-6ab3dc1850f5" />
<img width="453" height="185" alt="image" src="https://github.com/user-attachments/assets/be1e4fa1-fb67-4ab3-af58-ad8b83f438c0" />
</details>

<details>
<summary>During Review Wrap Up</summary>
Hide review's level enabled: <br>
<img width="628" height="127" alt="image" src="https://github.com/user-attachments/assets/1c9259fe-ee8a-4c31-8dbe-d701f824b3fd" />
<img width="447" height="183" alt="image" src="https://github.com/user-attachments/assets/2fbfc076-be61-4749-a7fe-0f8fdaa04cd5" />
 <br> <br>

Hide review's level disabled: <br>
<img width="532" height="101" alt="image" src="https://github.com/user-attachments/assets/4bf741b2-06ae-42c8-b57c-d277240e6dd2" />

<img width="447" height="183" alt="image" src="https://github.com/user-attachments/assets/0732de75-ecff-47d5-bc13-1ee4251550e5" />

</details>
