### PR TITLE
feat: add Terousd activity

### DIFF
--- a/websites/T/Terousd/metadata.json
+++ b/websites/T/Terousd/metadata.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "id": "1009426635780542475",
+    "name": "Terousd"
+  },
+  "service": "Terousd",
+  "description": {
+    "en": "Terousd is a streaming platform for discovering and watching movies and TV series."
+  },
+  "url": "stream.terousd.online",
+  "regExp": "^https?[:][/][/]stream[.]terousd[.]online[/]",
+  "version": "1.0.0",
+  "logo": "https://stream.terousd.online/favicon.png",
+  "thumbnail": "https://stream.terousd.online/favicon.png",
+  "color": "#141414",
+  "category": "videos",
+  "tags": [
+    "movies",
+    "tv",
+    "streaming",
+    "video"
+  ],
+  "settings": [
+    {
+      "id": "showButtons",
+      "title": "Show Buttons",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true
+    }
+  ]
+}

--- a/websites/T/Terousd/presence.ts
+++ b/websites/T/Terousd/presence.ts
@@ -89,7 +89,7 @@ presence.on('UpdateData', async () => {
 
     if (showButtons && params.get('id')) {
       presenceData.buttons = [{
-        label: 'View Title',
+        label: 'Open Title',
         url: document.location.href,
       }]
     }
@@ -120,7 +120,7 @@ presence.on('UpdateData', async () => {
 
     if (showButtons && params.get('id')) {
       presenceData.buttons = [{
-        label: 'Watch Stream',
+        label: 'Open Stream',
         url: document.location.href,
       }]
     }

--- a/websites/T/Terousd/presence.ts
+++ b/websites/T/Terousd/presence.ts
@@ -1,0 +1,135 @@
+import { ActivityType, Assets, getTimestampsFromMedia } from 'premid'
+
+const presence = new Presence({
+  clientId: '1495463888920117410',
+})
+
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+const logo = 'https://stream.terousd.online/favicon.png'
+
+function cleanTitle(title: string | undefined) {
+  return title?.replace(/\s*-\s*Terousd$/i, '').trim()
+}
+
+function getCurrentTitle() {
+  return cleanTitle(
+    document.querySelector<HTMLElement>('#details-title, .details-title, h1.details-title')
+      ?.textContent
+      || document.title,
+  )
+}
+
+function getTitleArtwork() {
+  const poster = document.querySelector<HTMLImageElement>(
+    [
+      '#details-poster',
+      '.movie-details-poster img',
+      '.details-poster img',
+      'img[src*="image.tmdb.org"]',
+      'img[alt][src^="https://image.tmdb.org/"]',
+    ].join(', '),
+  )?.src
+
+  if (poster)
+    return poster
+
+  const backdropElement = document.querySelector<HTMLElement>(
+    [
+      '#player-backdrop',
+      '.player-backdrop',
+      '.detail-backdrop',
+      '[style*="background-image"]',
+    ].join(', '),
+  )
+  const backgroundImage = backdropElement ? window.getComputedStyle(backdropElement).backgroundImage : ''
+  const backdropMatch = /url\((["']?)(.*?)\1\)/.exec(backgroundImage)
+
+  return backdropMatch?.[2] || undefined
+}
+
+presence.on('UpdateData', async () => {
+  const showButtons = await presence.getSetting<boolean>('showButtons')
+  const path = document.location.pathname
+  const params = new URLSearchParams(document.location.search)
+  const pageTitle = getCurrentTitle()
+  const artwork = getTitleArtwork()
+  const player = document.querySelector<HTMLVideoElement>('video.player-iframe')
+
+  const presenceData: PresenceData = {
+    type: ActivityType.Watching,
+    largeImageKey: artwork || logo,
+    largeImageText: 'Terousd',
+    startTimestamp: browsingTimestamp,
+  }
+
+  if (path === '/') {
+    presenceData.details = 'Browsing the homepage'
+  }
+  else if (path === '/movies') {
+    presenceData.details = 'Browsing movies'
+  }
+  else if (path === '/tvshows') {
+    presenceData.details = 'Browsing TV shows'
+  }
+  else if (path === '/search') {
+    const query = params.get('q')
+    presenceData.details = query ? 'Searching titles' : 'Browsing search'
+    if (query)
+      presenceData.state = query
+  }
+  else if (path === '/title') {
+    presenceData.type = ActivityType.Watching
+    presenceData.details = pageTitle && pageTitle !== 'Terousd'
+      ? `Viewing details of ${pageTitle}`
+      : 'Viewing title details'
+    if (pageTitle && pageTitle !== 'Terousd')
+      presenceData.state = pageTitle
+    if (artwork)
+      presenceData.largeImageKey = artwork
+
+    if (showButtons && params.get('id')) {
+      presenceData.buttons = [{
+        label: 'View Title',
+        url: document.location.href,
+      }]
+    }
+  }
+  else if (path === '/watch') {
+    presenceData.type = ActivityType.Watching
+    presenceData.details = pageTitle && pageTitle !== 'Watch' && pageTitle !== 'Terousd'
+      ? `Watching ${pageTitle}`
+      : 'Watching on Terousd'
+    if (pageTitle && pageTitle !== 'Watch' && pageTitle !== 'Terousd')
+      presenceData.state = pageTitle
+    if (artwork)
+      presenceData.largeImageKey = artwork
+
+    if (player && Number.isFinite(player.duration)) {
+      const [startTimestamp, endTimestamp] = getTimestampsFromMedia(player)
+      presenceData.smallImageKey = player.paused ? Assets.Pause : Assets.Play
+      presenceData.smallImageText = player.paused ? 'Paused' : 'Playing'
+
+      if (!player.paused) {
+        presenceData.startTimestamp = startTimestamp
+        presenceData.endTimestamp = endTimestamp
+      }
+      else {
+        delete presenceData.endTimestamp
+      }
+    }
+
+    if (showButtons && params.get('id')) {
+      presenceData.buttons = [{
+        label: 'Watch Stream',
+        url: document.location.href,
+      }]
+    }
+  }
+  else {
+    presenceData.details = 'Browsing Terousd'
+    if (pageTitle && pageTitle !== 'Terousd')
+      presenceData.state = pageTitle
+  }
+
+  presence.setActivity(presenceData)
+})

--- a/websites/T/Terousd/presence.ts
+++ b/websites/T/Terousd/presence.ts
@@ -89,7 +89,7 @@ presence.on('UpdateData', async () => {
 
     if (showButtons && params.get('id')) {
       presenceData.buttons = [{
-        label: 'Open Title',
+        label: 'View Title',
         url: document.location.href,
       }]
     }
@@ -120,7 +120,7 @@ presence.on('UpdateData', async () => {
 
     if (showButtons && params.get('id')) {
       presenceData.buttons = [{
-        label: 'Open Stream',
+        label: 'Watch Stream',
         url: document.location.href,
       }]
     }


### PR DESCRIPTION
## Description
Adds a new PreMiD activity for Terousd (`stream.terousd.online`).

## Features
- Homepage, movies, TV shows, and search presence
- Title details presence with actual title name
- Watch presence with actual title name
- Poster/backdrop artwork on title/watch pages
- Timestamp support for native HTML5 video playback
- Watch/title buttons

## Notes
- Timestamp support works for native HTML5 video playback.
- External cross-origin iframe players may not expose playback time due to browser restrictions.
<img width="1366" height="768" alt="Screenshot (533)" src="https://github.com/user-attachments/assets/e48a4f0a-a8b7-4ddd-ba33-09332b2f6c0f" />
<img width="1366" height="768" alt="Screenshot (534)" src="https://github.com/user-attachments/assets/8ffc059b-73bb-40c9-8fe0-f6c3940bb12f" />
