### PR TITLE
feat(ccleaf): add activity

### DIFF
--- a/websites/C/ccLeaf/metadata.json
+++ b/websites/C/ccLeaf/metadata.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "id": "1028528977410797628",
+    "name": "th3wwt"
+  },
+  "service": "ccLeaf",
+  "description": {
+    "en": "ccLeaf is an animation template platform where creators can quickly edit and export high-quality visuals without doing everything from scratch. It’s built for speed, simplicity, and clean results."
+  },
+  "url": ["ccleaf.com", "app.ccleaf.com"],
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*ccleaf[.]com[/]",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/fv1VJQR.png",
+  "thumbnail": "https://i.imgur.com/qhIVv23.png",
+  "color": "#000000",
+  "category": "other",
+  "tags": [
+    "animation"
+  ]
+}

--- a/websites/C/ccLeaf/presence.ts
+++ b/websites/C/ccLeaf/presence.ts
@@ -1,38 +1,33 @@
 const presence = new Presence({
   clientId: '1498049243368390736',
-});
+})
 
-const browsingTimestamp = Math.floor(Date.now() / 1000);
+const browsingTimestamp = Math.floor(Date.now() / 1000)
 
 presence.on('UpdateData', async () => {
-  const path = document.location.pathname;
+  const path = document.location.pathname
 
-  let details = 'Using ccLeaf';
-  let state = 'In the app';
+  let details = 'Using ccLeaf'
+  let state = 'In the app'
 
-  // Homepage
   if (path === '/') {
-    details = 'Viewing homepage';
-    state = 'Exploring ccLeaf';
+    details = 'Viewing homepage'
+    state = 'Exploring ccLeaf'
   }
-
-  // Animations list
   else if (path === '/animations') {
-    details = 'Browsing animations';
-    state = 'Selecting a template';
+    details = 'Browsing animations'
+    state = 'Selecting a template'
   }
-
-  // Editor page
   else if (/^\/animations\/\d+\/.+/.test(path)) {
-    const animationSlug = path.match(/^\/animations\/\d+\/(.+)$/)?.[1];
+    const animationSlug = path.match(/^\/animations\/\d+\/(.+)$/)?.[1]
 
     if (animationSlug) {
       const animationName = animationSlug
         .replace(/-/g, ' ')
-        .replace(/\b\w/g, (c) => c.toUpperCase());
+        .replace(/\b\w/g, c => c.toUpperCase())
 
-      details = 'Editing animation';
-      state = animationName;
+      details = 'Editing animation'
+      state = animationName
     }
   }
 
@@ -41,5 +36,5 @@ presence.on('UpdateData', async () => {
     state,
     startTimestamp: browsingTimestamp,
     largeImageKey: 'https://i.imgur.com/fv1VJQR.png',
-  });
-});
+  })
+})

--- a/websites/C/ccLeaf/presence.ts
+++ b/websites/C/ccLeaf/presence.ts
@@ -1,37 +1,38 @@
 const presence = new Presence({
   clientId: '1498049243368390736',
-})
+});
 
