### PR TITLE
feat(AniHq): update domains, fix iFrame issues, add cache system & add more information

### DIFF
--- a/websites/A/AniHQ/iframe.ts
+++ b/websites/A/AniHQ/iframe.ts
@@ -1,19 +1,14 @@
 const iframe = new iFrame()
 
 iframe.on('UpdateData', () => {
-  if (document.location.hostname === 'animestream.playerp2p.com') {
-    const video = document.querySelector<HTMLVideoElement>(
-      '#media-player .jw-media video',
-    )
-    if (video && !Number.isNaN(video.duration)) {
-      iframe.send({
-        iFrameVideoData: {
-          iFrameVideo: true,
-          currTime: video.currentTime,
-          dur: video.duration,
-          paused: video.paused,
-        },
-      })
-    }
-  }
+  const video = document.querySelector<HTMLVideoElement>('video')
+  if (!video || Number.isNaN(video.duration))
+    return
+  iframe.send({
+    iFrameVideoData: {
+      currTime: video.currentTime,
+      dur: video.duration,
+      paused: video.paused || video.ended,
+    },
+  })
 })

--- a/websites/A/AniHQ/metadata.json
+++ b/websites/A/AniHQ/metadata.json
@@ -16,9 +16,9 @@
     "en": "AniHQ is a modern anime streaming site with English subbed content.",
     "hi-in": "AniHQ एक आधुनिक एनीमे स्ट्रीमिंग साइट है जहाँ आप English सब्टाइटल के साथ एनीमे देख सकते हैं।"
   },
-  "url": "anihq.to",
-  "regExp": "^https?[:][/][/]anihq[.]to[/]",
-  "version": "1.1.1",
+  "url": "anihq.org",
+  "regExp": "^https?[:][/][/](www[.])?anihq[.]org[/]",
+  "version": "1.2.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/A/AniHQ/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AniHQ/assets/thumbnail.png",
   "color": "#8151ff",
@@ -30,5 +30,5 @@
     "watch"
   ],
   "iframe": true,
-  "iFrameRegExp": "https://animestream\\.playerp2p\\.com/.*"
+  "iFrameRegExp": "https://(animestream\\.playerp2p\\.com|9ivihskdhwqv\\.playerp2p\\.com|hnexehfik2jq\\.playerp2p\\.com|byseqekaho\\.com|hglink\\.to|voe\\.sx|lauradaydo\\.com|mp4upload\\.com|hexload\\.com|mxdrop\\.to|listeamed\\.net|rubyvidhub\\.com|oneupload\\.to)/.*"
 }

--- a/websites/A/AniHQ/presence.ts
+++ b/websites/A/AniHQ/presence.ts
@@ -15,11 +15,41 @@ enum ActivityAssets {
   Logo = 'https://cdn.rcd.gg/PreMiD/websites/A/AniHQ/assets/logo.png',
 }
 
