### PR TITLE
feat(Patreon): add privacy mode and improve route coverage

### DIFF
--- a/websites/P/Patreon/metadata.json
+++ b/websites/P/Patreon/metadata.json
@@ -11,11 +11,12 @@
     "fr": "Patreon est le meilleur endroit pour les créateurs afin de créer de l'adhésion en fournissant des accès exclusifs à leur travail et une connexion plus profonde avec leur communauté."
   },
   "url": [
+    "patreon.com",
     "www.patreon.com",
     "support.patreon.com",
     "privacy.patreon.com"
   ],
-  "regExp": "^https?[:][/][/]((www|support|privacy)[.]patreon[.]com)[/]",
+  "regExp": "^https?[:][/][/]((www|support|privacy)[.]patreon[.]com|patreon[.]com)[/]",
   "version": "1.2.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/P/Patreon/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/P/Patreon/assets/thumbnail.png",

--- a/websites/P/Patreon/metadata.json
+++ b/websites/P/Patreon/metadata.json
@@ -16,7 +16,7 @@
     "privacy.patreon.com"
   ],
   "regExp": "^https?[:][/][/]((www|support|privacy)[.]patreon[.]com)[/]",
-  "version": "1.3.0",
+  "version": "1.2.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/P/Patreon/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/P/Patreon/assets/thumbnail.png",
   "color": "#F1465A",

--- a/websites/P/Patreon/metadata.json
+++ b/websites/P/Patreon/metadata.json
@@ -10,9 +10,13 @@
     "en": "Patreon is the best place for creators to build memberships by providing exclusive access to their work and a deeper connection with their communities.",
     "fr": "Patreon est le meilleur endroit pour les créateurs afin de créer de l'adhésion en fournissant des accès exclusifs à leur travail et une connexion plus profonde avec leur communauté."
   },
-  "url": "www.patreon.com",
-  "regExp": "^https?[:][/][/](www[.])?patreon[.]com[/]",
-  "version": "1.1.0",
+  "url": [
+    "www.patreon.com",
+    "support.patreon.com",
+    "privacy.patreon.com"
+  ],
+  "regExp": "^https?[:][/][/]((www|support|privacy)[.]patreon[.]com)[/]",
+  "version": "1.3.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/P/Patreon/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/P/Patreon/assets/thumbnail.png",
   "color": "#F1465A",
