### PR TITLE
feat: add Bourges Télévision presence

### DIFF
--- a/websites/B/Bourges Télévision/metadata.json
+++ b/websites/B/Bourges Télévision/metadata.json
@@ -11,7 +11,7 @@
     "fr": "Bourges Télévision est une chaîne de télévision locale couvrant l'actualité et la culture de Bourges et du Berry."
   },
   "url": "bourgestelevision.fr",
-  "regExp": "^https?://bourgestelevision\\.fr",
+  "regExp": "^https?[:][/][/]bourgestelevision[.]fr[/]",
   "version": "1.0.0",
   "logo": "https://i.ibb.co/yBY6V8RK/OAuth-Icon-512.png",
   "thumbnail": "https://bourgestelevision.fr/og-image.jpg",

--- a/websites/B/Bourges Télévision/metadata.json
+++ b/websites/B/Bourges Télévision/metadata.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "name": "!gatx",
+    "id": "199902444442877952"
+  },
+  "service": "Bourges Télévision",
+  "description": {
+    "en": "Bourges Télévision is a local television channel covering news and culture from Bourges and the Berry region in France.",
+    "fr": "Bourges Télévision est une chaîne de télévision locale couvrant l'actualité et la culture de Bourges et du Berry."
+  },
+  "url": "bourgestelevision.fr",
+  "regExp": "^https?://bourgestelevision\\.fr",
+  "version": "1.0.0",
+  "logo": "https://i.ibb.co/yBY6V8RK/OAuth-Icon-512.png",
+  "thumbnail": "https://bourgestelevision.fr/og-image.jpg",
+  "color": "#E63329",
+  "category": "videos",
+  "tags": [
+    "television",
+    "replay",
+    "france",
+    "news",
+    "local"
+  ],
+  "settings": [
+    {
+      "id": "buttons",
+      "title": "Show Buttons",
+      "icon": "fas fa-external-link-alt",
+      "value": true
+    }
+  ]
+}

