### PR TITLE
feat: disable Discord Rich Presence extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,6 +50,7 @@
 
   // Other settings
   "discord.enabled": false,
+  "vscord.enable": false,
   "yaml.schemas": {
     "https://json.schemastore.org/github-issue-config.json": "../.github/ISSUE_TEMPLATE/config.yml"
   }


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Disable the [Discord Rich Presence](https://marketplace.visualstudio.com/items?itemName=LeonardSSH.vscord) extension for the development of PreMiD Activity
Setting ref : [package.json on vscord repo](https://github.com/narcisbugeag/vscord/blob/4224d01e94a3361f357c8f3be03ae0ff5b686ec3/package.json#L126)

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
