### PR TITLE
feat(BBN): add presence

### DIFF
--- a/websites/B/BBN/metadata.json
+++ b/websites/B/BBN/metadata.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "name": "venus999999",
+    "id": "1228414171020787823"
+  },
+  "service": "BBN",
+  "description": {
+    "en": "BBN — Twitch streamer & TikTok creator. Mauritius × Paris.",
+    "fr": "BBN — Streamer Twitch & créateur TikTok. Maurice × Paris."
+  },
+  "url": "bbncorps.fr",
+  "regExp": "^https?[:][/][/](www[.])?bbncorps[.]fr[/]?",
+  "version": "1.0.0",
+  "logo": "https://bbncorps.fr/premid-logo.png",
+  "thumbnail": "https://bbncorps.fr/premid-thumbnail.png",
+  "color": "#D4AF37",
+  "category": "socials",
+  "tags": [
+    "bbn",
+    "bbn-zm",
+    "streamer",
+    "twitch",
+    "tiktok",
+    "mauritius",
+    "paris",
+    "gaming"
+  ]
+}

--- a/websites/B/BBN/metadata.json
+++ b/websites/B/BBN/metadata.json
@@ -18,13 +18,12 @@
   "color": "#D4AF37",
   "category": "socials",
   "tags": [
-    "bbn",
-    "bbn-zm",
     "streamer",
     "twitch",
     "tiktok",
     "mauritius",
     "paris",
-    "gaming"
+    "gaming",
+    "creator"
   ]
 }

--- a/websites/B/BBN/presence.ts
+++ b/websites/B/BBN/presence.ts
@@ -1,0 +1,68 @@
+import { ActivityType } from 'premid'
+
+const presence = new Presence({
+  clientId: '1503081269427437588',
+})
+
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+interface SectionState {
+  state: string
+  smallImageKey?: string
+  smallImageText?: string
+}
+
+const SECTIONS: Record<string, SectionState> = {
+  about: { state: 'Lit l\'histoire de BBN' },
+  universe: { state: 'Explore l\'univers BBN' },
+  malife: { state: 'Regarde les photos' },
+  setup: {
+    state: 'Découvre le setup PC',
+    smallImageKey: 'setup',
+    smallImageText: 'Ryzen 7 7800X3D · RX 9070 XT',
+  },
+  rediff: {
+    state: 'Regarde la dernière rediff',
+    smallImageKey: 'twitch',
+    smallImageText: 'Twitch',
+  },
+  socials: { state: 'Découvre les réseaux' },
+  contact: { state: 'Envoie un message' },
+}
+
+presence.on('UpdateData', () => {
+  const path = document.location.pathname
+  const hash = (document.location.hash || '').replace('#', '').toLowerCase()
+
+  const presenceData: PresenceData = {
+    type: ActivityType.Watching,
+    largeImageKey: 'bbn',
+    largeImageText: 'BBN — bbncorps.fr',
+    details: 'BBN · Streamer & Créateur',
+    state: 'Maurice × Paris',
+    startTimestamp: browsingTimestamp,
+    buttons: [
+      { label: 'Visiter le site', url: 'https://bbncorps.fr/' },
+      { label: 'Suivre sur Twitch', url: 'https://www.twitch.tv/bbn_zm/' },
+    ],
+  }
+
+  if (hash && SECTIONS[hash]) {
+    const section = SECTIONS[hash]
+    presenceData.state = section.state
+    if (section.smallImageKey) {
+      presenceData.smallImageKey = section.smallImageKey
+      presenceData.smallImageText = section.smallImageText
+    }
+  }
+
+  if (path === '/' || path === '') {
+    presence.setActivity(presenceData)
+  }
+  else {
+    presence.setActivity({
+      ...presenceData,
+      state: 'Sur le site',
+    })
+  }
+})


### PR DESCRIPTION
Adds Discord Rich Presence for BBN (bbncorps.fr) — Twitch streamer & TikTok creator from Mauritius based in Paris.

Activity:
- type: Watching ("Watching BBN")
- details: BBN · Streamer & Créateur
- state: Maurice × Paris (default), updates per URL hash for sections about / universe / malife / setup / rediff / socials / contact
- buttons: Visiter le site (https://bbncorps.fr) / Suivre sur Twitch (https://www.twitch.tv/bbn_zm)
- smallImageKey support for setup + rediff sections

## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
