### PR TITLE
feat(szabfun): add activity

### DIFF
--- a/websites/S/Szabfun/metadata.json
+++ b/websites/S/Szabfun/metadata.json
@@ -21,13 +21,5 @@
     "fun",
     "minigames",
     "casual-games"
-  ],
-  "settings": [
-    {
-      "id": "buttons",
-      "title": "Show Presence Buttons",
-      "icon": "fas fa-th-large",
-      "value": true
-    }
   ]
 }

--- a/websites/S/Szabfun/metadata.json
+++ b/websites/S/Szabfun/metadata.json
@@ -20,7 +20,7 @@
     "games",
     "fun",
     "minigames",
-    "szabfun"
+    "casual-games"
   ],
   "settings": [
     {

--- a/websites/S/Szabfun/metadata.json
+++ b/websites/S/Szabfun/metadata.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "name": "SzaBee13",
+    "id": "1015545127500009562"
+  },
+  "service": "Szabfun",
+  "description": {
+    "en": "Szabfun is a free online gaming platform with fun mini-games and interactive activities."
+  },
+  "url": "fun.szabee.me",
+  "regExp": "^https?[:][/][/]fun[.]szabee[.]me[/]",
+  "version": "1.0.0",
+  "logo": "https://fun.szabee.me/img/logo.png",
+  "thumbnail": "https://fun.szabee.me/img/thumbnail.png",
+  "color": "#FFFFFF",
+  "category": "games",
+  "tags": [
+    "games",
+    "fun",
+    "minigames",
+    "szabfun"
+  ],
+  "settings": [
+    {
+      "id": "buttons",
+      "title": "Show Presence Buttons",
+      "icon": "fas fa-th-large",
+      "value": true
+    }
+  ]
+}

--- a/websites/S/Szabfun/metadata.json
+++ b/websites/S/Szabfun/metadata.json
@@ -10,10 +10,10 @@
     "en": "Szabfun is a free online gaming platform with fun mini-games and interactive activities."
   },
   "url": "fun.szabee.me",
-  "regExp": "^https?[:][/][/]fun[.]szabee[.]me[/]",
+  "regExp": "^https?[:][/][/]fun[.]szabee[.]me([/]|$)",
   "version": "1.0.0",
