### PR TITLE
feat(MyAnimeList): Wider presence, cover support and privacy mode

### DIFF
--- a/websites/M/MyAnimeList/metadata.json
+++ b/websites/M/MyAnimeList/metadata.json
@@ -13,6 +13,10 @@
     {
       "name": "theusaf",
       "id": "193714715631812608"
+    },
+    {
+      "name": "shogun05",
+      "id": "524597801942777857"
     }
   ],
   "service": "MyAnimeList",
@@ -28,7 +32,7 @@
   },
   "url": "myanimelist.net",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*myanimelist[.]net[/]",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/M/MyAnimeList/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/M/MyAnimeList/assets/thumbnail.png",
   "color": "#2e51a2",
@@ -37,5 +41,19 @@
     "anime",
     "manga",
     "community"
+  ],
+  "settings": [
+    {
+      "id": "cover",
+      "title": "Show Cover",
+      "icon": "fas fa-images",
+      "value": true
+    },
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "icon": "fas fa-user-secret",
+      "value": false
+    }
   ]
 }

--- a/websites/M/MyAnimeList/presence.ts
+++ b/websites/M/MyAnimeList/presence.ts
@@ -4,6 +4,10 @@ const presence = new Presence({
 
 presence.on('UpdateData', async () => {
   const { pathname, href } = document.location
+  const [privacy, cover] = await Promise.all([
+    presence.getSetting<boolean>('privacy'),
+    presence.getSetting<boolean>('cover'),
+  ])
   const presenceData: PresenceData = {
     largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/M/MyAnimeList/assets/logo.png',
   }
@@ -24,17 +28,37 @@ presence.on('UpdateData', async () => {
   ) {
     presenceData.details = 'Looking for manga'
   }
+  else if (pathname.startsWith('/reviews.php')) {
+    presenceData.details = 'Viewing Reviews'
+  }
+  else if (pathname.startsWith('/watch/episode')) {
+    presenceData.details = 'Viewing Episode Videos'
+  }
+  else if (pathname.startsWith('/recommendations.php')) {
+    presenceData.details = 'Viewing Recommendations'
+    const type = new URLSearchParams(document.location.search).get('t')
+    if (type) {
+      presenceData.state = `For ${type.charAt(0).toUpperCase() + type.slice(1)}`
+    }
+  }
+  else if (pathname.startsWith('/stacks')) {
+    presenceData.details = 'Browsing Interest Stacks'
+  }
   else if (pathname.startsWith('/forum')) {
     presenceData.details = 'Viewing the forums'
-    presenceData.state = document
-      .querySelector('meta[property=\'og:title\']')
-      ?.getAttribute('content')
+    if (!privacy) {
+      presenceData.state = document
+        .querySelector('meta[property=\'og:title\']')
+        ?.getAttribute('content')
+    }
   }
   else if (pathname.startsWith('/clubs.php')) {
     if (document.querySelectorAll('.normal_header')[1]) {
       presenceData.details = 'Viewing a club'
-      presenceData.state = document.querySelector('.h1')?.textContent
-      presenceData.buttons = [{ label: 'View Club', url: href }]
+      if (!privacy) {
+        presenceData.state = document.querySelector('.h1')?.textContent
+        presenceData.buttons = [{ label: 'View Club', url: href }]
+      }
     }
     else if (
       document.querySelector('.h1-title')?.textContent === 'Invitations'
@@ -68,8 +92,10 @@ presence.on('UpdateData', async () => {
     }
     else {
       presenceData.details = 'Viewing an article'
-      presenceData.state = document.querySelector('.title')?.textContent
-      presenceData.buttons = [{ label: 'Read Article', url: href }]
+      if (!privacy) {
+        presenceData.state = document.querySelector('.title')?.textContent
+        presenceData.buttons = [{ label: 'Read Article', url: href }]
+      }
     }
   }
   else if (pathname.startsWith('/people')) {
@@ -78,11 +104,13 @@ presence.on('UpdateData', async () => {
     }
     else {
       presenceData.details = 'Viewing a person'
-      presenceData.state = document
-        .querySelector('.title-name')
-        ?.textContent
-        ?.replace(/(<([^>]+)>)/g, '')
-      presenceData.buttons = [{ label: 'View Person', url: href }]
+      if (!privacy) {
+        presenceData.state = document
+          .querySelector('.title-name')
+          ?.textContent
+          ?.replace(/<[^>]+>/g, '')
+        presenceData.buttons = [{ label: 'View Person', url: href }]
+      }
     }
   }
   else if (pathname.startsWith('/character')) {
@@ -91,37 +119,60 @@ presence.on('UpdateData', async () => {
     }
     else {
       presenceData.details = 'Viewing a character'
-      presenceData.state = document
-        .querySelectorAll('.normal_header')[2]
-        ?.textContent
-        ?.replace(/(<([^>]+)>)/g, '')
-      presenceData.buttons = [{ label: 'View Character', url: href }]
+      if (!privacy) {
+        presenceData.state = document
+          .querySelectorAll('.normal_header')[2]
+          ?.textContent
+          ?.replace(/<[^>]+>/g, '')
+        presenceData.buttons = [{ label: 'View Character', url: href }]
+      }
     }
   }
   else if (pathname.startsWith('/profile')) {
     presenceData.details = 'Viewing a profile'
-    presenceData.state = pathname.split('/')[2]
-    presenceData.buttons = [{ label: 'View Profile', url: href }]
+    if (!privacy) {
+      presenceData.state = pathname.split('/')[2]
+      presenceData.buttons = [{ label: 'View Profile', url: href }]
+
+      if (cover) {
+        const userImage = document.querySelector<HTMLImageElement>('.user-image img')
+        const imgSrc = userImage?.src || userImage?.getAttribute('data-src')
+        if (imgSrc)
+          presenceData.largeImageKey = imgSrc
+      }
+    }
   }
   else if (pathname.startsWith('/animelist')) {
     presenceData.details = 'Viewing an anime list'
-    presenceData.state = pathname.split('/')[2]
-    presenceData.buttons = [{ label: 'View List', url: href }]
+    if (!privacy) {
+      presenceData.state = pathname.split('/')[2]
+      presenceData.buttons = [{ label: 'View List', url: href }]
+    }
   }
   else if (pathname.startsWith('/mangalist')) {
     presenceData.details = 'Viewing a manga list'
-    presenceData.state = pathname.split('/')[2]
-    presenceData.buttons = [{ label: 'View List', url: href }]
+    if (!privacy) {
+      presenceData.state = pathname.split('/')[2]
+      presenceData.buttons = [{ label: 'View List', url: href }]
+    }
   }
   else if (pathname.startsWith('/anime')) {
     // TODO: The if loop to check if the user is really on the page of an anime is currently always true for some reason which results in the presence going away when the user is for example in the anime directory
     if (document.querySelector('.js-anime-edit-info-button')) {
-      const englishTitle = document.querySelector('.title-english')?.textContent
       presenceData.details = 'Viewing an anime'
-      presenceData.state = `${
-        document.querySelector('.title-name')?.textContent
-      } ${englishTitle ? `| ${englishTitle}` : ''}`.trim()
-      presenceData.buttons = [{ label: 'View Anime', url: href }]
+      if (!privacy) {
+        const englishTitle = document.querySelector('.title-english')?.textContent
+        presenceData.state = `${
+          document.querySelector('.title-name')?.textContent
+        } ${englishTitle ? `| ${englishTitle}` : ''}`.trim()
+        presenceData.buttons = [{ label: 'View Anime', url: href }]
+
+        if (cover) {
+          const coverImg = document.querySelector<HTMLImageElement>('img[itemprop="image"]')?.src
+          if (coverImg)
+            presenceData.largeImageKey = coverImg
+        }
+      }
     }
     else {
       presenceData.details = 'Looking for anime'
@@ -130,12 +181,20 @@ presence.on('UpdateData', async () => {
   else if (pathname.startsWith('/manga')) {
     // TODO: The if loop to check if the user is really on the page of an anime is currently always true for some reason which results in the presence going away when the user is for example in the anime directory
     if (document.querySelector('.js-manga-edit-info-button')) {
-      const englishTitle = document.querySelector('.title-english')?.textContent
       presenceData.details = 'Viewing a manga'
-      presenceData.state = `${
-        document.querySelector('.title-name')?.textContent
-      } ${englishTitle ? ` | ${englishTitle}` : ''}`.trim()
-      presenceData.buttons = [{ label: 'View Mange', url: href }]
+      if (!privacy) {
+        const englishTitle = document.querySelector('.title-english')?.textContent
+        presenceData.state = `${
+          document.querySelector('span[itemprop="name"]')?.firstChild?.textContent
+        } ${englishTitle ? ` | ${englishTitle}` : ''}`.trim()
+        presenceData.buttons = [{ label: 'View Manga', url: href }]
+
+        if (cover) {
+          const coverImg = document.querySelector<HTMLImageElement>('img[itemprop="image"]')?.src
+          if (coverImg)
+            presenceData.largeImageKey = coverImg
+        }
+      }
     }
     else {
       presenceData.details = 'Looking for manga'


### PR DESCRIPTION
## Description
This is a feature implementation for MyAnimeList activity, to add a privacy mode like many of the other activities do. 
Other than that, add "Show Cover" feature to display the cover of anime/manga/user profiles in discord status.
Add in more support for /recommendations.php , /stacks, /watch/episodes route , /reviews.php presence.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img width="445" height="546" alt="image" src="https://github.com/user-attachments/assets/9b4a6911-97e2-4c65-89e5-f2ce876b7223" />

When privacy mode is turned on

<img width="444" height="561" alt="image" src="https://github.com/user-attachments/assets/3e9e1d7c-0408-4f23-9d2c-f422753362e6" />

When the show cover is turned on. This support extends for all anime, manga and user profiles

<img width="441" height="556" alt="image" src="https://github.com/user-attachments/assets/3b4ece38-1cbf-452f-ac9a-1c568df79aea" />

Rest of the changes include just updation in what status they display for more routes.

</details>
