### PR TITLE
feat(Railway): add activity

### DIFF
--- a/websites/R/Railway/metadata.json
+++ b/websites/R/Railway/metadata.json
@@ -12,7 +12,7 @@
   "url": ["railway.com", "docs.railway.com", "station.railway.com"],
   "regExp": "^https?[:][/][/]((www|docs|station)[.])?railway[.]com",
   "version": "1.0.0",
-  "logo": "https://images2.imgbox.com/11/df/OKXNN5nV_o.png",
+  "logo": "https://images2.imgbox.com/6e/77/ycpeme8m_o.png",
   "thumbnail": "https://images2.imgbox.com/f9/26/GGcwuFjo_o.png",
   "color": "#B94CF6",
   "category": "other",

--- a/websites/R/Railway/presence.ts
+++ b/websites/R/Railway/presence.ts
@@ -4,7 +4,7 @@ const presence = new Presence({
 const browsingTimestamp = Math.floor(Date.now() / 1000)
 
 enum ActivityAssets {
-  Logo = 'https://images2.imgbox.com/11/df/OKXNN5nV_o.png',
+  Logo = 'https://images2.imgbox.com/6e/77/ycpeme8m_o.png',
 }
 
 let elapsed = browsingTimestamp
@@ -77,16 +77,16 @@ presence.on('UpdateData', async () => {
     }
     case pathname.startsWith('/workspace/'): {
       const workspaceTabs: Record<string, string> = {
-        usage: 'Viewing usage & billing',
-        templates: 'Browsing workspace templates',
-        members: 'Viewing team members',
-        settings: 'Viewing workspace settings',
-        general: 'Viewing workspace settings',
-        environments: 'Viewing environments',
-        integrations: 'Viewing integrations',
-        billing: 'Viewing billing',
+        'usage': 'Viewing usage & billing',
+        'templates': 'Browsing workspace templates',
+        'members': 'Viewing team members',
+        'settings': 'Viewing workspace settings',
+        'general': 'Viewing workspace settings',
+        'environments': 'Viewing environments',
+        'integrations': 'Viewing integrations',
+        'billing': 'Viewing billing',
         'audit-logs': 'Viewing audit logs',
-        referrals: 'Viewing referrals',
+        'referrals': 'Viewing referrals',
       }
       const parts = pathname.split('/').filter(Boolean)
       const tab = workspaceTabs[parts[1] ?? ''] ? parts[1] : parts[2]


### PR DESCRIPTION
## Description
Adds activity for [Railway](https://railway.com) — cloud platform for deploying apps, servers and databases.

- detects homepage, dashboard, project canvas, service view
- shows workspace section names (usage, templates, members, etc.)
- supports docs.railway.com and station.railway.com
- privacy mode hides project/service names

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary>Proof showing the creation/modification is working as expected</summary>

<img width="267" height="127" alt="изображение" src="https://github.com/user-attachments/assets/a1ff28e2-6c83-416e-b207-243159138b0c" />
<img width="269" height="165" alt="изображение" src="https://github.com/user-attachments/assets/bfe51bff-4f57-4ad9-afd1-4613cece1765" />


</details>