-function getAnimeNameFromTitle(raw: string | null): string {
-  if (!raw)
-    return ''
-  return raw
-    .replace(/episode\s*\d+/gi, '')
+let cacheAnime: {
+  text: string
+  numberEpisode: string
+  seasonAnime: string
+  nameAnime: string
+  bannerImg: string
+  epDesc: string | undefined | null
+} = {
+  text: '',
+  numberEpisode: 'Episode 1',
+  seasonAnime: '',
+  nameAnime: '',
+  bannerImg: ActivityAssets.Logo,
+  epDesc: '',
+}
+
+interface AnimeInfo {
+  title: string
+  episode: string
+}
+
+async function parseAnimeInfo(raw: string | null): Promise<AnimeInfo> {
+  if (!raw) {
+    return { title: '', episode: '' }
+  }
+  const cleaned = raw
+    .replace(/^\/watch\//, '')
+    .replace(/\/$/, '')
+
+  const episodeMatch = cleaned.match(/episode[- ]?(\d+)/i)
+  const episodeNumber = episodeMatch ? episodeMatch[1] : ''
+  const episode = episodeNumber ? `Episode ${episodeNumber}` : ''
+
+  const title = cleaned
+    .replace(/episode[- ]?\d.*$/gi, '')
     .replace(/\b(?:english|hindi|telugu|tamil)\b/gi, '')
     .replace(/\b(?:subbed|dubbed)\b/gi, '')
     .replace(/\b\d{4}\b/g, '')
@@ -27,6 +57,11 @@ function getAnimeNameFromTitle(raw: string | null): string {
     .replace(/\s+/g, ' ')
     .trim()
     .replace(/\b\w/g, c => c.toUpperCase())
+
+  return {
+    title,
+    episode,
+  }
 }
 
 function getGenreFromPath(path: string): string {
@@ -34,13 +69,47 @@ function getGenreFromPath(path: string): string {
   return genre.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
 }
 
-presence.on('iFrameData', (inc) => {
-  const data = (inc as any).iFrameVideoData
-  iframePlayback = !!data?.iFrameVideo
-  if (iframePlayback) {
-    currTime = data.currTime
-    durTime = data.dur
-    isPaused = data.paused
+async function getAnimeData(text: string) {
+  if (text === cacheAnime.text) {
+    return {
+      nameAnime: cacheAnime.nameAnime,
+      numberEpisode: cacheAnime.numberEpisode,
+      seasonAnime: cacheAnime.seasonAnime,
+      bannerImg: cacheAnime.bannerImg,
+      epDesc: cacheAnime.epDesc,
+    }
+  }
+  const seasonAnime = 'Season 1'
+  const animeInfo = await parseAnimeInfo(text)
+  const nameAnime = animeInfo.title || ''
+  const numberEpisode = animeInfo.episode || 'Episode 1'
+  const epDesc = document.querySelector('.anime-synopsis')?.querySelector('p')?.textContent?.trim() || 'Viewing on AnimeHQ'
+  const bannerImg = document.querySelector('.anime-featured.relative.isolate')?.querySelector('img')?.getAttribute('src') || ActivityAssets.Logo
+
+  cacheAnime = {
+    nameAnime,
+    numberEpisode,
+    epDesc,
+    bannerImg,
+    text,
+    seasonAnime,
+  }
+
+  return {
+    nameAnime,
+    numberEpisode,
+    epDesc,
+    bannerImg,
+    seasonAnime,
+  }
+}
+
+presence.on('iFrameData', (data: any) => {
+  if (data.iFrameVideoData) {
+    iframePlayback = true
+    currTime = data.iFrameVideoData.currTime
+    durTime = data.iFrameVideoData.dur
+    isPaused = data.iFrameVideoData.paused
   }
 })
 
@@ -49,17 +118,42 @@ presence.on('UpdateData', async () => {
 
   const presenceData: PresenceData = {
     details: 'Browsing AniHQ',
-    state: 'Home Page',
+    state: 'Viewing Home Page',
     largeImageKey: ActivityAssets.Logo,
-    largeImageText: 'AniHQ',
-    smallImageKey: Assets.Search,
-    smallImageText: 'AniHQ',
+    smallImageKey: Assets.Reading,
     type: ActivityType.Watching,
     startTimestamp: browsingTimestamp,
   }
-  if (pathname === '/home/') {
-    presenceData.details = 'Home Page'
-    presenceData.state = 'Browsing...'
+
+  if (pathname.includes('/watch/')) {
+    const videoPage = document.querySelector('.episode-player-info')
+    if (videoPage) {
+      const animeData = await getAnimeData(pathname)
+      if (animeData) {
+        presenceData.name = animeData.nameAnime || 'AniHQ'
+        presenceData.details = animeData.nameAnime || ''
+        presenceData.state = animeData.epDesc || 'Viewing on AniHQ'
+        presenceData.largeImageText = `${animeData.seasonAnime.toString()}, ${animeData.numberEpisode.toString()}`
+        presenceData.largeImageKey = animeData.bannerImg
+
+        if (iframePlayback) {
+          presenceData.smallImageKey = isPaused ? Assets.Pause : Assets.Play
+          presenceData.smallImageText = isPaused ? 'Pausado' : 'Reproduciendo'
+        }
+        if (!isPaused) {
+          const [startTs, endTs] = getTimestamps(
+            Math.floor(currTime),
+            Math.floor(durTime),
+          )
+          presenceData.startTimestamp = startTs
+          presenceData.endTimestamp = endTs
+        }
+        else {
+          delete presenceData.startTimestamp
+          delete presenceData.endTimestamp
+        }
+      }
+    }
   }
   else if (pathname.startsWith('/search')) {
     presenceData.details = 'Searching...'
@@ -71,67 +165,8 @@ presence.on('UpdateData', async () => {
     presenceData.state = genreName
   }
   else if (pathname.startsWith('/anime/')) {
-    const raw = pathname.split('/')[2] || ''
-    const animeName = getAnimeNameFromTitle(raw)
     presenceData.details = 'Browsing Anime'
-    presenceData.state = animeName
-  }
-  else if (pathname.startsWith('/watch/')) {
-    const titleEl = document.querySelector(
-      '.episode-head .anime-data h4 a span',
-    )
-    const epEl = document.querySelector(
-      '.episode-player-info .episode-information span:nth-child(2)',
-    )
-    const bigImg = document.querySelector(
-      '.anime-featured img',
-    )?.getAttribute('src')
-
-    const animeTitle = titleEl?.textContent?.trim()
-    const episodeNum = epEl?.textContent?.trim()
-
-    if (!animeTitle) {
-      presence.setActivity(presenceData)
-      return
-    }
-
-    presenceData.name = animeTitle
-    presenceData.details = episodeNum || ''
-    delete presenceData.state
-    presenceData.largeImageKey = bigImg || presenceData.largeImageKey
-
-    const playing = iframePlayback ? !isPaused : undefined
-    if (playing !== undefined) {
-      presenceData.smallImageKey = playing ? Assets.Play : Assets.Pause
-      presenceData.smallImageText = playing ? 'Playing' : 'Paused'
-    }
-    let curr: number | undefined, dur: number | undefined
-    if (iframePlayback) {
-      curr = Math.floor(currTime)
-      dur = Math.floor(durTime)
-    }
-    else {
-      const videoEl = document.querySelector<HTMLVideoElement>(
-        '#media-player .jw-media video',
-      )
-      if (videoEl) {
-        curr = Math.floor(videoEl.currentTime)
-        dur = Math.floor(videoEl.duration)
-      }
-    }
-
-    if (playing && curr != null && dur != null) {
-      const [startTs, endTs] = getTimestamps(curr, dur)
-      presenceData.startTimestamp = startTs
-      presenceData.endTimestamp = endTs
-    }
-    else {
-      delete presenceData.startTimestamp
-      delete presenceData.endTimestamp
-    }
-
-    presence.setActivity(presenceData)
-    return
+    presenceData.state = 'Viewing Anime Description'
   }
   presence.setActivity(presenceData)
 })


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
This is a biggest update for the presence AniHQ.
The iframe was totally fixed and fully support all video types. Also added a cache system and fixed all old selectors from the website, adding and improving how information is showed in discord!.
Fixed the new URL domaing, and reconfigured the iframe.ts too. 

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

HomePage
<img width="502" height="171" alt="image" src="https://github.com/user-attachments/assets/f0a811f3-404b-47b6-868a-0ae9200c611f" />

Categories
<img width="501" height="172" alt="image" src="https://github.com/user-attachments/assets/cfc3cc9c-b6c3-4ffe-8bdd-1ad6c8bc5df6" />

Anime Description
<img width="484" height="160" alt="image" src="https://github.com/user-attachments/assets/7eaeee50-0cea-468b-b41c-73f1b421cd98" />

Anime/Movie Reproduction
<img width="504" height="178" alt="image" src="https://github.com/user-attachments/assets/ee379d78-373d-467a-88b3-55f63c50444f" />
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
