### PR TITLE
feat(SakuraMangas): add activity

### DIFF
--- a/websites/S/Sakura Mangas/metadata.json
+++ b/websites/S/Sakura Mangas/metadata.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "id": "458776046184169473",
+    "name": "Luscarvalho"
+  },
+  "service": "Sakura Mangas",
+  "description": {
+    "en": "Read manga online on Sakura Mangas",
+    "pt-br": "Leia mangás online no Sakura Mangas"
+  },
+  "url": ["www.sakuramangas.org", "sakuramangas.org"],
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*sakuramangas[.]org[/]",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/8EhCZKg.png",
+  "thumbnail": "https://i.imgur.com/BPYoKf7.png",
+  "color": "#ea6db5",
+  "category": "anime",
+  "tags": [
+    "manga"
+  ],
+  "settings": [
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "icon": "fas fa-user-secret",
+      "value": false
+    },
+    {
+      "id": "showButtons",
+      "title": "Show buttons",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "privacy": false
+      }
+    },
+    {
+      "id": "showCover",
+      "title": "Show Cover",
+      "icon": "fas fa-images",
+      "value": true,
+      "if": {
+        "privacy": false
+      }
+    }
+  ]
+}

--- a/websites/S/Sakura Mangas/presence.ts
+++ b/websites/S/Sakura Mangas/presence.ts
@@ -8,12 +8,14 @@ enum ActivityAssets {
 }
 
 // Fetches an image and converts it to a base64 data URL, with caching.
+// Uses sessionStorage so the cache persists across page navigations.
 // Needed because the server requires JavaScript to serve images,
 // so Discord can't fetch them directly via URL.