@@ -23,7 +27,16 @@
   ],
   "settings": [
     {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "icon": "fad fa-user-secret",
+      "value": false
+    },
+    {
       "id": "buttons",
+      "if": {
+        "privacy": false
+      },
       "title": "Show Buttons",
       "icon": "fas fa-compress-arrows-alt",
       "value": true

--- a/websites/P/Patreon/presence.ts
+++ b/websites/P/Patreon/presence.ts
@@ -12,8 +12,70 @@ const statics: {
   'login': 'Log in Patreon',
 }
 const slideshow = presence.createSlideshow()
+const creatorSections: Record<string, string> = {
+  'about': 'Viewing creator about page',
+  'chats': 'Viewing creator chats',
+  'collections': 'Viewing creator collections',
+  'gift': 'Viewing gift options',
+  'membership': 'Viewing membership options',
+  'memberships': 'Viewing membership options',
+  'posts': 'Browsing creator posts',
+  'recommendations': 'Viewing creator recommendations',
+  'shop': 'Viewing creator shop',
+}
+
 enum ActivityAssets {
   Logo = 'https://cdn.rcd.gg/PreMiD/websites/P/Patreon/assets/logo.png',
+}
+
+function getTextContent(selector: string) {
+  return document.querySelector(selector)?.textContent?.trim()
+}
+
+function getPageTitle(...suffixes: string[]) {
+  let title = document.title.trim()
+
+  for (const suffix of suffixes)
+    title = title.replace(suffix, '').trim()
+
+  return title
+}
+
+function getSearchQuery() {
+  const params = new URLSearchParams(document.location.search)
+
+  return params.get('q')
+    ?? params.get('query')
+    ?? document.querySelector<HTMLInputElement>('input[type="search"], input')?.value
+}
+
+function getPostTitle() {
+  return getTextContent('[data-tag="post-title"]')
+    ?? getTextContent('h1')
+    ?? document.title.replace(/\s+\|\s+Patreon$/, '')
+}
+
+function getPostCreatorName() {
+  const ogTitle = document
+    .querySelector('meta[property="og:title"]')
+    ?.getAttribute('content')
+    ?.trim()
+
+  if (ogTitle?.includes(' | '))
+    return ogTitle.split(' | ').slice(1).join(' | ').trim()
+
+  return [...document.querySelectorAll<HTMLAnchorElement>('a[href]')]
+    .find(anchor =>
+      /^https:\/\/www\.patreon\.com\/[A-Za-z0-9_.-]+\/?$/.test(anchor.href)
+      && anchor.textContent?.trim(),
+    )
+    ?.textContent
+    ?.trim()
+}
+
+function getCreatorName() {
+  return getTextContent('h1')
+    ?? document.title.split(' | ')[0]?.trim()
 }
 
 presence.on('UpdateData', async () => {
@@ -25,31 +87,103 @@ presence.on('UpdateData', async () => {
     largeImageKey: ActivityAssets.Logo,
     startTimestamp: browsingTimestamp,
   }
-  const showButtons = await presence.getSetting<boolean>('buttons')
-  const { pathname, href } = document.location
+  const [privacy, showButtons] = await Promise.all([
+    presence.getSetting<boolean>('privacy'),
+    presence.getSetting<boolean>('buttons'),
+  ])
+  const { pathname, href, hostname } = document.location
+  const searchParams = new URLSearchParams(document.location.search)
   const pathArr = pathname.split('/')
+  const creatorSlugIndex = pathArr[1] === 'cw' ? 2 : 1
+  const creatorSlug = pathArr[creatorSlugIndex]
+  const creatorSection = pathArr[creatorSlugIndex + 1]
 
-  switch (pathArr[1]) {
+  if (slideshow.getSlides().length > 0)
+    slideshow.deleteAllSlides()
+
+  if (hostname === 'support.patreon.com') {
+    switch (pathArr[1]) {
+      case 'hc':
+        if (pathArr[3] === 'requests' && pathArr[4] === 'new') {
+          presenceData.details = searchParams.get('ticket_form_id') === '28810449009677'
+            ? 'Submitting a feature request'
+            : 'Submitting a help request'
+        }
+        else if (pathArr[3] === 'articles') {
+          presenceData.details = 'Reading a help article'
+          if (!privacy)
+            presenceData.state = getPageTitle(' – Patreon Help Center', ' - Patreon Help Center')
+        }
+        else {
+          presenceData.details = 'Browsing the Help Center'
+        }
+        break
+      default:
+        presenceData.details = 'Browsing the Help Center'
+    }
+  }
+  else if (hostname === 'privacy.patreon.com') {
+    presenceData.details = pathArr[1] === 'policies'
+      ? 'Reading privacy policies'
+      : 'Viewing Patreon privacy information'
+  }
+  else switch (pathArr[1]) {
     case 'product':
       presenceData.details = 'Viewing a plan'
-      presenceData.state = `Plan: ${pathArr[2]}`
+      if (!privacy)
+        presenceData.state = `Plan: ${pathArr[2]}`
       break
     case 'c':
       presenceData.details = 'Viewing a page for creators'
-      presenceData.state = `For: ${
-        {
-          'podcasts': 'podcasters',
-          'video': 'video creators',
-          'music': 'musicians',
-          'visualartists': 'visual artists',
-          'communities': 'community leaders',
-          'writing': 'writers & journalists',
-          'gaming': 'gaming creators',
-          'nonprofits': 'nonprofit organizations',
-          'tutorials-and-education': 'education & tutorial creators',
-          'local-businesses': 'local businesses',
-        }[pathArr[2]!]
-      }`
+      if (!privacy) {
+        presenceData.state = `For: ${
+          {
+            'podcasts': 'podcasters',
+            'video': 'video creators',
+            'music': 'musicians',
+            'visualartists': 'visual artists',
+            'communities': 'community leaders',
+            'writing': 'writers & journalists',
+            'gaming': 'gaming creators',
+            'nonprofits': 'nonprofit organizations',
+            'tutorials-and-education': 'education & tutorial creators',
+            'local-businesses': 'local businesses',
+          }[pathArr[2]!]
+        }`
+      }
+      break
+    case 'explore':
+      if (pathArr[2] === 'search') {
+        const searchQuery = getSearchQuery()
+        const searchType = searchParams.get('type')
+
+        presenceData.details = searchQuery
+          ? {
+              'post': 'Searching posts',
+              'creator': 'Searching creators',
+            }[searchType ?? ''] ?? 'Searching Patreon'
+          : 'On searching page'
+        if (!privacy && searchQuery)
+          presenceData.state = `Query: ${searchQuery}`
+        presenceData.smallImageKey = Assets.Search
+      }
+      else {
+        presenceData.details = pathArr[2] === 'creators'
+          ? searchParams.get('type') === 'suggested-campaigns'
+              ? 'Exploring suggested creators'
+              : 'Exploring creators'
+          : 'Exploring Patreon'
+        if (!privacy) {
+          const topic = searchParams
+            .get('topic')
+            ?.replace(/_/g, ' ')
+            ?? (pathArr[2] && !['all', 'creators'].includes(pathArr[2])
+              ? pathArr[2].replace(/-/g, ' ')
+              : undefined)
+          if (topic)
+            presenceData.state = `Topic: ${topic}`
+        }
+      }
       break
     case 'apps':
       if (pathArr.length === 2) {
@@ -57,46 +191,93 @@ presence.on('UpdateData', async () => {
       }
       else {
         presenceData.details = 'Viewing an app'
-        presenceData.state = document.querySelector(
-          '.Text_variantDisplayTextLg__NwCo5',
-        )?.textContent
-        presenceData.buttons = [{ label: 'View app', url: href }]
+        if (!privacy) {
+          presenceData.state = document.querySelector(
+            '.Text_variantDisplayTextLg__NwCo5',
+          )?.textContent
+          presenceData.buttons = [{ label: 'View app', url: href }]
+        }
       }
       break
     case 'settings':
       presenceData.details = 'Editing their settings'
-      presenceData.state = `Page: ${
-        document.querySelectorAll('a[aria-current="page"]')[1]?.textContent
-      }`
+      if (!privacy) {
+        presenceData.state = `Page: ${
+          document.querySelectorAll('a[aria-current="page"]')[1]?.textContent
+        }`
+      }
       break
     case 'search':
-      if (href.includes('?q=')) {
-        presenceData.details = 'Searching'
-        presenceData.state = `Query: ${document
-          .querySelector('input')
-          ?.getAttribute('value')}`
+      if (getSearchQuery()) {
+        presenceData.details = 'Searching creators'
+        if (!privacy)
+          presenceData.state = `Query: ${getSearchQuery()}`
         presenceData.smallImageKey = Assets.Search
       }
       else {
         presenceData.details = 'On searching page'
       }
       break
+    case 'notifications':
+      presenceData.details = 'Viewing notifications'
+      break
+    case 'messages':
+      if (searchParams.get('tab') === 'direct-messages') {
+        presenceData.details = pathArr[2]
+          ? 'Viewing a direct message'
+          : 'Browsing direct messages'
+      }
+      else if (searchParams.get('tab') === 'chats') {
+        presenceData.details = pathArr[2]
+          ? 'Viewing a group chat'
+          : 'Browsing group chats'
+      }
+      else {
+        presenceData.details = 'Reading their messages'
+      }
+      break
+    case 'policy':
+      presenceData.details = pathArr[2] === 'legal'
+        ? 'Reading terms of use'
+        : 'Reading community policies'
+      break
     case 'posts':
-      presenceData.details = presenceDataSlide.details = 'Viewing a post'
-      presenceData.state = document.querySelector(
-        'span[data-tag="post-title"]',
-      )?.textContent
-      presenceDataSlide.state = `From ${
-        document.querySelector('div[data-tag="metadata-wrapper"] > div > div')
-          ?.textContent
-      }`
+      presenceData.details = 'Viewing a post'
 
-      presenceData.buttons = presenceDataSlide.buttons = [
-        { label: 'View Post', url: href },
-      ]
+      if (!privacy) {
+        const postTitle = getPostTitle()
+        const creatorName = getPostCreatorName()
 
-      slideshow.addSlide('slidePostName', presenceData, 5000)
-      slideshow.addSlide('slideCreatorName', presenceDataSlide, 5000)
+        if (postTitle) {
+          presenceData.state = postTitle
+          slideshow.addSlide('slidePostName', presenceData, 5000)
+        }
+
+        if (creatorName) {
+          presenceDataSlide.details = 'Viewing a post'
+          presenceDataSlide.state = `From ${creatorName}`
+          slideshow.addSlide('slideCreatorName', presenceDataSlide, 5000)
+        }
+
+        if (showButtons)
+          presenceData.buttons = presenceDataSlide.buttons = [{ label: 'View Post', url: href }]
+      }
+      break
+    case 'collection':
+      presenceData.details = 'Viewing a collection'
+      if (!privacy)
+        presenceData.state = getTextContent('h1') ?? undefined
+      break
+    case 'cw':
+      presenceData.details = creatorSlug === 'patreon' && !creatorSection
+        ? 'Viewing Patreon news'
+        : creatorSection && creatorSections[creatorSection]
+            ? creatorSections[creatorSection]
+            : 'Viewing a creator'
+      if (!privacy && creatorSlug !== 'patreon')
+        presenceData.state = getCreatorName()
+      if (!privacy && showButtons && !creatorSection)
+        presenceData.buttons = [{ label: 'View Creator', url: href }]
       break
     default:
       if (Object.keys(statics).includes(pathArr[1]!)) {
@@ -106,18 +287,25 @@ presence.on('UpdateData', async () => {
         presenceData.details = 'Reading their messages'
       }
       else {
-        presenceData.details = 'Viewing a creator'
-        presenceData.state = document.querySelector('h1')?.textContent?.trim()
-        presenceData.buttons = [{ label: 'View Creator', url: href }]
+        presenceData.details = creatorSection && creatorSections[creatorSection]
+          ? creatorSections[creatorSection]
+          : 'Viewing a creator'
+        if (!privacy) {
+          presenceData.state = creatorSlug === 'patreon' && !creatorSection
+            ? undefined
+            : getCreatorName()
+          if (!creatorSection)
+            presenceData.buttons = [{ label: 'View Creator', url: href }]
+        }
       }
   }
 
-  if (!showButtons) {
+  if (!showButtons || privacy) {
     delete presenceData.buttons
     delete presenceDataSlide.buttons
   }
 
-  if (slideshow.getSlides().length > 0)
+  if (!privacy && slideshow.getSlides().length > 0)
     presence.setActivity(slideshow)
   else if (presenceData.details)
     presence.setActivity(presenceData)

--- a/websites/P/Patreon/presence.ts
+++ b/websites/P/Patreon/presence.ts
@@ -13,15 +13,15 @@ const statics: {
 }
 const slideshow = presence.createSlideshow()
 const creatorSections: Record<string, string> = {
-  'about': 'Viewing creator about page',
-  'chats': 'Viewing creator chats',
-  'collections': 'Viewing creator collections',
-  'gift': 'Viewing gift options',
-  'membership': 'Viewing membership options',
-  'memberships': 'Viewing membership options',
-  'posts': 'Browsing creator posts',
-  'recommendations': 'Viewing creator recommendations',
-  'shop': 'Viewing creator shop',
+  about: 'Viewing creator about page',
+  chats: 'Viewing creator chats',
+  collections: 'Viewing creator collections',
+  gift: 'Viewing gift options',
+  membership: 'Viewing membership options',
+  memberships: 'Viewing membership options',
+  posts: 'Browsing creator posts',
+  recommendations: 'Viewing creator recommendations',
+  shop: 'Viewing creator shop',
 }
 
 enum ActivityAssets {
@@ -66,7 +66,7 @@ function getPostCreatorName() {
 
   return [...document.querySelectorAll<HTMLAnchorElement>('a[href]')]
     .find(anchor =>
-      /^https:\/\/www\.patreon\.com\/[A-Za-z0-9_.-]+\/?$/.test(anchor.href)
+      /^https:\/\/www\.patreon\.com\/[\w.-]+\/?$/.test(anchor.href)
       && anchor.textContent?.trim(),
     )
     ?.textContent
@@ -127,17 +127,17 @@ presence.on('UpdateData', async () => {
       ? 'Reading privacy policies'
       : 'Viewing Patreon privacy information'
   }
-  else switch (pathArr[1]) {
-    case 'product':
-      presenceData.details = 'Viewing a plan'
-      if (!privacy)
-        presenceData.state = `Plan: ${pathArr[2]}`
-      break
-    case 'c':
-      presenceData.details = 'Viewing a page for creators'
-      if (!privacy) {
-        presenceData.state = `For: ${
-          {
+  else {
+    switch (pathArr[1]) {
+      case 'product':
+        presenceData.details = 'Viewing a plan'
+        if (!privacy && pathArr[2])
+          presenceData.state = `Plan: ${pathArr[2]}`
+        break
+      case 'c': {
+        presenceData.details = 'Viewing a page for creators'
+        if (!privacy) {
+          const creatorType = ({
             'podcasts': 'podcasters',
             'video': 'video creators',
             'music': 'musicians',
@@ -148,156 +148,162 @@ presence.on('UpdateData', async () => {
             'nonprofits': 'nonprofit organizations',
             'tutorials-and-education': 'education & tutorial creators',
             'local-businesses': 'local businesses',
-          }[pathArr[2]!]
-        }`
+          } as Record<string, string>)[pathArr[2]!]
+          if (creatorType)
+            presenceData.state = `For: ${creatorType}`
+        }
+        break
       }
-      break
-    case 'explore':
-      if (pathArr[2] === 'search') {
-        const searchQuery = getSearchQuery()
-        const searchType = searchParams.get('type')
+      case 'explore':
+        if (pathArr[2] === 'search') {
+          const searchQuery = getSearchQuery()
+          const searchType = searchParams.get('type')
 
-        presenceData.details = searchQuery
-          ? {
-              'post': 'Searching posts',
-              'creator': 'Searching creators',
-            }[searchType ?? ''] ?? 'Searching Patreon'
-          : 'On searching page'
-        if (!privacy && searchQuery)
-          presenceData.state = `Query: ${searchQuery}`
-        presenceData.smallImageKey = Assets.Search
-      }
-      else {
-        presenceData.details = pathArr[2] === 'creators'
-          ? searchParams.get('type') === 'suggested-campaigns'
+          presenceData.details = searchQuery
+            ? {
+                post: 'Searching posts',
+                creator: 'Searching creators',
+              }[searchType ?? ''] ?? 'Searching Patreon'
+            : 'On searching page'
+          if (!privacy && searchQuery)
+            presenceData.state = `Query: ${searchQuery}`
+          presenceData.smallImageKey = Assets.Search
+        }
+        else {
+          presenceData.details = pathArr[2] === 'creators'
+            ? searchParams.get('type') === 'suggested-campaigns'
               ? 'Exploring suggested creators'
               : 'Exploring creators'
-          : 'Exploring Patreon'
-        if (!privacy) {
-          const topic = searchParams
-            .get('topic')
-            ?.replace(/_/g, ' ')
-            ?? (pathArr[2] && !['all', 'creators'].includes(pathArr[2])
-              ? pathArr[2].replace(/-/g, ' ')
-              : undefined)
-          if (topic)
-            presenceData.state = `Topic: ${topic}`
+            : 'Exploring Patreon'
+          if (!privacy) {
+            const topic = searchParams
+              .get('topic')
+              ?.replace(/_/g, ' ')
+              ?? (pathArr[2] && !['all', 'creators'].includes(pathArr[2])
+                ? pathArr[2].replace(/-/g, ' ')
+                : undefined)
+            if (topic)
+              presenceData.state = `Topic: ${topic}`
+          }
         }
-      }
-      break
-    case 'apps':
-      if (pathArr.length === 2) {
-        presenceData.details = 'Viewing apps available'
-      }
-      else {
-        presenceData.details = 'Viewing an app'
-        if (!privacy) {
-          presenceData.state = document.querySelector(
-            '.Text_variantDisplayTextLg__NwCo5',
-          )?.textContent
-          presenceData.buttons = [{ label: 'View app', url: href }]
+        break
+      case 'apps':
+        if (pathArr.length === 2) {
+          presenceData.details = 'Viewing apps available'
         }
+        else {
+          presenceData.details = 'Viewing an app'
+          if (!privacy) {
+            presenceData.state = document.querySelector(
+              '.Text_variantDisplayTextLg__NwCo5',
+            )?.textContent
+            presenceData.buttons = [{ label: 'View app', url: href }]
+          }
+        }
+        break
+      case 'settings': {
+        presenceData.details = 'Editing their settings'
+        if (!privacy) {
+          const settingPage = document.querySelectorAll('a[aria-current="page"]')[1]?.textContent
+          if (settingPage)
+            presenceData.state = `Page: ${settingPage}`
+        }
+        break
       }
-      break
-    case 'settings':
-      presenceData.details = 'Editing their settings'
-      if (!privacy) {
-        presenceData.state = `Page: ${
-          document.querySelectorAll('a[aria-current="page"]')[1]?.textContent
-        }`
+      case 'search': {
+        const legacySearchQuery = getSearchQuery()
+        if (legacySearchQuery) {
+          presenceData.details = 'Searching creators'
+          if (!privacy)
+            presenceData.state = `Query: ${legacySearchQuery}`
+          presenceData.smallImageKey = Assets.Search
+        }
+        else {
+          presenceData.details = 'On searching page'
+        }
+        break
       }
-      break
-    case 'search':
-      if (getSearchQuery()) {
-        presenceData.details = 'Searching creators'
+      case 'notifications':
+        presenceData.details = 'Viewing notifications'
+        break
+      case 'messages':
+        if (searchParams.get('tab') === 'direct-messages') {
+          presenceData.details = pathArr[2]
+            ? 'Viewing a direct message'
+            : 'Browsing direct messages'
+        }
+        else if (searchParams.get('tab') === 'chats') {
+          presenceData.details = pathArr[2]
+            ? 'Viewing a group chat'
+            : 'Browsing group chats'
+        }
+        else {
+          presenceData.details = 'Reading their messages'
+        }
+        break
+      case 'policy':
+        presenceData.details = pathArr[2] === 'legal'
+          ? 'Reading terms of use'
+          : 'Reading community policies'
+        break
+      case 'posts':
+        presenceData.details = 'Viewing a post'
+
+        if (!privacy) {
+          const postTitle = getPostTitle()
+          const creatorName = getPostCreatorName()
+
+          if (postTitle) {
+            presenceData.state = postTitle
+            slideshow.addSlide('slidePostName', presenceData, 5000)
+          }
+
+          if (creatorName) {
+            presenceDataSlide.details = 'Viewing a post'
+            presenceDataSlide.state = `From ${creatorName}`
+            slideshow.addSlide('slideCreatorName', presenceDataSlide, 5000)
+          }
+
+          if (showButtons)
+            presenceData.buttons = presenceDataSlide.buttons = [{ label: 'View Post', url: href }]
+        }
+        break
+      case 'collection':
+        presenceData.details = 'Viewing a collection'
         if (!privacy)
-          presenceData.state = `Query: ${getSearchQuery()}`
-        presenceData.smallImageKey = Assets.Search
-      }
-      else {
-        presenceData.details = 'On searching page'
-      }
-      break
-    case 'notifications':
-      presenceData.details = 'Viewing notifications'
-      break
-    case 'messages':
-      if (searchParams.get('tab') === 'direct-messages') {
-        presenceData.details = pathArr[2]
-          ? 'Viewing a direct message'
-          : 'Browsing direct messages'
-      }
-      else if (searchParams.get('tab') === 'chats') {
-        presenceData.details = pathArr[2]
-          ? 'Viewing a group chat'
-          : 'Browsing group chats'
-      }
-      else {
-        presenceData.details = 'Reading their messages'
-      }
-      break
-    case 'policy':
-      presenceData.details = pathArr[2] === 'legal'
-        ? 'Reading terms of use'
-        : 'Reading community policies'
-      break
-    case 'posts':
-      presenceData.details = 'Viewing a post'
-
-      if (!privacy) {
-        const postTitle = getPostTitle()
-        const creatorName = getPostCreatorName()
-
-        if (postTitle) {
-          presenceData.state = postTitle
-          slideshow.addSlide('slidePostName', presenceData, 5000)
-        }
-
-        if (creatorName) {
-          presenceDataSlide.details = 'Viewing a post'
-          presenceDataSlide.state = `From ${creatorName}`
-          slideshow.addSlide('slideCreatorName', presenceDataSlide, 5000)
-        }
-
-        if (showButtons)
-          presenceData.buttons = presenceDataSlide.buttons = [{ label: 'View Post', url: href }]
-      }
-      break
-    case 'collection':
-      presenceData.details = 'Viewing a collection'
-      if (!privacy)
-        presenceData.state = getTextContent('h1') ?? undefined
-      break
-    case 'cw':
-      presenceData.details = creatorSlug === 'patreon' && !creatorSection
-        ? 'Viewing Patreon news'
-        : creatorSection && creatorSections[creatorSection]
+          presenceData.state = getTextContent('h1') ?? undefined
+        break
+      case 'cw':
+        presenceData.details = creatorSlug === 'patreon' && !creatorSection
+          ? 'Viewing Patreon news'
+          : creatorSection && creatorSections[creatorSection]
             ? creatorSections[creatorSection]
             : 'Viewing a creator'
-      if (!privacy && creatorSlug !== 'patreon')
-        presenceData.state = getCreatorName()
-      if (!privacy && showButtons && !creatorSection)
-        presenceData.buttons = [{ label: 'View Creator', url: href }]
-      break
-    default:
-      if (Object.keys(statics).includes(pathArr[1]!)) {
-        presenceData.details = statics[pathArr[1]!]
-      }
-      else if (pathArr[1]!.includes('messages')) {
-        presenceData.details = 'Reading their messages'
-      }
-      else {
-        presenceData.details = creatorSection && creatorSections[creatorSection]
-          ? creatorSections[creatorSection]
-          : 'Viewing a creator'
-        if (!privacy) {
-          presenceData.state = creatorSlug === 'patreon' && !creatorSection
-            ? undefined
-            : getCreatorName()
-          if (!creatorSection)
-            presenceData.buttons = [{ label: 'View Creator', url: href }]
+        if (!privacy && creatorSlug !== 'patreon')
+          presenceData.state = getCreatorName()
+        if (!privacy && showButtons && !creatorSection)
+          presenceData.buttons = [{ label: 'View Creator', url: href }]
+        break
+      default:
+        if (Object.keys(statics).includes(pathArr[1]!)) {
+          presenceData.details = statics[pathArr[1]!]
         }
-      }
+        else if (pathArr[1]!.includes('messages')) {
+          presenceData.details = 'Reading their messages'
+        }
+        else {
+          presenceData.details = creatorSection && creatorSections[creatorSection]
+            ? creatorSections[creatorSection]
+            : 'Viewing a creator'
+          if (!privacy) {
+            presenceData.state = creatorSlug === 'patreon' && !creatorSection
+              ? undefined
+              : getCreatorName()
+            if (!creatorSection)
+              presenceData.buttons = [{ label: 'View Creator', url: href }]
+          }
+        }
+    }
   }
 
   if (!showButtons || privacy) {


### PR DESCRIPTION
## Description

Adds privacy mode to the Patreon activity and improves route coverage across several
Patreon surfaces. Previously the activity had no privacy option and could expose
creator names, post titles, and search queries in Discord. It also had stale slideshow
state between route changes and limited support for Patreon's subdomain structure.

Changes:
- add `Privacy Mode` setting. Hides all creator/page-specific details when enabled
- hide buttons automatically when privacy mode is on
- clear slideshow between route changes to prevent stale Rich Presence
- add support for `support.patreon.com` (Help Center) and `privacy.patreon.com`
- improve route handling: explore/search, creator sections, notifications, messages,
  Patreon news (`/cw/patreon`), policy/legal pages, posts, collections, apps

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary>Proof showing the creation/modification is working as expected</summary>

<img width="660" height="370" alt="final-before-after" src="https://github.com/user-attachments/assets/f0142283-f50e-4535-a2f7-bc9fb7fa513a" />

</details>
