### PR TITLE
fix(Tidal): fix activity after Tidal UI update

### DIFF
--- a/websites/T/Tidal/metadata.json
+++ b/websites/T/Tidal/metadata.json
@@ -9,7 +9,11 @@
     {
       "name": "Kyrie",
       "id": "368399721494216706"
-    }
+    },
+	{
+	  "name": "theelgass",
+      "id": "275368935615102976"
+	}
   ],
   "service": "Tidal",
   "description": {
@@ -24,7 +28,7 @@
     "tidal.com"
   ],
   "regExp": "^https?[:][/][/](listen[.])?tidal[.]com[/]",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/T/Tidal/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/T/Tidal/assets/thumbnail.png",
   "color": "#000000",

--- a/websites/T/Tidal/metadata.json
+++ b/websites/T/Tidal/metadata.json
@@ -10,10 +10,10 @@
       "name": "Kyrie",
       "id": "368399721494216706"
     },
-	{
-	  "name": "theelgass",
+    {
+      "name": "theelgass",
       "id": "275368935615102976"
-	}
+    }
   ],
   "service": "Tidal",
   "description": {

--- a/websites/T/Tidal/presence.ts
+++ b/websites/T/Tidal/presence.ts
@@ -1,6 +1,7 @@
 import { ActivityType, Assets } from 'premid'
 
 const LOGO_URL = 'https://cdn.rcd.gg/PreMiD/websites/T/Tidal/assets/logo.png'
+
 const presence = new Presence({ clientId: '901591802342150174' })
 
 async function getStrings() {
@@ -10,7 +11,6 @@ async function getStrings() {
       pause: 'general.paused',
       viewSong: 'general.buttonViewSong',
     },
-
   )
 }
 
@@ -18,7 +18,7 @@ let strings: Awaited<ReturnType<typeof getStrings>>
 let oldLang: string | null = null
 
 presence.on('UpdateData', async () => {
-  if (!document.querySelector('#footerPlayer'))
+  if (!document.querySelector('[data-test="track-info"]'))
     return presence.setActivity({ largeImageKey: LOGO_URL })
 
   const [newLang, timestamps, cover, buttons] = await Promise.all([
@@ -32,45 +32,44 @@ presence.on('UpdateData', async () => {
     oldLang = newLang
     strings = await getStrings()
   }
+
   const presenceData: PresenceData = {
     largeImageKey: LOGO_URL,
     type: ActivityType.Listening,
   }
+
   const songTitle = document.querySelector<HTMLAnchorElement>(
-    '[data-test=\'footer-track-title\'] > div > a',
+    '[data-test="footer-track-title"] a',
   )
+
   const currentTime = document.querySelector<HTMLElement>(
     'time[data-test="current-time"]',
   )?.textContent
-  const paused = document
-    .querySelector('div[data-test="play-controls"] div > button')
-    ?.getAttribute('data-test') === 'play'
-  const repeatType = document
-    .querySelector(
-      'div[data-test="play-controls"] > button[data-test="repeat"]',
-    )
-    ?.getAttribute('data-type')
+
+  const paused = !document.querySelector('button[data-test="pause"]')
 
   presenceData.details = songTitle?.textContent
-  // get artists
+
   presenceData.state = Array.from(
-    document.querySelectorAll<HTMLAnchorElement>('#footerPlayer .artist-link a'),
+    document.querySelectorAll<HTMLAnchorElement>(
+      '[data-test="footer-artist-name"] a',
+    ),
   )
     .map(artist => artist.textContent)
     .join(', ')
 
   if (cover) {
     presenceData.largeImageKey = document
-      .querySelector(
-        'figure[data-test=current-media-imagery] > div > div > div > img',
+      .querySelector<HTMLImageElement>(
+        'figure[data-test="current-media-imagery"] img',
       )
       ?.getAttribute('src')
       ?.replace('80x80', '640x640')
   }
-  if (
-    (Number.parseFloat(currentTime?.[0] ?? '') * 60 + Number.parseFloat(currentTime?.[1] ?? '')) * 1000 > 0
-    || !paused
-  ) {
+
+  const [min = 0, sec = 0] = (currentTime ?? '0:0').split(':').map(Number)
+
+  if ((min * 60 + sec) * 1000 > 0 || !paused) {
     [presenceData.startTimestamp, presenceData.endTimestamp] = presence.getTimestamps(
       presence.timestampFromFormat(currentTime ?? ''),
       presence.timestampFromFormat(
@@ -84,16 +83,14 @@ presence.on('UpdateData', async () => {
 
   if (
     document
-      .querySelector(
-        'div[data-test="play-controls"] > button[data-test="repeat"]',
-      )
+      .querySelector('button[data-test="repeat"]')
       ?.getAttribute('aria-checked') === 'true'
   ) {
-    presenceData.smallImageKey = repeatType === 'button__repeatAll' ? Assets.Repeat : Assets.RepeatOne
-    presenceData.smallImageText = repeatType === 'button__repeatAll' ? 'Playlist on loop' : 'On loop'
-
-    delete presenceData.endTimestamp
+    const isRepeatOne = !!document.querySelector('[data-test="icon--player__repeat-once"]')
+    presenceData.smallImageKey = isRepeatOne ? Assets.RepeatOne : Assets.Repeat
+    presenceData.smallImageText = isRepeatOne ? 'On loop' : 'Playlist on loop'
   }
+
   if (buttons) {
     presenceData.buttons = [
       {
@@ -102,7 +99,9 @@ presence.on('UpdateData', async () => {
       },
     ]
   }
+
   if (!timestamps)
     delete presenceData.endTimestamp
+
   presence.setActivity(presenceData)
 })

--- a/websites/T/Tidal/presence.ts
+++ b/websites/T/Tidal/presence.ts
@@ -1,4 +1,4 @@
-import { ActivityType, Assets } from 'premid'
+import { ActivityType, Assets, getTimestamps, timestampFromFormat } from 'premid'
 
 const LOGO_URL = 'https://cdn.rcd.gg/PreMiD/websites/T/Tidal/assets/logo.png'
 
@@ -70,9 +70,9 @@ presence.on('UpdateData', async () => {
   const [min = 0, sec = 0] = (currentTime ?? '0:0').split(':').map(Number)
 
   if ((min * 60 + sec) * 1000 > 0 || !paused) {
-    [presenceData.startTimestamp, presenceData.endTimestamp] = presence.getTimestamps(
-      presence.timestampFromFormat(currentTime ?? ''),
-      presence.timestampFromFormat(
+    [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestamps(
+      timestampFromFormat(currentTime ?? ''),
+      timestampFromFormat(
         document.querySelector<HTMLElement>('time[data-test="duration"]')
           ?.textContent ?? '',
       ),


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Update selectors for new Tidal UI

- Replace `#footerPlayer` with `[data-test="track-info"]`
- Fix song title selector: `[data-test="footer-track-title"] a`
- Fix artist selector: `[data-test="footer-artist-name"] a`
- Fix artwork selector: `figure[data-test="current-media-imagery"] img`
- Fix play/pause detection: `button[data-test="pause"]`
- Fix repeat and repeat one detection via `[data-test="icon--player__repeat-once"]`
- Fix timestamp parsing (string index → split(':'))
- Replace deprecated getTimestamps and timestampFromFormat functions
## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="612" height="262" alt="image" src="https://github.com/user-attachments/assets/bad9dd6e-536b-453d-8fea-db3969f4191f" />

</details>
