### PR TITLE
fix(RTL+): add support for beta.plus.rtl.de

### DIFF
--- a/websites/R/RTL+/metadata.json
+++ b/websites/R/RTL+/metadata.json
@@ -17,9 +17,12 @@
     "en": "RTL+ offers you exciting films and series. Also many shows and documentaries can be found in the online stream! Watch your favorite show online now!",
     "nl": "RTL+ biedt spannende films en series. Ook zijn er veel shows en documentaires te vinden in de online stream! Bekijk nu uw favoriete programma online!"
   },
-  "url": "plus.rtl.de",
-  "regExp": "^https?[:][/][/]plus[.]rtl[.]de[/]",
-  "version": "1.2.0",
+  "url": [
+    "plus.rtl.de",
+    "beta.plus.rtl.de"
+  ],
+  "regExp": "^https?[:][/][/](beta[.])?plus[.]rtl[.]de[/]",
+  "version": "1.2.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/R/RTL%2B/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/R/RTL%2B/assets/thumbnail.jpg",
   "color": "#ffbc2d",

--- a/websites/R/RTL+/presence.ts
+++ b/websites/R/RTL+/presence.ts
@@ -1,4 +1,4 @@
-import { Assets } from 'premid'
+import { Assets, getTimestampsFromMedia } from 'premid'
 
 const presence = new Presence({
   clientId: '1033504954763198545',
@@ -42,7 +42,7 @@ presence.on('UpdateData', async () => {
 
       presenceData.smallImageKey = video.paused ? Assets.Pause : Assets.Play
       presenceData.smallImageText = video.paused ? strings.pause : strings.play;
-      [presenceData.startTimestamp, presenceData.endTimestamp] = presence.getTimestampsfromMedia(video)
+      [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestampsFromMedia(video)
       presenceData.buttons = [
         {
           label: 'View',


### PR DESCRIPTION
## Description

Fixes #10701. RTL+ migrated to `beta.plus.rtl.de` and the extension no longer detected the activity there because the regExp was locked to `plus.rtl.de` exactly.

Changes:
- `url`: widened to `["plus.rtl.de", "beta.plus.rtl.de"]`
- `regExp`: `^https?[:][/][/](beta[.])?plus[.]rtl[.]de[/]`
- `version`: `1.2.0` → `1.2.1`

Second commit migrates `presence.getTimestampsfromMedia` → standalone `getTimestampsFromMedia` because the pre-push lint was blocking the push (the deprecation is pre-existing, not introduced by this PR).

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

### **`beta.plus.rtl.de/` — homepage (new domain)**

<img width="963" height="435" alt="beta-homepage" src="https://github.com/user-attachments/assets/5f9f3985-e1f1-4f62-9152-86a53490e1d1" />

### **`beta.plus.rtl.de/rtlplus-root/serien-rtl-f_3` — browsing series**

<img width="965" height="444" alt="beta-serien-browse" src="https://github.com/user-attachments/assets/fb24163b-4dd1-4e26-963b-af1180409ed6" />

</details>