-const browsingTimestamp = Math.floor(Date.now() / 1000)
+const browsingTimestamp = Math.floor(Date.now() / 1000);
 
 presence.on('UpdateData', async () => {
-  const path = document.location.pathname
+  const path = document.location.pathname;
 
-  let details = 'Using ccLeaf'
-  let state = 'In the app'
+  let details = 'Using ccLeaf';
+  let state = 'In the app';
 
   // Homepage
   if (path === '/') {
-    details = 'Viewing homepage'
-    state = 'Exploring ccLeaf'
+    details = 'Viewing homepage';
+    state = 'Exploring ccLeaf';
   }
 
   // Animations list
   else if (path === '/animations') {
-    details = 'Browsing animations'
-    state = 'Selecting a template'
+    details = 'Browsing animations';
+    state = 'Selecting a template';
   }
 
   // Editor page
   else if (/^\/animations\/\d+\/.+/.test(path)) {
-    const animationSlug = path.match(/^\/animations\/\d+\/(.+)$/)?.[1]
+    const animationSlug = path.match(/^\/animations\/\d+\/(.+)$/)?.[1];
 
     if (animationSlug) {
       const animationName = animationSlug
-  .replace(/-/g, ' ')
-  .replace(/\b\w/g, (c) => c.toUpperCase())
-      details = 'Editing animation'
-      state = animationName
+        .replace(/-/g, ' ')
+        .replace(/\b\w/g, (c) => c.toUpperCase());
+
+      details = 'Editing animation';
+      state = animationName;
     }
   }
 
@@ -40,5 +41,5 @@ presence.on('UpdateData', async () => {
     state,
     startTimestamp: browsingTimestamp,
     largeImageKey: 'https://i.imgur.com/fv1VJQR.png',
-  })
-})
+  });
+});

--- a/websites/C/ccLeaf/presence.ts
+++ b/websites/C/ccLeaf/presence.ts
@@ -1,0 +1,28 @@
+const presence = new Presence({
+  clientId: '1498049243368390736',
+})
+
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+presence.on('UpdateData', async () => {
+  const path = document.location.pathname
+
+  let details = 'Using ccLeaf'
+  let state = 'In the app'
+
+  if (path === '/animations') {
+    details = 'Browsing animations'
+    state = 'Looking for templates'
+  }
+  else if (/^\/animations\/\d+\/.+/.test(path)) {
+    details = 'In the editor'
+    state = 'Editing an animation'
+  }
+
+  presence.setActivity({
+    details,
+    state,
+    startTimestamp: browsingTimestamp,
+    largeImageKey: 'ccleaf',
+  })
+})

--- a/websites/C/ccLeaf/presence.ts
+++ b/websites/C/ccLeaf/presence.ts
@@ -10,19 +10,35 @@ presence.on('UpdateData', async () => {
   let details = 'Using ccLeaf'
   let state = 'In the app'
 
-  if (path === '/animations') {
-    details = 'Browsing animations'
-    state = 'Looking for templates'
+  // Homepage
+  if (path === '/') {
+    details = 'Viewing homepage'
+    state = 'Exploring ccLeaf'
   }
+
+  // Animations list
+  else if (path === '/animations') {
+    details = 'Browsing animations'
+    state = 'Selecting a template'
+  }
+
+  // Editor page
   else if (/^\/animations\/\d+\/.+/.test(path)) {
-    details = 'In the editor'
-    state = 'Editing an animation'
+    const animationSlug = path.match(/^\/animations\/\d+\/(.+)$/)?.[1]
+
+    if (animationSlug) {
+      const animationName = animationSlug
+  .replace(/-/g, ' ')
+  .replace(/\b\w/g, (c) => c.toUpperCase())
+      details = 'Editing animation'
+      state = animationName
+    }
   }
 
   presence.setActivity({
     details,
     state,
     startTimestamp: browsingTimestamp,
-    largeImageKey: 'ccleaf',
+    largeImageKey: 'https://i.imgur.com/fv1VJQR.png',
   })
 })


### PR DESCRIPTION
## Description

Adds Discord Rich Presence support for ccLeaf.

When a user is on ccLeaf, Discord will display:
- Browsing animations (on the animations page)
- Editing an animation (inside the editor)
- Viewing Homepage (In the app)

The presence updates dynamically based on the current page.

## Acknowledgements

- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)  
- [x] I linted the code by running `npm run lint`  
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)  

## Screenshots

<details>
<summary>Proof showing the creation/modification is working as expected</summary>

![Browsing animations](https://i.imgur.com/H5jFqvr.png)

![Editing an animation](https://i.imgur.com/sG66rkE.png)

![In the app](https://i.imgur.com/QHRO2K1.png)


</details>