### PR TITLE
feat(miruro.tv): add presence

### DIFF
--- a/websites/M/Miruro/metadata.json
+++ b/websites/M/Miruro/metadata.json
@@ -5,16 +5,15 @@
     "name": "primedby",
     "id": "774832439905484820"
   },
-  "service": "Miruro",
+  "service": "miruro.tv",
   "description": {
-    "en": "Watch anime on Miruro and show what you're watching on Discord."
+    "en": "Watch anime on miruro.tv and show what you're watching on Discord."
   },
   "url": "miruro.tv",
-  "altnames": ["miruro.com", "miruro.su", "miruro.ro"],
-  "regExp": "miruro\\.(tv|com|su|ro)",
+  "regExp": "miruro\\.tv",
   "version": "1.0.0",
-  "logo": "https://www.miruro.tv/favicon.ico",
-  "thumbnail": "https://www.miruro.tv/favicon.ico",
+  "logo": "https://www.miruro.tv/android-chrome-512x512.png",
+  "thumbnail": "https://www.miruro.tv/android-chrome-512x512.png",
   "color": "#E85D04",
   "tags": ["anime", "video", "streaming"],
   "category": "videos"

--- a/websites/M/Miruro/metadata.json
+++ b/websites/M/Miruro/metadata.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "name": "primedby",
+    "id": "774832439905484820"
+  },
+  "service": "Miruro",
+  "description": {
+    "en": "Watch anime on Miruro and show what you're watching on Discord."
+  },
+  "url": "miruro.tv",
+  "altnames": ["miruro.com", "miruro.su", "miruro.ro"],
+  "regExp": "miruro\\.(tv|com|su|ro)",
+  "version": "1.0.0",
+  "logo": "https://www.miruro.tv/favicon.ico",
+  "thumbnail": "https://www.miruro.tv/favicon.ico",
+  "color": "#E85D04",
+  "tags": ["anime", "video", "streaming"],
+  "category": "videos"
+}

--- a/websites/M/Miruro/presence.ts
+++ b/websites/M/Miruro/presence.ts
@@ -1,0 +1,150 @@
+const presence = new Presence({
+  clientId: "1497201619912360028",
+});
+
+const browsingTimestamp = Math.floor(Date.now() / 1000);
+const coverCache = new Map<string, string>();
+
+const MIRURO_LOGO = "https://www.miruro.tv/android-chrome-512x512.png";
+
+async function getAnimeCover(animeId: string): Promise<string> {
+  if (coverCache.has(animeId)) return coverCache.get(animeId)!;
+
+  const imgs = Array.from(document.querySelectorAll<HTMLImageElement>("img"));
+  const anilistImg = imgs.find(
+    (img) => img.src.includes("anilistcdn") && img.src.includes("anime/cover")
+  );
+  if (anilistImg?.src) {
+    coverCache.set(animeId, anilistImg.src);
+    return anilistImg.src;
+  }
+
+  try {
+    const query = `{ Media(id: ${animeId}) { coverImage { large } } }`;
+    const res = await fetch("https://graphql.anilist.co", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query }),
+    });
+    const json = await res.json();
+    const cover = json?.data?.Media?.coverImage?.large;
+    if (cover) {
+      coverCache.set(animeId, cover);
+      return cover;
+    }
+  } catch {}
+
+  return MIRURO_LOGO;
+}
+
+presence.on("UpdateData", async () => {
+  const path = location.pathname;
+
+  if (path.startsWith("/watch/")) {
+    const animeId = path.split("/")[2];
+    const video = document.querySelector<HTMLVideoElement>("video");
+    const episode = new URLSearchParams(location.search).get("ep");
+
+    let animeTitle = "Unknown Anime";
+    let episodeNum = episode ?? "?";
+
+    const titleEl =
+      document.querySelector<HTMLElement>("h1") ??
+      document.querySelector<HTMLElement>(".anime-title a") ??
+      document.querySelector<HTMLElement>("[class*='title']");
+
+    if (titleEl?.textContent) {
+      animeTitle = titleEl.textContent.trim();
+    } else {
+      const docTitle = document.title.replace("| Miruro", "").trim();
+      const parts = docTitle.split(" - Episode ");
+      if (parts.length === 2) {
+        animeTitle = parts[0]?.trim() ?? "Unknown Anime";
+        episodeNum = parts[1]?.trim() ?? "?";
+      } else {
+        animeTitle = docTitle;
+      }
+    }
+
+    const cover = animeId ? await getAnimeCover(animeId) : MIRURO_LOGO;
+
+    const presenceData: PresenceData = {
+      type: 3 as 3,
+      largeImageKey: cover,
+      largeImageText: animeTitle,
+      details: `Watching ${animeTitle}`,
+      state: `Episode ${episodeNum}`,
+      buttons: [{ label: "Watch on Miruro", url: location.href }],
+    };
+
+    if (video && !isNaN(video.duration) && video.duration > 0 && !video.paused) {
+      [presenceData.startTimestamp, presenceData.endTimestamp] =
+        presence.getTimestampsfromMedia(video);
+    } else {
+      presenceData.startTimestamp = browsingTimestamp;
+    }
+
+    presence.setActivity(presenceData);
+  } else if (path.startsWith("/info/")) {
+    const animeId = path.split("/")[2];
+    const cover = animeId ? await getAnimeCover(animeId) : MIRURO_LOGO;
+
+    const titleEl =
+      document.querySelector<HTMLElement>("h1") ??
+      document.querySelector<HTMLElement>("[class*='title']");
+    const animeTitle =
+      titleEl?.textContent?.trim() ??
+      document.title.replace("| Miruro", "").trim();
+
+    presence.setActivity({
+      type: 0 as 0,
+      largeImageKey: cover,
+      details: "Browsing Anime",
+      state: animeTitle,
+      startTimestamp: browsingTimestamp,
+      buttons: [{ label: "View on Miruro", url: location.href }],
+    });
+  } else if (path.startsWith("/search")) {
+    const query = new URLSearchParams(location.search).get("query");
+
+    presence.setActivity({
+      type: 0 as 0,
+      largeImageKey: MIRURO_LOGO,
+      details: "Searching",
+      state: query ? `"${query}"` : "Browsing",
+      startTimestamp: browsingTimestamp,
+    });
+  } else if (path === "/" || path === "") {
+    presence.setActivity({
+      type: 0 as 0,
+      largeImageKey: MIRURO_LOGO,
+      details: "Browsing",
+      state: "Home",
+      startTimestamp: browsingTimestamp,
+    });
+  } else if (path.startsWith("/trending")) {
+    presence.setActivity({
+      type: 0 as 0,
+      largeImageKey: MIRURO_LOGO,
+      details: "Browsing",
+      state: "Trending Anime",
+      startTimestamp: browsingTimestamp,
+    });
+  } else if (path.startsWith("/schedule")) {
+    presence.setActivity({
+      type: 0 as 0,
+      largeImageKey: MIRURO_LOGO,
+      details: "Browsing",
+      state: "Airing Schedule",
+      startTimestamp: browsingTimestamp,
+    });
+  } else {
+    presence.setActivity({
+      type: 0 as 0,
+      largeImageKey: MIRURO_LOGO,
+      details: "Browsing Miruro",
+      state: document.title.replace("| Miruro", "").trim(),
+      startTimestamp: browsingTimestamp,
+    });
+  }
+});


