### PR TITLE
ChatLLM Teams Presence Added

### DIFF
--- a/websites/C/ChatLLM Teams/metadata.json
+++ b/websites/C/ChatLLM Teams/metadata.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "id": "621775934382669894",
+    "name": "Clover Y5 Network"
+  },
+  "service": "ChatLLM Teams",
+  "altnames": ["Abacus AI", "ChatLLM"],
+  "description": {
+    "en": "ChatLLM Teams by Abacus.AI - An AI super assistant powered by large language models with access to multiple AI models including GPT-4, Claude, Gemini and more.",
+    "es": "ChatLLM Teams de Abacus.AI - Un super asistente de IA con acceso a multiples modelos de lenguaje como GPT-4, Claude, Gemini y mas."
+  },
+  "url": "apps.abacus.ai",
+  "regExp": "^https?[:][/][/]apps[.]abacus[.]ai[/]chatllm.*",
+  "version": "1.0.0",
+  "logo": "https://play-lh.googleusercontent.com/O35u7LcmgKHsRpEQvHmT9ACfvDvP5S6HRIVmz-x-spUhojXIcnk0wbMEqaBSWPUJYQ",
+  "thumbnail": "https://www.hrkatha.com/wp-content/uploads/2022/01/Abacus.png",
+  "color": "#4F46E5",
+  "category": "other",
+  "tags": [
+    "ai",
+    "chat",
+    "assistant",
+    "llm",
+    "abacus",
+    "productivity"
+  ],
+  "settings": [
+    {
+      "id": "title",
+      "title": "Show Chat Title",
+      "icon": "fad fa-user-secret",
+      "value": true
+    },
+    {
+      "id": "timestamp",
+      "title": "Show Timestamp",
+      "icon": "fad fa-stopwatch",
+      "value": true
+    }
+  ]
+}

--- a/websites/C/ChatLLM Teams/presence.ts
+++ b/websites/C/ChatLLM Teams/presence.ts
@@ -1,0 +1,80 @@
+import { ActivityType, Assets } from "premid";
+
+const presence = new Presence({clientId: "1485675381863219241",});
+
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+// Variable to store the last known title when the sidebar is hidden  
+let lastKnownTitle = "";
+
+enum ActivityAssets {
+    Logo = 'https://cdn.abacus.ai/chatllm/favicon.ico',
+}
+
+presence.on("UpdateData", async () => {
+  const [title, timestamp] = await Promise.all([
+    presence.getSetting<boolean>('title'),
+    presence.getSetting<boolean>('timestamp'),
+  ])
+
+  const { href, search } = document.location; 
+  if (!href.includes("apps.abacus.ai/chatllm")) {  
+    presence.clearActivity();  
+    return;
+  }
+  const params = new URLSearchParams(search);  
+  const projectId = params.get("projectId");  
+  const convoId = params.get("convoId");
+
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    type: ActivityType.Playing
+  };
+    
+  const getTitleFromUI = () => {
+    const activeChatElement = document.querySelector("div[class*='bg-bwleftblue/25'] span[data-state], div[class*='dark:bg-bwleftblue/40'] span[data-state]"); 
+    if (activeChatElement?.textContent) {
+      lastKnownTitle = activeChatElement.textContent.trim(); 
+      return lastKnownTitle;
+    }
+    const headerTitle = document.querySelector("h1, .text-xl, .font-bold")?.textContent;
+    if (headerTitle && !headerTitle.includes("ChatLLM")) return headerTitle.trim();
+    return document.title.replace(` - ${lastKnownTitle}`, "").trim();
+  };
+
+  if (timestamp) {
+    presenceData.startTimestamp = browsingTimestamp
+  }
+
+ if (convoId && projectId) {
+    presenceData.details = "Chatting in a project";
+    presenceData.smallImageKey = Assets.Writing;
+    if (title) presenceData.state = `Project Chat: ${getTitleFromUI()}`;
+  } 
+  else if (convoId && !projectId) {
+    presenceData.details = "In a conversation";
+    presenceData.smallImageKey = Assets.Writing;
+    if (title) presenceData.state = `Chat: ${getTitleFromUI()}`;
+  } 
+  else if (projectId && !convoId) {
+    presenceData.details = "Viewing a project";
+    presenceData.smallImageKey = Assets.Reading;
+    if (title) presenceData.state = `Project: ${getTitleFromUI()}`;
+  } 
+  else {
+    presenceData.details = "On the home screen";
+    presenceData.state = "Exploring ChatLLM Teams";
+    presenceData.smallImageKey = Assets.Search;
+  }
+
+  presence.setActivity(presenceData);
+  });
+
+"Project Title = line-clamp-1 text-sm"
+"Chat Name =  overflow-hidden text-ellipsis whitespace-nowrap"
+
+
+
+
+
+


### PR DESCRIPTION
## Description
Presence for ChatLLM Teams has been added.
Privacy and Timestamp buttons still don't respond, but logic is inside presence.ts .
largeimagekey still not showing correctly on Discord.
presenceData.state gets changed to ChatLLM Teams after page's Sidebar gets closed or minimized.

## Acknowledgements
- [X] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `npm run lint` 
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="2560" height="1315" alt="VBox 1" src="https://github.com/user-attachments/assets/6b5cf055-7705-4a42-bb9b-f9d484ce3846" />
<img width="1440" height="3088" alt="VBox 1-1" src="https://github.com/user-attachments/assets/588606d8-5197-4067-b5a7-5760d56db3cd" />
<img width="2560" height="1315" alt="VBox 2" src="https://github.com/user-attachments/assets/97856a5e-1431-4253-a496-cdd8bb9dcc31" />
<img width="1224" height="928" alt="VBox 2-2" src="https://github.com/user-attachments/assets/422da3fb-d12a-4432-b112-b2234b760ad4" />


</details>
