### PR TITLE
feat: add Miruro

### DIFF
--- a/websites/M/Miruro/iframe.ts
+++ b/websites/M/Miruro/iframe.ts
@@ -1,0 +1,12 @@
+const iframe = new iFrame()
+
+iframe.on('UpdateData', async () => {
+  const video = document.querySelector<HTMLVideoElement>('video')
+  if (video && !Number.isNaN(video.duration)) {
+    iframe.send({
+      duration: video.duration,
+      currTime: video.currentTime,
+      paused: video.paused,
+    })
+  }
+})

--- a/websites/M/Miruro/metadata.json
+++ b/websites/M/Miruro/metadata.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "id": "401715907975577600",
+    "name": "UndoingTurtle"
+  },
+  "service": "Miruro",
+  "description": {
+    "en": "Miruro is a free anime website where millions visit to watch anime online."
+  },
+  "url": [
+    "miruro.tv",
+    "miruro.to",
+    "miruro.bz",
+    "miruro.ru"
+  ],
+  "regExp": "^https?[:][/][/](www[.])?miruro[.](tv|to|bz|ru)[/]",
+  "version": "1.0.0",
+  "logo": "https://i.postimg.cc/N0ZsxZxb/favicon-V2.png",
+  "thumbnail": "https://i.postimg.cc/N0ZsxZxb/favicon-V2.png",
+  "color": "#1a1a1a",
+  "category": "anime",
+  "tags": ["anime", "streaming"],
+  "iframe": true,
+  "iFrameRegExp": "kwik[.](cx|si)|ok[.]ru|megaplay[.]buzz",
+  "settings": [
+    {
+      "id": "usePresenceName",
+      "title": "Show Title as Presence",
+      "icon": "fad fa-user-edit",
+      "value": true
+    }
+  ]
+}

--- a/websites/M/Miruro/presence.ts
+++ b/websites/M/Miruro/presence.ts
@@ -1,0 +1,120 @@
+import { ActivityType, Assets, getTimestamps } from 'premid'
+
+const presence = new Presence({
+  clientId: '1498739119990378626', 
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+
+let iframeData: { currTime: number; duration: number; paused: boolean } | null = null
+
+
+presence.on('iFrameData', (data: any) => {
+  iframeData = data
+})
+
+enum ActivityAssets {
+  Logo = 'https://i.postimg.cc/N0ZsxZxb/favicon-V2.png',
+}
+
+presence.on('UpdateData', async () => {
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+    type: ActivityType.Watching,
+  }
+  
+  const usePresenceName = await presence.getSetting<boolean>('usePresenceName')
+  const { href, pathname, search } = document.location
+  
+  switch (true) {
+    case pathname === '/':
+    case pathname === '/home':
+      presenceData.details = 'Viewing Homepage'
+      break
+    case pathname === '/search':
+      presenceData.details = `Viewing results: ${search.split('=')[1]?.replace(/\+/g, ' ')}`
+      break
+    case pathname.includes('/watch'): {
+      
+      const rawTitle = document.title
+        .replace(/^Watch\s/i, '') 
+        .replace(/\s*[·\-]\s*Miruro.*$/i, '') 
+      const title = rawTitle ? rawTitle.trim() : 'Watching Anime'
+
+      const coverArt = 
+        document.querySelector<HTMLImageElement>('img[class*="coverImg"]')?.src ||
+        document.querySelector<HTMLImageElement>('img[class*="poster"]')?.src ||
+        document.querySelector<HTMLImageElement>('img[src*="anilist"]')?.src
+
+      const urlParams = new URLSearchParams(window.location.search)
+      const episodeNumber = urlParams.get('ep') || urlParams.get('episode')
+
+      let episodeName = document.querySelector('.ep-title')?.textContent
+      if (episodeName) {
+        episodeName = episodeName.replace(/^(EP\s*\d+|Episode\s*\d+|\d+)\s*[·•\-.:|]?\s*/i, '').trim()
+      }
+
+      if (usePresenceName) {
+        presenceData.name = title
+        presenceData.details = episodeNumber ? `Episode ${episodeNumber}` : 'Watching'
+        presenceData.state = episodeName || 'Enjoying the anime'
+      }
+      else {
+        presenceData.details = title
+        presenceData.state = episodeNumber 
+          ? (episodeName ? `Ep ${episodeNumber}: ${episodeName}` : `Episode ${episodeNumber}`) 
+          : (episodeName || 'Enjoying the anime')
+      }
+      
+      presenceData.largeImageKey = coverArt ?? ActivityAssets.Logo
+      presenceData.buttons = [
+        {
+          label: 'View Anime',
+          url: href,
+        },
+      ]
+
+    
+      const localVideo = document.querySelector<HTMLVideoElement>('video')
+
+     
+      if (iframeData) {
+        if (!iframeData.paused) {
+          const timestamps = getTimestamps(iframeData.currTime, iframeData.duration)
+          presenceData.startTimestamp = timestamps[0]
+          presenceData.endTimestamp = timestamps[1]
+          presenceData.smallImageKey = Assets.Play
+          presenceData.smallImageText = 'Playing on Embed'
+        } else {
+          delete presenceData.startTimestamp
+          delete presenceData.endTimestamp
+          presenceData.smallImageKey = Assets.Pause
+          presenceData.smallImageText = 'Paused'
+        }
+      } 
+     
+      else if (localVideo) {
+        if (!localVideo.paused && !Number.isNaN(localVideo.duration)) {
+          const timestamps = getTimestamps(localVideo.currentTime, localVideo.duration)
+          presenceData.startTimestamp = timestamps[0]
+          presenceData.endTimestamp = timestamps[1]
+          presenceData.smallImageKey = Assets.Play
+          presenceData.smallImageText = 'Playing'
+        } else {
+          delete presenceData.startTimestamp
+          delete presenceData.endTimestamp
+          presenceData.smallImageKey = Assets.Pause
+          presenceData.smallImageText = 'Paused'
+        }
+      }
+      
+      break
+    }
+    default:
+      presenceData.details = 'Browsing Miruro...'
+      break
+  }
+  
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description
Added full rich presence support for Miruro.tv. Includes dynamic episode tracking, native video player progress bar math, and an iframe spy script for embedded Kwik and MegaPlay servers. Also added regex support for the .to, .bz, and .ru mirror domains.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
Browsing
<img width="267" height="103" alt="1ScBF5Ld9u" src="https://github.com/user-attachments/assets/a91dd495-1ede-438c-adeb-ea4babe40ddc" />
Playing
<img width="270" height="100" alt="K9Ykdbk5Rm" src="https://github.com/user-attachments/assets/f29351ce-ff56-4a8a-88ec-7e3dbd0d8e3a" />

</details>
