### PR TITLE
fix(UpBeatRadio): remove private routes and update metadata

### DIFF
--- a/websites/U/UpBeatRadio/metadata.json
+++ b/websites/U/UpBeatRadio/metadata.json
@@ -5,12 +5,6 @@
     "name": "Bas950",
     "id": "241278257335500811"
   },
-  "contributors": [
-    {
-      "name": "Ollie",
-      "id": "1337437594228883569"
-    }
-  ],
   "service": "UpBeatRadio",
   "description": {
     "en": "UpBeat is an ad-free, community powered online radio.",
@@ -19,9 +13,9 @@
   },
   "url": "upbeatradio.net",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*upbeatradio[.]net[/]",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/U/UpBeatRadio/assets/logo.png",
-  "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/U/UpBeatRadio/assets/thumbnail.png",
+  "thumbnail": "https://upbeat.pw/images/548o97",
   "color": "#212121",
   "category": "music",
   "tags": [

--- a/websites/U/UpBeatRadio/metadata.json
+++ b/websites/U/UpBeatRadio/metadata.json
@@ -15,7 +15,7 @@
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*upbeatradio[.]net[/]",
   "version": "3.3.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/U/UpBeatRadio/assets/logo.png",
-  "thumbnail": "https://upbeat.pw/images/548o97",
+  "thumbnail": "https://i.imgur.com/UJWFFkq.png",
   "color": "#212121",
   "category": "music",
   "tags": [

--- a/websites/U/UpBeatRadio/presence.ts
+++ b/websites/U/UpBeatRadio/presence.ts
@@ -203,14 +203,6 @@ presence.on('UpdateData', async () => {
       presenceData.details = 'Sending in a partner enquiry'
       presenceData.smallImageKey = Assets.Writing
     }
-    else if (document.location.pathname.includes('/content.new')) {
-      presenceData.details = 'Writing an article...'
-      presenceData.smallImageKey = Assets.Writing
-    }
-    else if (document.location.pathname.includes('/station.dashboard')) {
-      presenceData.details = 'Presenting a show...'
-      presenceData.smallImageKey = Assets.PremiereLive
-    }
   }
   else {
     if (document.querySelector('.stats-djName')?.textContent === 'UpBeat')


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Remove handling for private routes `/content.new` and `/station.dashboard` as these are staff routes that should not be publicly exposed or known about.

Update thumbnail URL and remove outdated contributor entry.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="903" height="270" alt="image" src="https://github.com/user-attachments/assets/9018e805-a2fe-476e-a06d-40b14008cbff" />



</details>