--- a/websites/B/Bourges Télévision/presence.ts
+++ b/websites/B/Bourges Télévision/presence.ts
@@ -92,14 +92,15 @@ presence.on('UpdateData', async () => {
   }
   // Page : Direct
   else if (pathname.startsWith('/direct')) {
-    const isOffline = Array.from(document.querySelectorAll('h2')).some((el) =>
-      el.textContent?.includes('Nous ne diffusons pas')
+    const isOffline = Array.from(document.querySelectorAll('h2')).some(el =>
+      el.textContent?.includes('Nous ne diffusons pas'),
     )
 
     if (isOffline) {
       presenceData.details = (await strings).view
       presenceData.state = 'Direct (Hors ligne)'
-    } else {
+    }
+    else {
       presenceData.details = (await strings).watching
       presenceData.state = 'Le direct'
 

--- a/websites/B/Bourges Télévision/presence.ts
+++ b/websites/B/Bourges Télévision/presence.ts
@@ -1,0 +1,102 @@
+import { ActivityType, Assets, getTimestamps } from 'premid'
+
+const presence = new Presence({
+  clientId: '1503166751603556543',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+
+const strings = presence.getStrings({
+  browse: 'general.browsing',
+  viewHome: 'general.viewHome',
+  view: 'general.view',
+  watching: 'general.watching',
+  paused: 'general.paused',
+  buttonWatchVideo: 'general.buttonWatchVideo',
+  buttonViewShow: 'general.buttonViewShow',
+})
+
+presence.on('UpdateData', async () => {
+  const presenceData: PresenceData = {
+    largeImageKey: 'https://i.ibb.co/yBY6V8RK/OAuth-Icon-512.png',
+    type: ActivityType.Watching,
+    startTimestamp: browsingTimestamp,
+  }
+
+  const { href, pathname } = document.location
+  const showButtons = await presence.getSetting<boolean>('buttons')
+
+  // Page : Accueil
+  if (pathname === '/') {
+    presenceData.details = (await strings).viewHome
+    presenceData.state = 'bourgestelevision.fr'
+  }
+  // Page : Regard un replay en cours de lecture  /replay/watch/*
+  else if (pathname.startsWith('/replay/watch/')) {
+    const episodeTitle = document.querySelector<HTMLElement>(
+      'h1[data-v-24a19c48]',
+    )?.textContent?.trim()
+
+    presenceData.details = (await strings).watching
+    presenceData.state = episodeTitle ?? 'Un épisode en replay'
+    // Progression de lecture via l'élément vidéo
+    const video = document.querySelector('video')
+    const isPaused = video?.paused ?? false
+    const current = Math.floor(video?.currentTime ?? 0)
+    const duration = Math.floor(video?.duration ?? 0)
+
+    if (duration > 0) {
+      const [start, end] = getTimestamps(current, duration)
+      if (!isPaused) {
+        presenceData.startTimestamp = start
+        presenceData.endTimestamp = end
+      }
+      else {
+        delete presenceData.startTimestamp
+      }
+    }
+
+    presenceData.smallImageKey = isPaused ? Assets.Pause : Assets.Play
+    presenceData.smallImageText = isPaused
+      ? (await strings).paused
+      : (await strings).watching
+
+    presenceData.buttons = [
+      {
+        label: (await strings).buttonWatchVideo,
+        url: href,
+      },
+    ]
+  }
+  // Page : Collection / émission  /replay/collection/*
+  else if (pathname.startsWith('/replay/collection/')) {
+    const showTitle = document.querySelector<HTMLElement>(
+      'h1.text-4xl',
+    )?.textContent?.trim()
+
+    presenceData.details = (await strings).view
+    presenceData.state = showTitle ?? 'Une émission'
+
+    if (showButtons) {
+      presenceData.buttons = [
+        {
+          label: (await strings).buttonViewShow,
+          url: href,
+        },
+      ]
+    }
+  }
+  // Page : Tous les replays  /replay/*  (liste, recent, catégorie…)
+  else if (pathname.startsWith('/replay')) {
+    presenceData.details = (await strings).browse
+    presenceData.state = 'Catalogue Replay'
+  }
+  // Toute autre page (la-chaine, direct, programmation…)
+  else {
+    const pageTitle = document.querySelector('title')?.textContent?.trim()
+    presenceData.details = (await strings).view
+    presenceData.state = pageTitle ?? 'bourgestelevision.fr'
+  }
+
+  presence.setActivity(presenceData)
+})

--- a/websites/B/Bourges Télévision/presence.ts
+++ b/websites/B/Bourges Télévision/presence.ts
@@ -90,7 +90,39 @@ presence.on('UpdateData', async () => {
     presenceData.details = (await strings).browse
     presenceData.state = 'Catalogue Replay'
   }
-  // Toute autre page (la-chaine, direct, programmation…)
+  // Page : Direct
+  else if (pathname.startsWith('/direct')) {
+    const isOffline = Array.from(document.querySelectorAll('h2')).some((el) =>
+      el.textContent?.includes('Nous ne diffusons pas')
+    )
+
+    if (isOffline) {
+      presenceData.details = (await strings).view
+      presenceData.state = 'Direct (Hors ligne)'
+    } else {
+      presenceData.details = (await strings).watching
+      presenceData.state = 'Le direct'
+
+      const video = document.querySelector('video')
+      if (video) {
+        const isPaused = video.paused
+        presenceData.smallImageKey = isPaused ? Assets.Pause : Assets.Play
+        presenceData.smallImageText = isPaused
+          ? (await strings).paused
+          : (await strings).watching
+      }
+
+      if (showButtons) {
+        presenceData.buttons = [
+          {
+            label: (await strings).buttonWatchVideo,
+            url: href,
+          },
+        ]
+      }
+    }
+  }
+  // Toute autre page (la-chaine, programmation…)
   else {
     const pageTitle = document.querySelector('title')?.textContent?.trim()
     presenceData.details = (await strings).view

--- a/websites/B/Bourges Télévision/presence.ts
+++ b/websites/B/Bourges Télévision/presence.ts
@@ -5,7 +5,6 @@ const presence = new Presence({
 })
 const browsingTimestamp = Math.floor(Date.now() / 1000)
 
-
 const strings = presence.getStrings({
   browse: 'general.browsing',
   viewHome: 'general.viewHome',


### PR DESCRIPTION
## Description
Adds a new presence for [Bourges Télévision](https://bourgestelevision.fr/), a local television channel covering news and culture from Bourges and the Berry region in France.

### Pages supported
| URL | Behavior |
|---|---|
| `/` | Shows "Viewing home page" |
| `/replay/*` | Shows "Browsing..." + "Catalogue Replay" |
| `/replay/collection/*` | Shows the show name with a "View Show" button |
| `/replay/watch/*` | Shows episode title, playback progress, play/pause icon, "Watch Video" button |

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

<!-- Add at least 2 screenshots of your Discord status showing the presence working -->
<!-- Example: one on the home page, one while watching an episode with progress bar -->

</details>
<img width="1625" height="1101" alt="image" src="https://github.com/user-attachments/assets/86972410-8acf-495c-b625-a3a6d1467950" />
<img width="462" height="196" alt="image" src="https://github.com/user-attachments/assets/71b33f20-8e49-4bdc-a852-afccd338da81" />
