### PR TITLE
feat:(AniVault): add activity

### DIFF
--- a/websites/A/AniVault/metadata.json
+++ b/websites/A/AniVault/metadata.json
@@ -13,7 +13,7 @@
   "regExp": "^https?[:][/][/](www[.]|dev[.])?anivault[.]xyz[/]",
   "version": "1.0.0",
   "logo": "https://anivault.xyz/icon-512.png",
-  "thumbnail": "https://anivault.xyz/icon-512.png",
+  "thumbnail": "https://anivault.xyz/thumbnail.png",
   "color": "#9333ea",
   "category": "anime",
   "tags": [

--- a/websites/A/AniVault/metadata.json
+++ b/websites/A/AniVault/metadata.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "name": "GBlox",
+    "id": "887829997987975180"
+  },
+  "service": "AniVault",
+  "description": {
+    "en": "AniVault is a premium anime streaming platform. Browse, watch, and track your favorite anime with a cinematic experience."
+  },
+  "url": "anivault.xyz",
+  "regExp": "^https?[:][/][/](www[.]|dev[.])?anivault[.]xyz[/]",
+  "version": "1.0.0",
+  "logo": "https://anivault.xyz/icon-512.png",
+  "thumbnail": "https://anivault.xyz/icon-512.png",
+  "color": "#9333ea",
+  "category": "anime",
+  "tags": [
+    "anime",
+    "streaming",
+    "video"
+  ],
+  "settings": [
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "icon": "fad fa-user-secret",
+      "value": false
+    },
+    {
+      "id": "showBrowsing",
+      "if": {
+        "privacy": false
+      },
+      "title": "Show Browsing Activity",
+      "icon": "fad fa-book-reader",
+      "value": true
+    },
+    {
+      "id": "showCover",
+      "if": {
+        "privacy": false
+      },
+      "title": "Show Anime Cover",
+      "icon": "fad fa-images",
+      "value": true
+    },
+    {
+      "id": "hideWhenPaused",
+      "title": "Hide When Paused",
+      "icon": "fad fa-pause",
+      "value": false
+    }
+  ]
+}

--- a/websites/A/AniVault/presence.ts
+++ b/websites/A/AniVault/presence.ts
@@ -1,3 +1,5 @@
+import { ActivityType, getTimestamps } from 'premid'
+
 const presence = new Presence({
   clientId: '1489078772291342418',
 })