-const dataUrlCache = new Map<string, string | null>()
+const DATA_URL_PREFIX = 'pmd_dataurl_'
 async function toDataUrl(url: string): Promise<string | null> {
-  if (dataUrlCache.has(url))
-    return dataUrlCache.get(url)!
+  const cached = sessionStorage.getItem(`${DATA_URL_PREFIX}${url}`)
+  if (cached !== null)
+    return cached || null
   try {
     const blob = await fetch(url).then(r => r.blob())
     const result = await new Promise<string | null>((resolve) => {
@@ -21,11 +23,11 @@ async function toDataUrl(url: string): Promise<string | null> {
       reader.onloadend = () => resolve(reader.result as string)
       reader.readAsDataURL(blob)
     })
-    dataUrlCache.set(url, result)
+    sessionStorage.setItem(`${DATA_URL_PREFIX}${url}`, result ?? '')
     return result
   }
   catch {
-    dataUrlCache.set(url, null)
+    sessionStorage.setItem(`${DATA_URL_PREFIX}${url}`, '')
     return null
   }
 }

--- a/websites/S/Sakura Mangas/presence.ts
+++ b/websites/S/Sakura Mangas/presence.ts
@@ -3,7 +3,7 @@ const presence = new Presence({
 })
 const browsingTimestamp = Math.floor(Date.now() / 1000)
 
-enum ActivityAssets { // Other default assets can be found at index.d.ts
+enum ActivityAssets {
   Logo = 'https://i.imgur.com/8EhCZKg.png',
 }
 
@@ -38,7 +38,6 @@ presence.on('UpdateData', async () => {
   const presenceData: PresenceData = {
     largeImageKey: ActivityAssets.Logo,
     startTimestamp: browsingTimestamp,
-    // smallImageKey: Assets.Play,
   }
 
   const { href, pathname } = document.location

--- a/websites/S/Sakura Mangas/presence.ts
+++ b/websites/S/Sakura Mangas/presence.ts
@@ -1,0 +1,121 @@
+const presence = new Presence({
+  clientId: '1497792741130768546',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets { // Other default assets can be found at index.d.ts
+  Logo = 'https://i.imgur.com/8EhCZKg.png',
+}
+
+// Fetches an image and converts it to a base64 data URL.
+// Needed because the server requires JavaScript to serve images,
+// so Discord can't fetch them directly via URL.
+async function toDataUrl(url: string): Promise<string | null> {
+  try {
+    const blob = await fetch(url).then(r => r.blob())
+    return await new Promise((resolve) => {
+      const reader = new FileReader()
+      reader.onloadend = () => resolve(reader.result as string)
+      reader.readAsDataURL(blob)
+    })
+  }
+  catch {
+    return null
+  }
+}
+
+presence.on('UpdateData', async () => {
+  const [
+    privacy,
+    showButtons,
+    showCover,
+  ] = await Promise.all([
+    presence.getSetting<boolean>('privacy'),
+    presence.getSetting<boolean>('showButtons'),
+    presence.getSetting<boolean>('showCover'),
+  ])
+
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+    // smallImageKey: Assets.Play,
+  }
+
+  const { href, pathname } = document.location
+  const [, section, slug, subSlug] = pathname.split('/')
+
+  if (privacy) {
+    presenceData.details = 'Navegando no site'
+    presence.setActivity(presenceData)
+    return
+  }
+
+  switch (section) {
+    case 'login':
+      presenceData.details = 'Fazendo login'
+      break
+
+    case 'obras': {
+      if (subSlug) {
+        const mangaUrl = `${document.location.origin}/obras/${slug}/`
+        if (showCover) {
+          const coverUrl = await toDataUrl(`${mangaUrl}thumb_256.jpg`)
+          if (coverUrl)
+            presenceData.largeImageKey = coverUrl
+        }
+        presenceData.details = document.querySelector('.reader-manga-title')?.textContent
+        presenceData.state = `Capítulo ${subSlug.replaceAll('-', '.')}`
+        if (showButtons) {
+          presenceData.buttons = [
+            { label: 'Ler capítulo', url: href },
+            { label: 'Ver mangá', url: mangaUrl },
+          ]
+        }
+      }
+      else if (slug) {
+        if (showCover) {
+          const cover = document.querySelector<HTMLImageElement>('.img-fluid.capa')
+          if (cover?.src) {
+            const coverUrl = await toDataUrl(cover.src)
+            if (coverUrl)
+              presenceData.largeImageKey = coverUrl
+          }
+        }
+        presenceData.details = document.querySelector('.h1-titulo')?.textContent
+        if (showButtons) {
+          presenceData.buttons = [{ label: 'Ler mangá', url: href }]
+        }
+      }
+      else {
+        presenceData.details = 'Explorando o catálogo'
+      }
+      break
+    }
+
+    case 'feed': {
+      const userName = document.querySelector('#header-username')?.textContent
+      presenceData.details = `Perfil: ${userName}`
+      presenceData.state = document.querySelector('button.nav-link.active')?.textContent
+      break
+    }
+
+    case 'scans': {
+      if (slug) {
+        presenceData.details = document.querySelector('#scan-nome')?.textContent
+        if (showButtons) {
+          presenceData.buttons = [{ label: 'Ver scan', url: href }]
+        }
+      }
+      else {
+        presenceData.details = 'Explorando as scans'
+      }
+      break
+    }
+
+    default: {
+      presenceData.details = 'Na página inicial'
+      break
+    }
+  }
+  presence.setActivity(presenceData)
+})

--- a/websites/S/Sakura Mangas/presence.ts
+++ b/websites/S/Sakura Mangas/presence.ts
@@ -7,19 +7,25 @@ enum ActivityAssets {
   Logo = 'https://i.imgur.com/8EhCZKg.png',
 }
 
-// Fetches an image and converts it to a base64 data URL.
+// Fetches an image and converts it to a base64 data URL, with caching.
 // Needed because the server requires JavaScript to serve images,
 // so Discord can't fetch them directly via URL.
+const dataUrlCache = new Map<string, string | null>()
 async function toDataUrl(url: string): Promise<string | null> {
+  if (dataUrlCache.has(url))
+    return dataUrlCache.get(url)!
   try {
     const blob = await fetch(url).then(r => r.blob())
-    return await new Promise((resolve) => {
+    const result = await new Promise<string | null>((resolve) => {
       const reader = new FileReader()
       reader.onloadend = () => resolve(reader.result as string)
       reader.readAsDataURL(blob)
     })
+    dataUrlCache.set(url, result)
+    return result
   }
   catch {
+    dataUrlCache.set(url, null)
     return null
   }
 }


### PR DESCRIPTION
## Description
When a user is on Sakura Mangas, Discord will display:

- Viewing the catalog (on the obras page)
- Reading a manga (on a manga page, with cover art)
- Reading a chapter (with chapter number and manga title)
- Viewing their profile (on the feed page)
- Exploring scans (on the scans page)

The presence updates dynamically based on the current page. Covers are fetched as base64 data URLs since the server requires JavaScript to serve images. Includes privacy mode, button toggle, and cover toggle settings.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
Home Page
<img width="321" height="120" alt="Captura de Tela 2026-04-26 às 19 25 23" src="https://github.com/user-attachments/assets/e45eb5b0-8fb2-401b-a552-051dc7bbccfc" />
Manga Page
<img width="317" height="161" alt="Captura de Tela 2026-04-26 às 19 26 09" src="https://github.com/user-attachments/assets/2cbf06d9-d733-418d-8055-398b1cd1c3a6" />
Chapter Page
<img width="324" height="199" alt="Captura de Tela 2026-04-26 às 19 26 35" src="https://github.com/user-attachments/assets/4a3d7d3c-449c-4288-aa3b-c5bfa5910ab6" />
Privacy Mode
<img width="314" height="110" alt="image" src="https://github.com/user-attachments/assets/8add0854-d0c2-4d67-b611-22269681bcc7" />
Disable Cover and Buttons
<img width="314" height="130" alt="image" src="https://github.com/user-attachments/assets/28efd4fa-49d2-41e7-a645-6b3645be6d22" />

</details>
