### PR TITLE
feat(Cardmarket): add activity

### DIFF
--- a/websites/C/Cardmarket/Cardmarket.json
+++ b/websites/C/Cardmarket/Cardmarket.json
@@ -1,0 +1,22 @@
+{
+  "cardmarket.browsing": {
+    "description": "Shown when browsing Cardmarket homepage",
+    "message": "Browsing Cardmarket"
+  },
+  "cardmarket.homepage": {
+    "description": "Shown when viewing a game's homepage",
+    "message": "Homepage"
+  },
+  "cardmarket.game": {
+    "description": "Shown with the game name (e.g., 'Game: Pokemon')",
+    "message": "Game: {0}"
+  },
+  "cardmarket.browsing_category": {
+    "description": "Shown when browsing a category (e.g., 'Browsing Singles')",
+    "message": "Browsing {0}"
+  },
+  "cardmarket.viewing": {
+    "description": "Shown when viewing a product (e.g., 'Viewing Pikachu')",
+    "message": "Viewing {0}"
+  }
+}

--- a/websites/C/Cardmarket/Cardmarket.json
+++ b/websites/C/Cardmarket/Cardmarket.json
@@ -1,8 +1,4 @@
 {
-  "cardmarket.homepage": {
-    "description": "Shown when viewing a game's homepage",
-    "message": "Homepage"
-  },
   "cardmarket.game": {
     "description": "Shown with the game name (e.g., 'Game: Pokemon')",
     "message": "Game: {0}"

--- a/websites/C/Cardmarket/Cardmarket.json
+++ b/websites/C/Cardmarket/Cardmarket.json
@@ -3,20 +3,60 @@
     "description": "Shown when browsing Cardmarket homepage",
     "message": "Browsing Cardmarket"
   },
+  "cardmarket.browsing_fr": {
+    "description": "Shown when browsing Cardmarket homepage (French)",
+    "message": "Navigation sur Cardmarket"
+  },
+  "cardmarket.browsing_es": {
+    "description": "Shown when browsing Cardmarket homepage (Spanish)",
+    "message": "Navegando por Cardmarket"
+  },
   "cardmarket.homepage": {
     "description": "Shown when viewing a game's homepage",
     "message": "Homepage"
+  },
+  "cardmarket.homepage_fr": {
+    "description": "Shown when viewing a game's homepage (French)",
+    "message": "Page d'accueil"
+  },
+  "cardmarket.homepage_es": {
+    "description": "Shown when viewing a game's homepage (Spanish)",
+    "message": "Página de inicio"
   },
   "cardmarket.game": {
     "description": "Shown with the game name (e.g., 'Game: Pokemon')",
     "message": "Game: {0}"
   },
+  "cardmarket.game_fr": {
+    "description": "Shown with the game name (French)",
+    "message": "Jeu : {0}"
+  },
+  "cardmarket.game_es": {
+    "description": "Shown with the game name (Spanish)",
+    "message": "Juego: {0}"
+  },
   "cardmarket.browsing_category": {
     "description": "Shown when browsing a category (e.g., 'Browsing Singles')",
     "message": "Browsing {0}"
   },
+  "cardmarket.browsing_category_fr": {
+    "description": "Shown when browsing a category (French)",
+    "message": "Parcours de {0}"
+  },
+  "cardmarket.browsing_category_es": {
+    "description": "Shown when browsing a category (Spanish)",
+    "message": "Navegando {0}"
+  },
   "cardmarket.viewing": {
     "description": "Shown when viewing a product (e.g., 'Viewing Pikachu')",
     "message": "Viewing {0}"
+  },
+  "cardmarket.viewing_fr": {
+    "description": "Shown when viewing a product (French)",
+    "message": "Consultation de {0}"
+  },
+  "cardmarket.viewing_es": {
+    "description": "Shown when viewing a product (Spanish)",
+    "message": "Viendo {0}"
   }
 }