--- a/websites/A/AniVault/presence.ts
+++ b/websites/A/AniVault/presence.ts
@@ -1,0 +1,146 @@
+const presence = new Presence({
+  clientId: '1489078772291342418',
+})
+
+enum ActivityAssets {
+  Logo = 'https://anivault.xyz/icon-512.png',
+  Play = 'https://cdn.rcd.gg/PreMiD/resources/play.png',
+  Pause = 'https://cdn.rcd.gg/PreMiD/resources/pause.png',
+  Search = 'https://cdn.rcd.gg/PreMiD/resources/search.png',
+}
+
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+presence.on('UpdateData', async () => {
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    largeImageText: 'AniVault',
+    type: ActivityType.Watching,
+    startTimestamp: browsingTimestamp,
+  }
+
+  const { pathname } = window.location
+
+  const [privacy, showCover, showBrowsing, hideWhenPaused] = await Promise.all([
+    presence.getSetting<boolean>('privacy'),
+    presence.getSetting<boolean>('showCover'),
+    presence.getSetting<boolean>('showBrowsing'),
+    presence.getSetting<boolean>('hideWhenPaused'),
+  ])
+
+  // ── Watch Page ──
+  if (pathname === '/watch') {
+    const video = document.querySelector<HTMLVideoElement>('video')
+    const premidData = document.querySelector<HTMLElement>('#premid-data')
+
+    // Always read paused state from video element to avoid stale values
+    const paused = video?.paused ?? true
+    const currentTime = video?.currentTime ?? 0
+    const duration = (video && !Number.isNaN(video.duration)) ? video.duration : 0
+
+    const animeTitle = premidData?.dataset.animeTitle || 'Unknown Anime'
+    const episodeNumber = premidData?.dataset.episodeNumber || '1'
+    const episodeTitle = premidData?.dataset.episodeTitle || ''
+    const animePoster = premidData?.dataset.animePoster || ''
+
+    // Title line
+    if (privacy)
+      presenceData.details = 'Watching anime'
+    else
+      presenceData.details = animeTitle.split(' ').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
+
+    // Episode line
+    if (!privacy) {
+      presenceData.state = episodeTitle
+        ? `Ep ${episodeNumber} — ${episodeTitle}`
+        : `Episode ${episodeNumber}`
+    }
+
+    // Cover art
+    if (showCover && !privacy && animePoster) {
+      presenceData.largeImageKey = animePoster
+      presenceData.largeImageText = animeTitle.split(' ').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
+    }
+
+    // Play/pause indicator
+    presenceData.smallImageKey = paused ? ActivityAssets.Pause : ActivityAssets.Play
+    presenceData.smallImageText = paused ? 'Paused' : 'Playing'
+
+    // Timestamps — only when video has valid duration
+    if (!paused && !privacy && duration > 0) {
+      [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestamps(
+        Math.floor(currentTime),
+        Math.floor(duration),
+      )
+    }
+
+    // Hide when paused
+    if (paused) {
+      if (hideWhenPaused)
+        return presence.clearActivity()
+      delete presenceData.startTimestamp
+      delete presenceData.endTimestamp
+    }
+
+    // Buttons
+    if (!privacy) {
+      const animeSlug = premidData?.dataset.animeSlug || ''
+      presenceData.buttons = [
+        {
+          label: 'Watch on AniVault',
+          url: window.location.href,
+        },
+        {
+          label: 'View Anime',
+          url: `https://anivault.xyz/anime/${animeSlug}`,
+        },
+      ]
+    }
+  }
+
+  // ── Browse Page ──
+  else if (pathname === '/browse' && showBrowsing && !privacy) {
+    presenceData.details = 'Browsing anime'
+    presenceData.smallImageKey = ActivityAssets.Search
+    presenceData.smallImageText = 'Browsing'
+  }
+
+  // ── Search Page ──
+  else if (pathname === '/search' && showBrowsing && !privacy) {
+    const query = document.querySelector<HTMLInputElement>(
+      'input[type="text"], input[type="search"]',
+    )?.value
+    presenceData.details = 'Searching'
+    presenceData.state = query || undefined
+    presenceData.smallImageKey = ActivityAssets.Search
+  }
+
+  // ── Trending Page ──
+  else if (pathname === '/trending' && showBrowsing && !privacy) {
+    presenceData.details = 'Viewing trending anime'
+  }
+
+  // ── Schedule Page ──
+  else if (pathname === '/schedule' && showBrowsing && !privacy) {
+    presenceData.details = 'Checking anime schedule'
+  }
+
+  // ── Anime Detail Page ──
+  else if (pathname.startsWith('/anime/') && showBrowsing && !privacy) {
+    const title = document.querySelector<HTMLHeadingElement>('h1')?.textContent
+    presenceData.details = 'Viewing anime'
+    presenceData.state = title || undefined
+  }
+
+  // ── Home / Other Pages ──
+  else if (showBrowsing || privacy) {
+    presenceData.details = privacy ? 'Browsing' : 'On the home page'
+    delete presenceData.state
+    delete presenceData.smallImageKey
+  }
+  else {
+    return presence.clearActivity()
+  }
+
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## AniVault Presence

AniVault (anivault.xyz) is a premium anime streaming platform.

### Features
- **Watch page**: Shows anime title, episode number, episode title, cover art, play/pause status, and timestamps
- - **Browse/Search/Trending/Schedule**: Shows browsing activity
- - **Anime detail page**: Shows which anime the user is viewing
- - **Settings**: Privacy mode, hide when paused, show anime cover, show browsing activity
- - **Buttons**: Watch on AniVault, View Anime

## Acknowledgements

- [x] I read the [Activity Guidelines](https://docs.premid.app/dev/presence/guidelines)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://docs.premid.app/dev/presence/guidelines#activity-guidelines)

### Screenshots
The presence reads data from hidden DOM attributes on the watch page and the native video element for playback state

Proof showing the creation/modification is working as expected

<img width="489" height="176" alt="image" src="https://github.com/user-attachments/assets/28cfba57-2611-4acf-862c-31eebf78040d" />

<img width="495" height="186" alt="image" src="https://github.com/user-attachments/assets/7ca74858-6a16-41a7-b49c-84926fbdbf8f" />
