### PR TITLE
fix(1Shows): restore activity with new 1shows.ru domain

### DIFF
--- a/websites/0-9/1Shows/metadata.json
+++ b/websites/0-9/1Shows/metadata.json
@@ -12,8 +12,8 @@
   "url": "www.1shows.ru",
   "regExp": "^https?[:][/][/](www[.])?1shows[.]ru[/]",
   "version": "1.0.0",
-  "logo": "https://cdn.rcd.gg/PreMiD/websites/0-9/1Shows/assets/logo.png",
-  "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/0-9/1Shows/assets/thumbnail.png",
+  "logo": "https://i.imgur.com/GhoM28H.png",
+  "thumbnail": "https://i.imgur.com/HCpF6JV.png",
   "color": "#121212",
   "category": "videos",
   "tags": [

--- a/websites/0-9/1Shows/metadata.json
+++ b/websites/0-9/1Shows/metadata.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "id": "1171471152695214094",
+    "name": "ownernotfound"
+  },
+  "service": "1Shows",
+  "description": {
+    "en": "Enjoy unlimited streaming of movies, TV shows, and anime in HD & 4K, completely free! 1Shows offers a seamless experience with multi-language support and auto-next playback, ensuring you never miss a moment. Watch your favorite content anytime, anywhere for free!"
+  },
+  "url": "www.1shows.ru",
+  "regExp": "^https?[:][/][/](www[.])?1shows[.]ru[/]",
+  "version": "1.0.0",
+  "logo": "https://cdn.rcd.gg/PreMiD/websites/0-9/1Shows/assets/logo.png",
+  "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/0-9/1Shows/assets/thumbnail.png",
+  "color": "#121212",
+  "category": "videos",
+  "tags": [
+    "movies",
+    "anime",
+    "tv"
+  ],
+  "settings": [
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "icon": "fas fa-user-secret",
+      "value": false
+    }
+  ]
+}

