### PR TITLE
feat(OgladajAnime): change large image dimensions

### DIFF
--- a/websites/O/OgladajAnime/metadata.json
+++ b/websites/O/OgladajAnime/metadata.json
@@ -21,7 +21,7 @@
     "www.ogladajanime.pl"
   ],
   "regExp": "^https?[:][/][/](www[.])?ogladajanime[.]pl[/]",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/O/OgladajAnime/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/O/OgladajAnime/assets/thumbnail.png",
   "color": "#29C5F6",
@@ -89,11 +89,28 @@
       "value": true
     },
     {
+      "id": "usePosterDimensions",
+      "title": "Use Poster Dimensions",
+      "description": "This uses the dimensions that the anime images typically use when required. This may break some features, such as the small images or making the status show 'Showing character:' instead of just OgladajAnime.",
+      "value": false,
+      "icon": "fas fa-image-portrait"
+    },
+    {
       "id": "determineSeason",
       "title": "Determine Season",
       "description": "This checks all available names to try and determine the season and show it on the activity. This may not find the season always and might sometimes have false positives. This might interfere with the 'Use Alternative Name' setting",
       "icon": "fas fa-film",
       "value": true
+    },
+    {
+      "id": "defaultSeasonOne",
+      "title": "Default To Season One",
+      "description": "If a season was not found, make it appear as season 1",
+      "icon": "fas fa-1",
+      "value": true,
+      "if": {
+        "determineSeason": true
+      }
     }
   ]
 }

--- a/websites/O/OgladajAnime/types.ts
+++ b/websites/O/OgladajAnime/types.ts
@@ -12,7 +12,7 @@ export interface Playback {
 export interface PictureCache {
   id: string
   url: string
-  date: Date
+  date: number
 }
 
 export interface SeasonResponse {

--- a/websites/O/OgladajAnime/utils.ts
+++ b/websites/O/OgladajAnime/utils.ts
@@ -3,25 +3,25 @@ import { ActivityAssets } from './constants.js'
 
 const cache: PictureCache[] = []
 
-function cacheExpired(date: Date): boolean {
+function cacheExpired(date: number): boolean {
   if (date === null)
     return true
 
-  return ((new Date().getTime() - date.getTime()) / 1000 / 60) < 5
+  return ((Date.now() - date) / 1000 / 60) > 5
 }
 
 export async function getProfilePicture(id: string): Promise<string | undefined> {
   const index = cache.findIndex((val, _, __) => val.id === id)
   const _val = cache[index]
   if (index === -1) {
-    const _new: PictureCache = { id, url: await internal_getPFP(id), date: new Date() }
+    const _new: PictureCache = { id, url: await internal_getPFP(id), date: Date.now() }
     cache.push(_new)
     return _new.url
   }
   else if (_val !== undefined && cacheExpired(_val.date)) {
     const url = await internal_getPFP(id)
     _val.url = url
-    _val.date = new Date()
+    _val.date = Date.now()
     return url
   }
   else {
@@ -30,7 +30,7 @@ export async function getProfilePicture(id: string): Promise<string | undefined>
 }
 
 async function internal_getPFP(id: string) {
-  let url = `https://cdn.ogladajanime.pl/images/user/${id}.webp?${new Date().getTime()}`
+  let url = `https://cdn.ogladajanime.pl/images/user/${id}.webp?${Date.now()}`
   try {
     const res = await fetch(new URL(url))
     if (res.status === 404)


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

This PR mainly focuses on changing the large image dimensions by initializing two Presence classes - one with the OgladajAnime ID and one with the Crunchyroll one. When the large image is an anime image or a character image, it sets the crunchyroll presence, otherwise - the OgladajAnime one. 

This is a very hacky way of doing it and has introduced some minor issues, such as 
- `statusDisplayType` not working on Crunchyroll's presence, causing some issues (Discord's hard-coded thing probably doesnt even check that)
- Small Images not appearing at all on Crunchyroll's presence (once again, Discord's hard-coded thing)

This also includes several other changes, such as:
- Added an option to default to Season 1 if no season was found
- Fixed the cache not working and spam setting activity, causing rate limits

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

<img width="565" height="307" alt="Anime Presence" src="https://github.com/user-attachments/assets/c8bd5023-c77b-4987-a5fa-8e7214efd923" />

<img width="562" height="282" alt="Character Presence" src="https://github.com/user-attachments/assets/c4f4e77c-9134-4ac8-97d9-68abebdd6825" />

<img width="560" height="230" alt="Profile Presence" src="https://github.com/user-attachments/assets/73310afd-5880-4a73-bc96-1ff43c304e74" />

<img width="564" height="296" alt="1st Settings" src="https://github.com/user-attachments/assets/ec5682e1-2a95-4a8b-bb61-bf08b91899ef" />

<img width="607" height="813" alt="2nd Settings" src="https://github.com/user-attachments/assets/973f60e2-1e9e-42df-8ba6-c309f950b7ff" />


</details>
