### PR TITLE
fix(YTPLR): update video title selector

### DIFF
--- a/websites/Y/YTPLR/iframe.ts
+++ b/websites/Y/YTPLR/iframe.ts
@@ -5,7 +5,7 @@ ytplrIframe.on('UpdateData', async () => {
     return
 
   ytplrIframe.send({
-    title: document.querySelector<HTMLAnchorElement>('div.ytp-title-text > a')
+    title: document.querySelector<HTMLAnchorElement>('a.ytmVideoInfoVideoTitle')
       ?.textContent,
     duration: videoElement.duration,
     currentTime: videoElement.currentTime,

--- a/websites/Y/YTPLR/metadata.json
+++ b/websites/Y/YTPLR/metadata.json
@@ -17,7 +17,7 @@
     "ytplr.bitbucket.io"
   ],
   "regExp": "^https?[:][/][/](youtube-playlist-randomizer|ytplr)[.]bitbucket[.]io[/]",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YTPLR/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YTPLR/assets/thumbnail.png",
   "color": "#ff6d70",


### PR DESCRIPTION
## Description
YouTube has recently changed the iFrame Embed Player to match their new round design, and by doing so changed the Class name for the Video Title

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img width="492" height="188" alt="image" src="https://github.com/user-attachments/assets/a098796a-b7af-420f-a6c7-63b6a0adb34d" />

</details>
