### PR TITLE
fix(Jellyfin): handle non-public URLs for Discord thumbnails

### DIFF
--- a/websites/J/Jellyfin/metadata.json
+++ b/websites/J/Jellyfin/metadata.json
@@ -18,7 +18,7 @@
   },
   "url": "jellyfin.org",
   "regExp": "^https?[:][/][/](jellyfin[.]org|.*[/]web[/](index[.]html)?#)[/]",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/J/Jellyfin/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/J/Jellyfin/assets/thumbnail.png",
   "color": "#00698c",
@@ -47,6 +47,15 @@
       "title": "Show thumbnails",
       "icon": "fad fa-image",
       "value": true
+    },
+    {
+      "id": "localImageExtraction",
+      "title": "Force local image extraction",
+      "icon": "fad fa-download",
+      "value": false,
+      "if": {
+        "showThumbnails": true
+      }
     }
   ],
   "allowURLOverrides": true

--- a/websites/J/Jellyfin/presence.ts
+++ b/websites/J/Jellyfin/presence.ts
@@ -871,7 +871,8 @@ async function updateData(): Promise<void> {
   // if jellyfin is detected init/update the presence status
   if (showPresence) {
     const largeImageKey = presenceData.largeImageKey as string
-    if (isPrivateIP(largeImageKey)) {
+    const forceLocalExtraction = await presence.getSetting<boolean>('localImageExtraction')
+    if (isNonPublicURL(largeImageKey) || forceLocalExtraction) {
       if (uploadedMediaCache.has(largeImageKey)) {
         presenceData.largeImageKey = uploadedMediaCache.get(largeImageKey)
       }
@@ -896,10 +897,16 @@ async function updateData(): Promise<void> {
   }
 }
 
-function isPrivateIP(ip: string): boolean {
-  return /^http:\/\/(?:192\.168\.|10\.|172\.(?:1[6-9]|2\d|3[01])\.|127\.0\.0\.1|localhost)/.test(
-    ip,
-  )
+function isNonPublicURL(url: string): boolean {
+  // Match RFC 1918 private IPs, CGNAT (100.64.0.0/10, used by Tailscale), and localhost (http or https)
+  if (/^https?:\/\/(?:192\.168\.|10\.|172\.(?:1[6-9]|2\d|3[01])\.|100\.(?:6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.|127\.0\.0\.1|localhost)/.test(url))
+    return true
+
+  // Match Tailscale domains (*.ts.net)
+  if (/^https?:\/\/[^/]+\.ts\.net(?:\/|:|$)/.test(url))
+    return true
+
+  return false
 }
 /**
  * Check if the presence should be initialized, if so start doing the magic


### PR DESCRIPTION
## Description
The `isPrivateIP` function only matched RFC 1918 private IP addresses over plain `http://`. Users accessing Jellyfin through non-standard private networks (e.g. Tailscale) had their thumbnail image URLs passed directly to Discord, which cannot access these private networks — resulting in the fallback lucky block image being shown instead.
### Changes
- **Renamed `isPrivateIP` → `isNonPublicURL`** and expanded detection to cover:
  - HTTPS in addition to HTTP for all private IP ranges
  - CGNAT range `100.64.0.0/10` (non-publicly-routable, also used by Tailscale for device IPs)
  - Tailscale domains (`*.ts.net`)
- **Added a new setting: "Force local image extraction"** — a manual toggle (off by default, only visible when "Show thumbnails" is enabled) that forces all thumbnail images to be fetched locally and converted to base64 data URLs, as a fallback for any network setup not automatically detected
- **Bumped version** from `1.10.3` → `1.10.4`
## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)
## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="534" height="230" alt="1778374895656437367" src="https://github.com/user-attachments/assets/bedf4d48-52c1-4355-b0b8-835cdf8ce523" />
<img width="1350" height="1287" alt="1778374902709124206" src="https://github.com/user-attachments/assets/307db360-3bf3-4489-a485-7671d4a4f48a" />

</details>