### PR TITLE
fix(Udemy): fixing the document query retrieval

### DIFF
--- a/websites/U/Udemy/metadata.json
+++ b/websites/U/Udemy/metadata.json
@@ -19,7 +19,7 @@
   },
   "url": "www.udemy.com",
   "regExp": "^https?[:][/][/](www[.])?udemy[.]com[/]",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/U/Udemy/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/U/Udemy/assets/thumbnail.png",
   "color": "#a435f0",

--- a/websites/U/Udemy/metadata.json
+++ b/websites/U/Udemy/metadata.json
@@ -5,6 +5,12 @@
     "name": "EGGSY",
     "id": "162969778699501569"
   },
+  "contributors": [
+    {
+      "name": "rikunz",
+      "id": "430729478151602183"
+    }
+  ],
   "service": "Udemy",
   "description": {
     "en": " Udemy is an online learning and teaching marketplace with over 100000 courses and 24 million students.",

--- a/websites/U/Udemy/utils/helpers.ts
+++ b/websites/U/Udemy/utils/helpers.ts
@@ -4,10 +4,9 @@ export function getVideoInfo() {
   const video = document.querySelector('video')
   if (!video || video.readyState === 0)
     return null
-
-  const courseTitle = document.querySelector('h1[data-purpose=course-header-title] a')?.textContent || UNKNOWN_COURSE
+  const courseTitle = document.querySelector('h1[data-purpose=course-header-title] a')?.textContent || document.querySelector('#content-drawer-curriculum > div > div:nth-child(2) > a > h3')?.textContent || UNKNOWN_COURSE
   const currentLecture = document.querySelector('div[data-purpose="curriculum-item-viewer-content"] section')?.ariaLabel?.split(', ')?.[1]?.match(/\d+:\s*.+/)?.[0] || document.querySelector('li[class*=curriculum-item-link--is-current] span > span')
-    ?.textContent || UNKNOWN_LECTURE
+    ?.textContent || document.querySelector('div[data-testid="curriculum-navigation"] h2')?.textContent || UNKNOWN_LECTURE
 
   return {
     title: courseTitle,
@@ -20,9 +19,7 @@ export function getVideoInfo() {
 }
 
 export function getCourseInfo() {
-  return (
-    document.querySelector('h1[data-purpose="lead-title"]')?.textContent || UNKNOWN_COURSE
-  )
+  return document.querySelector('nav[aria-label="Course topics"]')?.parentElement?.querySelector('h1')?.textContent || UNKNOWN_COURSE
 }
 
 export function normalizePath(pathname: string) {


### PR DESCRIPTION
## Description
Update the udemy selector on document query

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img width="874" height="340" alt="image" src="https://github.com/user-attachments/assets/7c75cd2c-b80a-4dd2-ba3f-22aea12599db" />
<img width="890" height="316" alt="image" src="https://github.com/user-attachments/assets/912720a0-4572-4f2b-93c9-bc36fa77fdef" />






</details>
