### PR TITLE
feat(USACO Guide): add activity

### DIFF
--- a/websites/U/USACO Guide/metadata.json
+++ b/websites/U/USACO Guide/metadata.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "id": "441580459663818752",
+    "name": "masonmxllen"
+  },
+  "service": "USACO Guide",
+  "description": {
+    "en": "The USACO Guide provides a comprehensive, organized roadmap carefully designed and crafted for USACO contestants – available to everyone, for free."
+  },
+  "url": "usaco.guide",
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*usaco[.]guide[/]",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/j5URmRB.png",
+  "thumbnail": "https://i.imgur.com/cxOe02L.jpeg",
+  "color": "#1e90ff",
+  "category": "other",
+  "tags": [
+    "education",
+    "coding",
+    "competition",
+    "usaco"
+  ]
+}

--- a/websites/U/USACO Guide/metadata.json
+++ b/websites/U/USACO Guide/metadata.json
@@ -12,7 +12,7 @@
   "url": "usaco.guide",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*usaco[.]guide[/]",
   "version": "1.0.0",
-  "logo": "https://i.imgur.com/j5URmRB.png",
+  "logo": "https://i.imgur.com/oRapkfu.png",
   "thumbnail": "https://i.imgur.com/cxOe02L.jpeg",
   "color": "#1e90ff",
   "category": "other",

--- a/websites/U/USACO Guide/presence.ts
+++ b/websites/U/USACO Guide/presence.ts
@@ -4,7 +4,7 @@ const presence = new Presence({
 const browsingTimestamp = Math.floor(Date.now() / 1000) // Show elapsed time
 
 enum ActivityAssets {
-  Logo = 'https://forum.usaco.guide/uploads/default/original/1X/047f2df686adefc647703910bb5be85e7cce48e6.png',
+  Logo = 'https://i.imgur.com/oRapkfu.png',
 }
 
 presence.on('UpdateData', async () => {

--- a/websites/U/USACO Guide/presence.ts
+++ b/websites/U/USACO Guide/presence.ts
@@ -1,0 +1,81 @@
+const presence = new Presence({
+  clientId: '1498741548865552614',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000) // Show elapsed time
+
+enum ActivityAssets {
+  Logo = 'https://forum.usaco.guide/uploads/default/original/1X/047f2df686adefc647703910bb5be85e7cce48e6.png',
+}
+
+presence.on('UpdateData', async () => {
+  const { pathname, hostname } = document.location
+
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+  }
+
+  let title = document.title.split(' · ')[0]?.split(' | ')[0]?.trim() || ''
+  if (title.toLowerCase().endsWith(' - solution')) {
+    title = title.substring(0, title.length - 11).trim()
+  }
+  else if (title.toLowerCase().endsWith(' - editorial')) {
+    title = title.substring(0, title.length - 12).trim()
+  }
+
+  if (hostname === 'ide.usaco.guide') {
+    presenceData.details = 'Using IDE'
+    presenceData.state = title === 'USACO IDE' || !title ? 'Coding' : title
+  }
+  else if (hostname === 'forum.usaco.guide') {
+    presenceData.details = 'Browsing Forum'
+    presenceData.state = title === 'USACO Forum' || !title ? 'Homepage' : title
+  }
+  else {
+    const pathParts = pathname.split('/').filter(Boolean)
+    const section = pathParts[0]
+
+    const sections: Record<string, string> = {
+      general: 'General section',
+      bronze: 'Bronze section',
+      silver: 'Silver section',
+      gold: 'Gold section',
+      plat: 'Platinum section',
+      adv: 'Advanced section',
+      problems: 'Problems',
+      groups: 'Groups',
+      editor: 'Editor',
+      settings: 'Settings',
+    }
+
+    if (!section || pathname === '/') {
+      presenceData.details = 'Browsing USACO Guide'
+      presenceData.state = 'Homepage'
+    }
+    else if (section === 'problems' && pathParts[1]) {
+      let problemName = pathParts[1]
+
+      problemName = problemName.replace(/^(?:usaco|cf|cses|ac|spoj|kattis|poi|joi|joic|boi|ceoi|ioi|apio|coci|ys|infoarena|balkan|szkopul)(?:-[a-z0-9]+)?-/i, '')
+
+      problemName = problemName.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')
+
+      if (pathParts.includes('solution')) {
+        presenceData.details = 'Viewing Solution'
+      }
+      else {
+        presenceData.details = 'Solving Problem'
+      }
+      presenceData.state = title === 'USACO Guide' || !title ? problemName : title
+    }
+    else if (section && sections[section]) {
+      presenceData.details = `Browsing ${sections[section]}`
+      presenceData.state = title === 'USACO Guide' || !title ? 'Exploring guides' : title
+    }
+    else {
+      presenceData.details = 'Browsing USACO Guide'
+      presenceData.state = title === 'USACO Guide' || !title ? 'Exploring guides' : title
+    }
+  }
+
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description
Adds presence for [USACO Guide](https://usaco.guide) - a comprehensive resource for competitive programming contestants.
- Supports USACO IDE
- Supports Guide Editor
- Supports USACO Forum
- Supports USACO Group

The presence updates dynamically depending on the module and the division the user is reading.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img width="279" height="134" alt="image" src="https://github.com/user-attachments/assets/9507cbf4-173d-4544-b2a4-9ebac8d9f0ad" />
<img width="267" height="120" alt="image" src="https://github.com/user-attachments/assets/56d1c6c5-d9c1-4701-9b17-d3ba06c81011" />
</details>
