### PR TITLE
feat(P-Stream): add activity

### DIFF
--- a/websites/P/P-Stream/metadata.json
+++ b/websites/P/P-Stream/metadata.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "id": "391511241786654721",
+    "name": "lechixy"
+  },
+  "service": "P-Stream",
+  "description": {
+    "en": "Presence for P-Stream movies and series. (Not affiliated with P-Stream)"
+  },
+  "url": [
+    "pstream.mov",
+    "beta.pstream.mov",
+    "mirror.pstream.mov"
+  ],
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*pstream[.]mov[/]",
+  "version": "1.0.0",
+  "logo": "https://iili.io/friz2yB.png",
+  "thumbnail": "https://iili.io/frKnt8F.webp",
+  "color": "#6D76DD",
+  "category": "videos",
+  "tags": [
+    "movie",
+    "series",
+    "streaming",
+    "video",
+    "entertainment"
+  ],
+  "settings": [
+    {
+      "id": "showWhileMain",
+      "title": "Show While Main Page",
+      "icon": "fad fa-play-circle",
+      "value": true
+    },
+    {
+      "id": "showWhileWatching",
+      "title": "Show While Watching",
+      "icon": "fad fa-play-circle",
+      "value": true
+    }
+  ]
+}

--- a/websites/P/P-Stream/presence.ts
+++ b/websites/P/P-Stream/presence.ts
@@ -1,0 +1,100 @@
+import { ActivityType } from 'premid'
+
+const presence = new Presence({
+  clientId: '1463157769053016239',
+})
+
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+let pausedTimestamp: number | null = null
+
+enum CustomAssets {
+  Logo = 'https://iili.io/friz2yB.png',
+  LogoNoBG = 'https://iili.io/frizFTP.png',
+}
+
+const presenceData: PresenceData = {
+  largeImageKey: CustomAssets.Logo,
+  type: ActivityType.Watching,
+}
+
+presence.on('UpdateData', async () => {
+  const { pathname, href } = document.location
+
+  const [
+    showWhileMain,
+    showWhileWatching,
+  ] = await Promise.all([
+    presence.getSetting<boolean>('showWhileMain'),
+    presence.getSetting<boolean>('showWhileWatching'),
+  ])
+
+  const inOtherPages = pathname === '' || pathname === '/' || pathname.startsWith('/browse') || pathname.startsWith('/discover')
+  // Browsing the site
+  if (inOtherPages) {
+    let currentPage = pathname === '' || pathname === '/' ? 'homepage' : pathname.slice(1)
+    if (currentPage.startsWith('discover'))
+      currentPage = 'discover page'
+    if (currentPage.startsWith('browse'))
+      currentPage = 'browse page'
+
+    presenceData.details = 'P-Stream'
+    presenceData.state = `In the ${currentPage}`
+    presenceData.startTimestamp = browsingTimestamp
+    presenceData.endTimestamp = undefined
+    presenceData.largeImageKey = CustomAssets.Logo
+    presenceData.largeImageText = 'P-Stream'
+    presenceData.smallImageKey = undefined
+    presenceData.name = 'P-Stream'
+
+    if (showWhileMain)
+      presence.setActivity(presenceData)
+    else presence.clearActivity()
+    return
+  }
+
+  // Watching a video
+  const video = document.querySelector('video') as HTMLVideoElement | null
+  if (pathname.startsWith('/media') && video) {
+    if (href.includes('tmdb-movie'))
+      presenceData.name = document.title
+    else if (href.includes('tmdb-tv'))
+      presenceData.name = document.title.split(' - ')[0]
+    else
+      presenceData.name = 'P-Stream'
+
+    presenceData.details = document.title
+    presenceData.state = 'Loading...'
+
+    const isPlaying = !video.paused && !video.ended && video.readyState > 2
+
+    if (navigator.mediaSession) {
+      presenceData.largeImageKey = navigator.mediaSession.metadata?.artwork?.[0]?.src
+      presenceData.smallImageKey = CustomAssets.LogoNoBG
+      presenceData.smallImageText = 'P-Stream'
+    }
+
+    if (isPlaying) {
+      // presenceData.smallImageKey = Assets.Play
+      // presenceData.smallImageText = 'Playing'
+      presenceData.startTimestamp = Math.floor(Date.now() / 1000) - Math.floor(video.currentTime)
+      presenceData.endTimestamp = presenceData.startTimestamp + Math.floor(video.duration)
+      presenceData.state = `Watching`
+      pausedTimestamp = null // Reset paused timestamp when playing
+    }
+    else {
+      // presenceData.smallImageKey = Assets.Pause
+      // presenceData.smallImageText = 'Paused'
+      presenceData.state = `Paused`
+      if (!pausedTimestamp) {
+        pausedTimestamp = Math.floor(Date.now() / 1000)
+      }
+      // When paused, we show the timestamp when the video was paused
+      presenceData.startTimestamp = pausedTimestamp
+      presenceData.endTimestamp = undefined
+    }
+
+    if (showWhileWatching)
+      presence.setActivity(presenceData)
+    else presence.clearActivity()
+  }
+})


### PR DESCRIPTION
## Description
This pull request adds a P-Stream presence for PreMiD, allowing users to display their activities (watching, browsing) on P-Stream in real-time on Discord.

## Features
- **Movie Presence:** Shows duration of movie in progress bar
- **Series Presence:** Shows season and episode, duration of serie in progress bar
- **Browsing Status:** Shows while in browsing
- **Dynamic Status:** Fetches and displays the correct poster for the movie or series being viewed.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
Browsing
<img width="466" height="157" alt="browsing" src="https://github.com/user-attachments/assets/9ac76a45-3001-4857-a4b6-e329599dda05" />
Watching movie
<img width="459" height="148" alt="watchingmovie" src="https://github.com/user-attachments/assets/0394ea41-c14d-40b9-900f-bd2bc6f5d4c6" />
Paused movie
<img width="464" height="150" alt="pausedmovie" src="https://github.com/user-attachments/assets/c08d6dc4-313d-4291-ab50-caea3581c12a" />
Watching series
<img width="465" height="149" alt="watchingseries" src="https://github.com/user-attachments/assets/8a4450da-13a7-4f20-9d42-68ad000c91af" />
Paused series
<img width="462" height="149" alt="pausedseries" src="https://github.com/user-attachments/assets/0e7f5069-5dc7-4ccf-840c-a0a8f44db8dc" />
</details>