-  "logo": "https://fun.szabee.me/img/logo.png",
-  "thumbnail": "https://fun.szabee.me/img/thumbnail.png",
+  "logo": "https://i.imgur.com/uERHbwA.png",
+  "thumbnail": "https://i.imgur.com/IPzIfUO.png",
   "color": "#FFFFFF",
   "category": "games",
   "tags": [

--- a/websites/S/Szabfun/presence.ts
+++ b/websites/S/Szabfun/presence.ts
@@ -5,12 +5,12 @@ const presence = new Presence({
 const browsingTimestamp = Math.floor(Date.now() / 1000)
 
 enum ActivityAssets {
-  Logo = 'https://fun.szabee.me/img/logo.png',
+  Logo = 'https://i.imgur.com/uERHbwA.png',
 }
 
 const pageNames: Record<string, string> = {
   'tic-tac-toe': 'Tic-tac-toe',
-  'choose-an-username': 'Choose an Username',
+  'choose-a-username': 'Choose a Username',
   'swear-word-generator': 'Swear Word Generator',
   'guess-the-number': 'Guess The Number',
   'watch-some-youtube': 'Watch Some Youtube',

--- a/websites/S/Szabfun/presence.ts
+++ b/websites/S/Szabfun/presence.ts
@@ -13,7 +13,7 @@ const pageNames: Record<string, string> = {
   'choose-a-username': 'Choose a Username',
   'swear-word-generator': 'Swear Word Generator',
   'guess-the-number': 'Guess The Number',
-  'watch-some-youtube': 'Watch Some Youtube',
+  'watch-some-youtube': 'Watch Some YouTube',
   'escape-game': 'Escape Game',
   'chat': 'Chat',
   'enter-password': 'Enter Password',

--- a/websites/S/Szabfun/presence.ts
+++ b/websites/S/Szabfun/presence.ts
@@ -37,7 +37,6 @@ presence.on('UpdateData', async () => {
   const pathname = document.location.pathname
   const currentSegment = getPathSegment(pathname)
   const currentPageName = pageNames[currentSegment]
-  const buttons = await presence.getSetting<boolean>('buttons')
 
   const presenceData: PresenceData = {
     largeImageKey: ActivityAssets.Logo,
@@ -64,15 +63,6 @@ presence.on('UpdateData', async () => {
     presenceData.details = 'Browsing'
     if (title.length > 0)
       presenceData.state = title
-  }
-
-  if (buttons) {
-    presenceData.buttons = [
-      {
-        label: 'Visit Szabfun',
-        url: document.location.href,
-      },
-    ]
   }
 
   if (presenceData.details)

--- a/websites/S/Szabfun/presence.ts
+++ b/websites/S/Szabfun/presence.ts
@@ -1,0 +1,82 @@
+const presence = new Presence({
+  clientId: '1427310874296713279',
+})
+
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://fun.szabee.me/img/logo.png',
+}
+
+const pageNames: Record<string, string> = {
+  'tic-tac-toe': 'Tic-tac-toe',
+  'choose-an-username': 'Choose an Username',
+  'swear-word-generator': 'Swear Word Generator',
+  'guess-the-number': 'Guess The Number',
+  'watch-some-youtube': 'Watch Some Youtube',
+  'escape-game': 'Escape Game',
+  'chat': 'Chat',
+  'enter-password': 'Enter Password',
+  'sus-link': 'Sus Link',
+  'math': 'Math',
+  'chaos-clicker': 'Chaos Clicker',
+  'rock-paper-scissors': 'Rock Paper Scissors',
+  'login': 'Account',
+  'privacy-policy': 'Privacy Policy',
+  'suggestion': 'Suggestions',
+}
+
+function getPathSegment(pathname: string): string {
+  return pathname
+    .replace(/^\//, '')
+    .replace(/\/index\.html$/, '')
+    .split('/')[0] ?? ''
+}
+
+presence.on('UpdateData', async () => {
+  const pathname = document.location.pathname
+  const currentSegment = getPathSegment(pathname)
+  const currentPageName = pageNames[currentSegment]
+  const buttons = await presence.getSetting<boolean>('buttons')
+
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+  }
+
+  if (pathname === '/' || pathname === '/index.html') {
+    presenceData.details = 'Browsing games'
+    presenceData.state = 'Home'
+  }
+  else if (pathname.startsWith('/docs')) {
+    presenceData.details = 'Reading documentation'
+  }
+  else if (currentPageName) {
+    presenceData.details = currentSegment === 'login' ? 'Managing account' : 'Playing a game'
+    presenceData.state = currentPageName
+  }
+  else {
+    const title = document.title
+      .replace(/\s*-\s*Szabfun.*$/i, '')
+      .replace(/^Szabfun\s*-\s*/i, '')
+      .trim()
+
+    presenceData.details = 'Browsing'
+    if (title.length > 0)
+      presenceData.state = title
+  }
+
+  if (buttons) {
+    presenceData.buttons = [
+      {
+        label: 'Visit Szabfun',
+        url: document.location.href,
+      },
+    ]
+  }
+
+  if (presenceData.details)
+    presence.setActivity(presenceData)
+  else
+    presence.clearActivity()
+})


### PR DESCRIPTION
## Summary
This PR adds a new PreMiD Activity for Szabfun (fun.szabee.me).

## Changes
- Added metadata for Szabfun with service info, URL matching, category, tags, and settings
- Added presence implementation to detect key pages and update Discord Rich Presence accordingly
- Added support for a presence button to open the current Szabfun page

## Presence Behavior
- Home page: Browsing games
- Docs pages: Reading documentation
- Known game/tool pages: Playing a game + page name
- Fallback pages: Browsing + cleaned page title

## Files Added
- websites/S/Szabfun/metadata.json
- websites/S/Szabfun/presence.ts

## Notes
- Uses live Szabfun assets for logo/thumbnail
- Includes configured Discord application client ID for the activity