--- a/websites/C/Cardmarket/Cardmarket.json
+++ b/websites/C/Cardmarket/Cardmarket.json
@@ -1,62 +1,14 @@
 {
-  "cardmarket.browsing": {
-    "description": "Shown when browsing Cardmarket homepage",
-    "message": "Browsing Cardmarket"
-  },
-  "cardmarket.browsing_fr": {
-    "description": "Shown when browsing Cardmarket homepage (French)",
-    "message": "Navigation sur Cardmarket"
-  },
-  "cardmarket.browsing_es": {
-    "description": "Shown when browsing Cardmarket homepage (Spanish)",
-    "message": "Navegando por Cardmarket"
-  },
   "cardmarket.homepage": {
     "description": "Shown when viewing a game's homepage",
     "message": "Homepage"
-  },
-  "cardmarket.homepage_fr": {
-    "description": "Shown when viewing a game's homepage (French)",
-    "message": "Page d'accueil"
-  },
-  "cardmarket.homepage_es": {
-    "description": "Shown when viewing a game's homepage (Spanish)",
-    "message": "Página de inicio"
   },
   "cardmarket.game": {
     "description": "Shown with the game name (e.g., 'Game: Pokemon')",
     "message": "Game: {0}"
   },
-  "cardmarket.game_fr": {
-    "description": "Shown with the game name (French)",
-    "message": "Jeu : {0}"
-  },
-  "cardmarket.game_es": {
-    "description": "Shown with the game name (Spanish)",
-    "message": "Juego: {0}"
-  },
   "cardmarket.browsing_category": {
     "description": "Shown when browsing a category (e.g., 'Browsing Singles')",
     "message": "Browsing {0}"
-  },
-  "cardmarket.browsing_category_fr": {
-    "description": "Shown when browsing a category (French)",
-    "message": "Parcours de {0}"
-  },
-  "cardmarket.browsing_category_es": {
-    "description": "Shown when browsing a category (Spanish)",
-    "message": "Navegando {0}"
-  },
-  "cardmarket.viewing": {
-    "description": "Shown when viewing a product (e.g., 'Viewing Pikachu')",
-    "message": "Viewing {0}"
-  },
-  "cardmarket.viewing_fr": {
-    "description": "Shown when viewing a product (French)",
-    "message": "Consultation de {0}"
-  },
-  "cardmarket.viewing_es": {
-    "description": "Shown when viewing a product (Spanish)",
-    "message": "Viendo {0}"
   }
 }

--- a/websites/C/Cardmarket/metadata.json
+++ b/websites/C/Cardmarket/metadata.json
@@ -1,0 +1,42 @@
+{
+  "author": {
+    "name": "Swerk",
+    "id": "317411645129490435"
+  },
+  "service": "Cardmarket",
+  "description": {
+    "en": "Shows your current activity on Cardmarket.",
+    "es": "Muestra tu actividad actual en Cardmarket.",
+    "fr": "Affiche votre activité en cours sur Cardmarket."
+  },
+  "url": [
+    "www.cardmarket.com",
+    "cardmarket.com"
+  ],
+  "regExp": "^https?[:][/][/](www[.])?cardmarket[.]com",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/bmVVGUa.jpeg",
+  "thumbnail": "https://i.imgur.com/oRY0a6M.jpeg",
+  "color": "#014995",
+  "category": "games",
+  "tags": [
+    "trading",
+    "cards",
+    "tcg",
+    "pokemon",
+    "magic",
+    "yugioh"
+  ],
+  "settings": [
+    {
+      "id": "lang",
+      "multiLanguage": true
+    },
+    {
+      "id": "showButtons",
+      "title": "Show Buttons",
+      "icon": "fas fa-link",
+      "value": true
+    }
+  ]
+}

--- a/websites/C/Cardmarket/metadata.json
+++ b/websites/C/Cardmarket/metadata.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
   "author": {
     "name": "Swerk",
     "id": "317411645129490435"

--- a/websites/C/Cardmarket/metadata.json
+++ b/websites/C/Cardmarket/metadata.json
@@ -7,15 +7,15 @@
   },
   "service": "Cardmarket",
   "description": {
-    "en": "Shows your current activity on Cardmarket.",
-    "es": "Muestra tu actividad actual en Cardmarket.",
-    "fr": "Affiche votre activité en cours sur Cardmarket."
+    "en": "Cardmarket is Europe's leading online marketplace for trading card games, where users buy and sell singles, sealed products, and accessories.",
+    "es": "Cardmarket es la principal plataforma europea de compraventa de juegos de cartas coleccionables: cartas sueltas, productos sellados y accesorios.",
+    "fr": "Cardmarket est la principale place de marché en ligne européenne pour les jeux de cartes à collectionner : achat et vente de cartes à l'unité, produits scellés et accessoires."
   },
   "url": [
     "www.cardmarket.com",
     "cardmarket.com"
   ],
