### PR TITLE
feat(dアニメストア): add "Show Title" settings

### DIFF
--- a/websites/D/dアニメストア/metadata.json
+++ b/websites/D/dアニメストア/metadata.json
@@ -21,7 +21,7 @@
   },
   "url": "animestore.docomo.ne.jp",
   "regExp": "^https?[:][/][/]animestore[.]docomo[.]ne[.]jp[/]",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/D/d%E3%82%A2%E3%83%8B%E3%83%A1%E3%82%B9%E3%83%88%E3%82%A2/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/D/d%E3%82%A2%E3%83%8B%E3%83%A1%E3%82%B9%E3%83%88%E3%82%A2/assets/thumbnail.jpg",
   "color": "#ea552a",

--- a/websites/D/dアニメストア/metadata.json
+++ b/websites/D/dアニメストア/metadata.json
@@ -36,6 +36,12 @@
       "title": "Show Thumbnail",
       "icon": "fad fa-images",
       "value": true
+    },
+    {
+      "id": "showTitle",
+      "title": "Show Title",
+      "icon": "fas fa-tv",
+      "value": false
     }
   ]
 }

--- a/websites/D/dアニメストア/presence.ts
+++ b/websites/D/dアニメストア/presence.ts
@@ -53,7 +53,11 @@ presence.on('UpdateData', async () => {
       : (await strings).pause
 
     presenceData.type = ActivityType.Watching as any
-    presenceData.statusDisplayType = StatusDisplayType.Details
+
+    const isTitleEnabled = await presence.getSetting<boolean>('showTitle')
+    if (isTitleEnabled) {
+      presenceData.statusDisplayType = StatusDisplayType.Details
+    }
 
     if (isPlaying) {
       const [startTimestamp, endTimestamp] = getTimestampsFromMedia(video)


### PR DESCRIPTION
## Description
`Show Title` (default: `false`): Toggles whether the anime title is shown as the main status text on the Discord member list (`statusDisplayType: details`).

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<img width="331" height="243" alt="{9EDD270D-2F1A-4B65-8454-8C00A4B25C9B}" src="https://github.com/user-attachments/assets/bb6b479e-33cc-46b7-98ef-462dc6f820b0" />