--- a/websites/0-9/1Shows/presence.ts
+++ b/websites/0-9/1Shows/presence.ts
@@ -7,7 +7,7 @@ const presence = new Presence({
 const browsingTimestamp = Math.floor(Date.now() / 1000)
 
 enum ActivityAssets {
-  Logo = 'https://cdn.rcd.gg/PreMiD/websites/0-9/1Shows/assets/logo.png',
+  Logo = 'https://i.imgur.com/GhoM28H.png',
 }
 
 presence.on('UpdateData', async () => {

--- a/websites/0-9/1Shows/presence.ts
+++ b/websites/0-9/1Shows/presence.ts
@@ -36,6 +36,14 @@ presence.on('UpdateData', async () => {
       details: 'Viewing Profile',
       smallImageKey: Assets.Viewing,
     },
+    '/login': {
+      details: 'Signing in',
+      smallImageKey: Assets.Viewing,
+    },
+    '/register': {
+      details: 'Creating an account',
+      smallImageKey: Assets.Viewing,
+    },
     '/tv': {
       details: 'Browsing TV Shows',
       smallImageKey: Assets.Viewing,

--- a/websites/0-9/1Shows/presence.ts
+++ b/websites/0-9/1Shows/presence.ts
@@ -1,0 +1,186 @@
+import { ActivityType, Assets } from 'premid'
+
+const presence = new Presence({
+  clientId: '1452785817901600890',
+})
+
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://cdn.rcd.gg/PreMiD/websites/0-9/1Shows/assets/logo.png',
+}
+
+presence.on('UpdateData', async () => {
+  let presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+    details: 'Unsupported Page',
+  }
+
+  const { pathname } = document.location
+
+  const privacy = await presence.getSetting<boolean>('privacy')
+
+  if (privacy) {
+    presenceData.details = 'Watching 1Shows'
+    presence.setActivity(presenceData)
+    return
+  }
+
+  const pages: Record<string, PresenceData> = {
+    '/': {
+      details: 'Viewing HomePage',
+      smallImageKey: Assets.Viewing,
+    },
+    '/profile': {
+      details: 'Viewing Profile',
+      smallImageKey: Assets.Viewing,
+    },
+    '/tv': {
+      details: 'Browsing TV Shows',
+      smallImageKey: Assets.Viewing,
+    },
+    '/livetv': {
+      details: 'Browsing Live TV',
+      smallImageKey: Assets.Viewing,
+    },
+    '/sports': {
+      details: 'Browsing Live Sports',
+      smallImageKey: Assets.Viewing,
+    },
+    '/games': {
+      details: 'Playing Games',
+      smallImageKey: Assets.Viewing,
+    },
+  }
+
+  for (const [path, data] of Object.entries(pages)) {
+    if (pathname === path) {
+      presenceData = {
+        ...presenceData,
+        ...data,
+        type: ActivityType.Watching,
+      }
+    }
+  }
+
+  if (pathname.includes('/movies/')) {
+    switch (pathname.replace(/^\/+/, '').split('/')[0]) {
+      case 'movies': {
+        const match = pathname.match(/\/movies\/(\d+)(?:-([^/]+))?/)
+
+        if (match && match[1]) {
+          const movieName = match[2]?.replace(/-/g, ' ') || 'Unknown Movie'
+
+          const formattedMovieName = movieName
+            .split(' ')
+            .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(' ')
+
+          presenceData.name = `${formattedMovieName}`
+          presenceData.details = '1Shows'
+          presenceData.type = ActivityType.Watching
+
+          const rating = document.querySelector('.radial-progress span.text-white')?.textContent?.trim() || 'N/A'
+
+          const runtime = document.querySelector('#Movie\\ Runtime time p')?.textContent?.match(/\d+/)?.[0] || 'N/A'
+
+          let releaseDate = document.querySelector('#Movie\\ Release\\ Date time p')?.textContent?.trim() || 'N/A'
+
+          if (releaseDate !== 'N/A') {
+            const dateParts = releaseDate.split(', ')
+            if (dateParts.length === 3) {
+              releaseDate = `${dateParts[1]} ${dateParts[2]}`
+            }
+          }
+
+          presenceData.state = `⭐ ${rating} 🕒 ${runtime} mins 🗓️ ${releaseDate}`
+
+          const posterElement = document.querySelector('figure img.object-cover')
+
+          const posterSrc = posterElement?.getAttribute('src')
+
+          presenceData.largeImageKey = posterSrc
+
+          // Check URL parameter for streaming
+          const urlParams = new URLSearchParams(document.location.search)
+          const isStreaming = urlParams.get('streaming') === 'true'
+          presenceData.smallImageKey = isStreaming ? Assets.Play : Assets.Pause
+        }
+        break
+      }
+
+      default:
+        presenceData.details = 'Browsing a Movie'
+        break
+    }
+  }
+
+  if (pathname.includes('/tv/')) {
+    switch (pathname.replace(/^\/+/, '').split('/')[0]) {
+      case 'tv': {
+        const match = pathname.match(/\/tv\/(\d+)(?:-([^/]+))?/)
+
+        if (match && match[1]) {
+          const tmdbId = match[1]
+          const showName = match[2]?.replace(/-/g, ' ') || 'Unknown Show'
+
+          const formattedShowName = showName
+            .split(' ')
+            .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(' ')
+
+          const watchHistory = JSON.parse(localStorage.getItem('watch-history') || '{}')
+          const showData = watchHistory[tmdbId] || {
+            last_season_watched: '1',
+            last_episode_watched: '1',
+          }
+          const seasonNo = showData.last_season_watched
+          const episodeNo = showData.last_episode_watched
+
+          presenceData.name = ` ${formattedShowName} S${seasonNo}E${episodeNo}`
+          presenceData.details = '1Shows'
+          presenceData.type = ActivityType.Watching
+
+          const rating = document.querySelector('.radial-progress span.text-white')?.textContent?.trim() || 'N/A'
+
+          let releaseDate = document.querySelector('#TV\\ Shows\\ Air\\ Date time')?.textContent?.trim() || 'N/A'
+
+          if (releaseDate !== 'N/A') {
+            const dateParts = releaseDate.split(', ')
+            if (dateParts.length === 3) {
+              releaseDate = `${dateParts[1]} ${dateParts[2]}`
+            }
+          }
+
+          presenceData.state = `⭐ ${rating} 🗓️ ${releaseDate}`
+
+          presenceData.largeImageKey = document.querySelector<HTMLImageElement>('section.md\\:col-\\[1\\/4\\] img')?.src || ActivityAssets.Logo
+
+          // Check URL parameter for streaming
+          const urlParams = new URLSearchParams(document.location.search)
+          const isStreaming = urlParams.get('streaming') === 'true'
+          presenceData.smallImageKey = isStreaming ? Assets.Play : Assets.Pause
+        }
+        break
+      }
+
+      default:
+        presenceData.details = 'Browsing a TV Show'
+        break
+    }
+  }
+
+  if (pathname.includes('/search')) {
+    presenceData.details = `Searching for Content`
+    const query = document.querySelector('input')?.getAttribute('value')
+    if (query) {
+      presenceData.state = `Query: ${query}`
+    }
+    presenceData.smallImageKey = Assets.Search
+  }
+
+  if (presenceData.details)
+    presence.setActivity(presenceData)
+  else presence.setActivity()
+})

--- a/websites/0-9/1Shows/presence.ts
+++ b/websites/0-9/1Shows/presence.ts
@@ -190,5 +190,5 @@ presence.on('UpdateData', async () => {
 
   if (presenceData.details)
     presence.setActivity(presenceData)
-  else presence.setActivity()
+  else presence.clearActivity()
 })


### PR DESCRIPTION
## Description

Fixes #10695. The 1Shows activity was auto-removed by #10696 because `www.1shows.nl` failed the DNS check. The service has since moved to `www.1shows.ru` (confirmed live, HTTP 200, and `1shows.ru` redirects to `www.1shows.ru`). This PR restores the activity with the new domain and two small additions.

### Changes
- `url`: `www.1shows.ru`
- `regExp`: `^https?[:][/][/](www[.])?1shows[.]ru[/]`
- `version`: `1.0.0` (required by `pmd build --validate` since the folder was deleted and is being re-created)
- `presence.ts`: added routes `/login` → "Signing in" and `/register` → "Creating an account" (previously surfaced as "Unsupported Page")
- `logo` and `thumbnail`: hosted on `i.imgur.com` (the original `cdn.rcd.gg` assets were removed together with the activity in #10696). Happy to let the rehost bot move them back to the CDN after merge.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

### `www.1shows.ru/movies/1383731-protector` — watching a movie

<img width="1036" height="436" alt="movie-protector" src="https://github.com/user-attachments/assets/45ddcb25-c60a-42bf-8826-62ccaff3609e" />

### `www.1shows.ru/tv/95557-invincible` — watching a TV show

<img width="1039" height="440" alt="tv-invincible" src="https://github.com/user-attachments/assets/af3040af-e71f-4cbd-af45-07b2d656ee05" />

</details>