### PR DESCRIPTION
## Description

Adds a new presence for [Miruro](https://www.miruro.tv), a browser-based anime streaming site.

This presence was initially generated with AI assistance and has been manually reviewed, tested, and refined.

## Features

- **Watch page** — displays anime title, episode number, and cover art fetched from AniList (via DOM scraping with GraphQL fallback). Shows time remaining when playing, elapsed time when paused.
- **Info page** — displays anime title and cover art when browsing an anime's detail page.
- **Browse pages** — shows contextual state for Home, Trending, Schedule, and Search (including the search query).
- **Watch on Miruro** button on watch pages, **View on Miruro** button on info pages.
- Cover art is cached per anime ID to avoid redundant fetches.
- Uses direct URL (`https://www.miruro.tv/android-chrome-512x512.png`) for the logo per current PreMiD guidelines.

## Known Issue

The Miruro logo shows a question mark on the author's local setup when on browse pages. The direct logo URL is correctly set and loads fine in a browser, but does not render in Discord Rich Presence during local dev. This appears to be a local environment quirk (Arch Linux, browser Discord + Vesktop, Wayland) and is not expected to affect other users in production.

## Testing

- Tested on Arch Linux, KDE Plasma 6.6.4, Wayland
- Browser Discord (discord.com) + Vesktop
- Dev server: `npx pmd dev Miruro`
- Watch page, info page, home, trending, schedule, and search pages all confirmed working
<img width="284" height="120" alt="Screenshot_20260425_152314" src="https://github.com/user-attachments/assets/e0f2ac87-8d7e-4d16-9fbc-9371935f5e02" />
<img width="273" height="111" alt="Screenshot_20260425_152247" src="https://github.com/user-attachments/assets/536051d9-ca17-4467-88d6-0da2c85570bd" />
<img width="265" height="96" alt="Screenshot_20260425_152237" src="https://github.com/user-attachments/assets/2b3197ba-284e-4e71-baa2-7c6950755898" />
<img width="275" height="111" alt="Screenshot_20260425_152218" src="https://github.com/user-attachments/assets/95ac998a-8fd5-4459-927c-842d2d7fcd13" />
