### PR TITLE
feat(Flemmix): added new player URLs to iFrameRegExp

### DIFF
--- a/websites/F/Flemmix/metadata.json
+++ b/websites/F/Flemmix/metadata.json
@@ -11,7 +11,7 @@
     "fr": "Regardez vos films et séries préférés en streaming."
   },
   "url": "flemmix.rent",
-  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*flemmix[.]rent[/]",
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*flemmix([.][a-z]+)+[/]",
   "version": "1.2.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/F/Flemmix/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/F/Flemmix/assets/thumbnail.png",

--- a/websites/F/Flemmix/presence.ts
+++ b/websites/F/Flemmix/presence.ts
@@ -61,7 +61,7 @@ presence.on('UpdateData', async () => {
 
     const coverImageSrc = document.querySelector<HTMLImageElement>('img[itemprop="thumbnailUrl"]')?.getAttribute('src')
     if (coverImageSrc && showCover) {
-      presenceData.largeImageKey = `https://flemmix.rent${coverImageSrc}`
+      presenceData.largeImageKey = `${location.origin}${coverImageSrc}`
     }
 
     const [startTimestamp, endTimestamp] = getTimestamps(video.currentTime, video.duration)


### PR DESCRIPTION
## Description
Hey! The Flemmix website has changed its domain to `https://flemmix.surf/`, so I updated the base URL and the `regExp` to match the new domain.

While I was at it, I noticed they added a bunch of new video hosts. I updated the `iFrameRegExp` to include all the new iframe players they are currently using (like up4fun.top, upns.pro, christopheruntilpoint.com, savefiles.com, luluvid, etc.) so that the timestamps work correctly again for the users. 

Bumped version to 1.2.0.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

<img width="1562" height="971" alt="Capture d&#39;écran 2026-02-23 224105" src="https://github.com/user-attachments/assets/6c51bcb8-aee8-4231-8bcf-e1888261ce19" />

<img width="1496" height="936" alt="image" src="https://github.com/user-attachments/assets/0597166b-70d5-411f-85fc-fde43a4b1594" />

</details>