-  "regExp": "^https?[:][/][/](www[.])?cardmarket[.]com",
+  "regExp": "^https?[:][/][/](www[.])?cardmarket[.]com[/]",
   "version": "1.0.0",
   "logo": "https://i.imgur.com/bmVVGUa.jpeg",
   "thumbnail": "https://i.imgur.com/oRY0a6M.jpeg",

--- a/websites/C/Cardmarket/presence.ts
+++ b/websites/C/Cardmarket/presence.ts
@@ -52,11 +52,10 @@ presence.on('UpdateData', async () => {
 
   const strings = await presence.getStrings({
     browsing: 'general.browsing',
-    cardmarketBrowsing: 'cardmarket.browsing',
+    view: 'general.view',
     homepage: 'cardmarket.homepage',
     gameLabel: 'cardmarket.game',
-    browsingCategory: 'cardmarket.browsing_category',
-    viewing: 'cardmarket.viewing',
+    browsingCategory: 'cardmarket.browsingCategory',
   })
 
   const presenceData: PresenceData = {
@@ -66,7 +65,7 @@ presence.on('UpdateData', async () => {
 
   switch (pageType) {
     case 'homepage_all':
-      presenceData.details = strings.cardmarketBrowsing
+      presenceData.details = strings.browsing
       break
 
     case 'homepage_game':
@@ -83,7 +82,7 @@ presence.on('UpdateData', async () => {
       const productNameElem = document.querySelector('h1')
       const actualProductName = productNameElem?.textContent?.trim() ?? formatString(product)
 
-      presenceData.details = strings.viewing.replace('{0}', actualProductName)
+      presenceData.details = strings.view.replace('{0}', actualProductName)
       presenceData.state = `${formatString(game)} - ${formatString(category)}`
 
       if (showButtons) {
@@ -98,7 +97,7 @@ presence.on('UpdateData', async () => {
     }
 
     default:
-      presenceData.details = strings.cardmarketBrowsing
+      presenceData.details = strings.browsing
       if (game) {
         presenceData.state = strings.gameLabel.replace('{0}', formatString(game))
       }

--- a/websites/C/Cardmarket/presence.ts
+++ b/websites/C/Cardmarket/presence.ts
@@ -53,9 +53,8 @@ presence.on('UpdateData', async () => {
   const strings = await presence.getStrings({
     browsing: 'general.browsing',
     view: 'general.view',
-    homepage: 'cardmarket.homepage',
     gameLabel: 'cardmarket.game',
-    browsingCategory: 'cardmarket.browsingCategory',
+    browsingCategory: 'cardmarket.browsing_category',
   })
 
   const presenceData: PresenceData = {

--- a/websites/C/Cardmarket/presence.ts
+++ b/websites/C/Cardmarket/presence.ts
@@ -81,9 +81,9 @@ presence.on('UpdateData', async () => {
 
     case 'product': {
       const productNameElem = document.querySelector('h1')
-      const actualProductName = productNameElem ? productNameElem.textContent?.trim() : formatString(product)
+      const actualProductName = productNameElem?.textContent?.trim() ?? formatString(product)
 
-      presenceData.details = strings.viewing.replace('{0}', actualProductName || '')
+      presenceData.details = strings.viewing.replace('{0}', actualProductName)
       presenceData.state = `${formatString(game)} - ${formatString(category)}`
 
       if (showButtons) {

--- a/websites/C/Cardmarket/presence.ts
+++ b/websites/C/Cardmarket/presence.ts
@@ -1,0 +1,114 @@
+const presence = new Presence({
+  clientId: '568035160784896035',
+})
+
+enum ActivityAssets {
+  Logo = 'https://i.imgur.com/bmVVGUa.jpeg',
+}
+
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+function getPageInfo() {
+  const { pathname } = document.location
+
+  const pathParts = pathname.replace(/^\//, '').split('/')
+
+  const lang = pathParts[0] || 'en'
+  const game = pathParts[1] || ''
+
+  let pageType = 'unknown'
+  let category = ''
+  let product = ''
+
+  if (!game) {
+    pageType = 'homepage_all'
+  }
+  else if (pathParts.length === 2) {
+    pageType = 'homepage_game'
+  }
+  else if (pathParts[2] === 'Products') {
+    if (pathParts.length === 4) {
+      pageType = 'category'
+      category = pathParts[3] || ''
+    }
+    else if (pathParts.length >= 5) {
+      pageType = 'product'
+      category = pathParts[3] || ''
+      product = pathParts[pathParts.length - 1] || ''
+    }
+  }
+
+  return { lang, game, pageType, category, product }
+}
+
+function formatString(str: string): string {
+  return str.replace(/-/g, ' ')
+}
+
+presence.on('UpdateData', async () => {
+  const { game, pageType, category, product } = getPageInfo()
+
+  const showButtons = await presence.getSetting<boolean>('showButtons')
+
+  const strings = await presence.getStrings({
+    browsing: 'general.browsing',
+    cardmarketBrowsing: 'cardmarket.browsing',
+    homepage: 'cardmarket.homepage',
+    gameLabel: 'cardmarket.game',
+    browsingCategory: 'cardmarket.browsing_category',
+    viewing: 'cardmarket.viewing',
+  })
+
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+  }
+
+  switch (pageType) {
+    case 'homepage_all':
+      presenceData.details = strings.cardmarketBrowsing
+      break
+
+    case 'homepage_game':
+      presenceData.details = strings.browsing
+      presenceData.state = strings.gameLabel.replace('{0}', formatString(game))
+      break
+
+    case 'category':
+      presenceData.details = strings.browsingCategory.replace('{0}', formatString(category))
+      presenceData.state = strings.gameLabel.replace('{0}', formatString(game))
+      break
+
+    case 'product': {
+      const productNameElem = document.querySelector('h1')
+      const actualProductName = productNameElem ? productNameElem.textContent?.trim() : formatString(product)
+
+      presenceData.details = strings.viewing.replace('{0}', actualProductName || '')
+      presenceData.state = `${formatString(game)} - ${formatString(category)}`
+
+      if (showButtons) {
+        presenceData.buttons = [
+          {
+            label: 'View Product',
+            url: document.location.href,
+          },
+        ]
+      }
+      break
+    }
+
+    default:
+      presenceData.details = strings.cardmarketBrowsing
+      if (game) {
+        presenceData.state = strings.gameLabel.replace('{0}', formatString(game))
+      }
+      break
+  }
+
+  if (presenceData.details) {
+    presence.setActivity(presenceData)
+  }
+  else {
+    presence.clearActivity()
+  }
+})


### PR DESCRIPTION
## Description
This PR adds a new PreMiD activity for **Cardmarket** (https://www.cardmarket.com/), a popular European marketplace for trading card games.

### Features
- **Multi-language support**: English, French, and Spanish
- **Dynamic page detection**:
  - Homepage browsing
  - Game-specific pages (Pokémon, Magic: The Gathering, Yu-Gi-Oh!, etc.)
  - Category browsing (Singles, Sealed Products, etc.)
  - Individual product pages with exact product names from DOM
- **View Product button**: Optional button to visit the current product page directly from Discord
- **Settings**: Users can toggle the "View Product" button on/off

### Notes
- Product images from Cardmarket's S3 bucket cannot be displayed due to CORS restrictions. The activity uses the Cardmarket logo as the large image key. Tried to use the canvas but didn't figure it out. I will try to work on it.
- The activity has been tested on various Cardmarket pages including Pokémon, Magic, and Yu-Gi-Oh! sections.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npx pmd build Cardmarket --validate`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

### Browsing Homepage
![Homepage](https://i.imgur.com/W2n3yZY.png)

### Viewing Product Page
![Product](https://i.imgur.com/dbECOxF.png)

### Activity Settings
![Settings](https://i.imgur.com/Efuu5tT.png)

</details>
