### PR TITLE
feat(eBay): add livestream support

### DIFF
--- a/websites/E/eBay/metadata.json
+++ b/websites/E/eBay/metadata.json
@@ -9,6 +9,10 @@
     {
       "name": "The Gamerzs",
       "id": "730142125181894657"
+    },
+    {
+      "name": "cian",
+      "id": "834863623595229247"
     }
   ],
   "service": "eBay",
@@ -16,22 +20,32 @@
     "en": "Buy and sell electronics, cars, fashion apparel, collectibles, sporting goods, digital cameras, baby items, coupons, and everything else on eBay, the world's online marketplace.",
     "nl": "Koop en verkoop elektronica, auto's, mode, verzamelobjecten, sportartikelen, digitale camera's, babyartikelen, kortingsbonnen en al het andere op eBay, 's werelds online marktplaats."
   },
-  "url": "www.ebay.com",
+  "url": [
+    "www.ebay.com",
+    "www.ebay.co.uk"
+  ],
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*ebay([.][a-z]+)+[/]",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/E/eBay/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/E/eBay/assets/thumbnail.png",
   "color": "#e53238",
   "category": "other",
   "tags": [
     "store",
-    "shopping"
+    "shopping",
+    "livestream"
   ],
   "settings": [
     {
       "id": "buttons",
       "title": "Show Buttons",
       "icon": "fas fa-compress-arrows-alt",
+      "value": true
+    },
+    {
+      "id": "showLiveDetails",
+      "title": "Show Live Details",
+      "icon": "fas fa-broadcast-tower",
       "value": true
     }
   ]

--- a/websites/E/eBay/presence.ts
+++ b/websites/E/eBay/presence.ts
@@ -152,7 +152,6 @@ presence.on('UpdateData', async () => {
             presenceData.details = 'eBay Live'
             presenceData.state = subPage
           }
-
           break
         }
         default:

--- a/websites/E/eBay/presence.ts
+++ b/websites/E/eBay/presence.ts
@@ -84,6 +84,77 @@ presence.on('UpdateData', async () => {
 
           break
         }
+        case 'ebaylive': {
+          // eBay Live (livestreams) — e.g. /ebaylive/events/<id>/stream
+          const parts = location.pathname.split('/').filter(Boolean)
+          // parts[0] === 'ebaylive', parts[1] === 'events' | 'schedule' | etc., parts[2] === id, parts[3] === 'stream'
+          const subPage = parts[1]
+
+          if (subPage === 'events' && parts[2]) {
+            // Individual livestream page
+            const title
+              = document.querySelector('meta[property="og:title"]')?.getAttribute('content')?.trim()
+                ?? document.querySelector('h1')?.textContent?.trim()
+                ?? document.title?.replace(/\s*\|\s*eBay.*$/i, '').trim()
+                ?? 'Livestream'
+
+            // Try to grab the seller / host name from the "About" panel
+            const host
+              = document.querySelector<HTMLAnchorElement>('a[href*="/usr/"]')?.textContent?.trim()
+                ?? document.querySelector<HTMLAnchorElement>('a[href*="/str/"]')?.textContent?.trim()
+                ?? document.querySelector('[data-testid="host-name"]')?.textContent?.trim()
+                ?? ''
+
+            // Try to grab the stream thumbnail / poster image
+            const thumbnail
+              = document.querySelector<HTMLMetaElement>('meta[property="og:image"]')?.content
+                ?? document.querySelector<HTMLMetaElement>('meta[name="twitter:image"]')?.content
+                ?? document.querySelector<HTMLVideoElement>('video')?.poster
+                ?? ''
+
+            const showLiveDetails = await presence.getSetting<boolean>('showLiveDetails')
+
+            if (showLiveDetails) {
+              presenceData.details = 'Watching a livestream:'
+              presenceData.state = host ? `${title} — by ${host}` : title
+              if (thumbnail)
+                presenceData.largeImageKey = thumbnail
+              presenceData.smallImageKey = Assets.Live
+
+              const sellerUrl = document.querySelector<HTMLAnchorElement>(
+                'a[href*="/usr/"], a[href*="/str/"]',
+              )?.href
+
+              presenceData.buttons = host && sellerUrl
+                ? [
+                    { label: 'Watch Stream', url: location.href },
+                    { label: 'View Seller', url: sellerUrl },
+                  ]
+                : [
+                    { label: 'Watch Stream', url: location.href },
+                  ]
+            }
+            else {
+              // Privacy / minimal mode — just say they're watching eBay Live
+              presenceData.details = 'Watching an eBay livestream'
+            }
+          }
+          else if (subPage === 'schedule') {
+            presenceData.details = 'eBay Live'
+            presenceData.state = 'Browsing the schedule'
+          }
+          else if (!subPage) {
+            // /ebaylive homepage
+            presenceData.details = 'Browsing eBay Live'
+            presenceData.state = 'Livestreams'
+          }
+          else {
+            presenceData.details = 'eBay Live'
+            presenceData.state = subPage
+          }
+
+          break
+        }
         default:
           if (location.pathname.includes('/myb/')) {
             presenceData.details = 'Viewing their:'


### PR DESCRIPTION
## Description

Adds Discord rich presence support for eBay Live (livestreams).

When a user is on `ebay.com/ebaylive/events/<id>/stream` (or the same path on the UK domain), Discord now shows:

- "Watching a livestream:" with the actual stream title
- Host / seller name (when detectable)
- The stream's thumbnail as the large image
- A "Live" indicator as the small image
- Buttons: Watch Stream + View Seller

**Other changes:**

- Added `www.ebay.co.uk` to the `url` array (was previously only `www.ebay.com`); the existing `regExp` already matched all eBay regions, but the displayed Supported URLs list was missing the UK domain
- Added `livestream` tag in metadata
- Added a `Show Live Details` setting so users can toggle whether stream-specific info (title, host, thumbnail, live badge, buttons) is shown — defaults to on, but flipping it off collapses the status to a generic "Watching an eBay livestream" for privacy
- Bumped version to `1.5.0`

Tested on:
- An eBay UK livestream URL — shows full title and host
- Existing eBay paths (item pages, search, user profiles) — unchanged

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots

<details>
<summary> Proof showing the creation/modification is working as expected </summary>

<img width="868" height="333" alt="Discord status showing Watching a livestream" src="https://github.com/user-attachments/assets/63744319-56d5-4420-8e45-52402a8cae6a" />

<img width="420" height="600" alt="PreMiD panel showing v1.5.0 with new settings" src="https://github.com/user-attachments/assets/666f1d02-c86b-40f7-952e-273528485b29" />

</details>