### PR TITLE
chore(npm): rename `NPM Package Registry` to `npm`

### DIFF
--- a/websites/N/npm/metadata.json
+++ b/websites/N/npm/metadata.json
@@ -14,8 +14,8 @@
   "url": "www.npmjs.com",
   "regExp": "^https?[:][/][/](www[.])?npmjs[.]com[/]",
   "version": "1.0.0",
-  "logo": "https://cdn.rcd.gg/PreMiD/websites/N/npm/assets/logo.png",
-  "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/N/npm/assets/thumbnail.png",
+  "logo": "https://litomore.me/premid/npm-logo.png",
+  "thumbnail": "https://litomore.me/premid/npm-thumbnail.png",
   "color": "#C12127",
   "category": "other",
   "tags": [

--- a/websites/N/npm/presence.ts
+++ b/websites/N/npm/presence.ts
@@ -4,7 +4,7 @@ const presence = new Presence({
 
 presence.on('UpdateData', async () => {
   const presenceData: PresenceData = {
-    largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/N/npm/assets/logo.png',
+    largeImageKey: 'https://litomore.me/premid/npm-logo.png',
   }
   if (document.location.pathname === '/') {
     presenceData.details = 'Viewing the homepage'


### PR DESCRIPTION
## Description

According to https://github.com/npm/cli#faq-on-branding. The spelling should be `npm` rather than `NPM Package Registry`. We also have other registry activities like `JSR`, `DockerHub` don't name with `Registry`.

## Acknowledgements

- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots

No functionality change.