### PR TITLE
fix(Anime Nexus): query selector for video recognition

### DIFF
--- a/websites/A/Anime Nexus/metadata.json
+++ b/websites/A/Anime Nexus/metadata.json
@@ -11,7 +11,7 @@
   },
   "url": "anime.nexus",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*anime[.]nexus[/]",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/bSgz75K.png",
   "thumbnail": "https://i.imgur.com/lMeW3B0.png",
   "color": "#000000",

--- a/websites/A/Anime Nexus/presence.ts
+++ b/websites/A/Anime Nexus/presence.ts
@@ -55,7 +55,6 @@ presence.on('UpdateData', async () => {
     && !Number.isNaN(duration)
     && pathname.includes('/watch/')
   ) {
-    console.log("aa")
     const scripts = document.querySelectorAll('script[type="application/ld+json"]')
 
     presenceData.largeImageText = ANIME_NEXUS

--- a/websites/A/Anime Nexus/presence.ts
+++ b/websites/A/Anime Nexus/presence.ts
@@ -42,7 +42,7 @@ presence.on('UpdateData', async () => {
   ])
 
   let video = false
-  const player = document.querySelector<HTMLVideoElement>('div[data-media-provider] video')
+  const player = document.querySelector<HTMLVideoElement>('video')
   if (player !== null && !Number.isNaN(player.duration)) {
     video = true
     currentTime = player.currentTime
@@ -55,6 +55,7 @@ presence.on('UpdateData', async () => {
     && !Number.isNaN(duration)
     && pathname.includes('/watch/')
   ) {
+    console.log("aa")
     const scripts = document.querySelectorAll('script[type="application/ld+json"]')
 
     presenceData.largeImageText = ANIME_NEXUS


### PR DESCRIPTION
## Description
The website made changes to the video player and removed the data-id, which was previously attached to the video player. That caused the presence to be stuck in the "Browsing..." state instead of showing the anime the user is currently watching. I fixed this by just querying for the video tag itself. 

## Acknowledgements
- [X] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `npm run lint`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

<br />

> 🔗  https://anime.nexus/watch/019da4dd-88bf-73ac-9a38-b7a052cfcac3/episode-2-265149fc5fd8c23d4844

Before:

<img width="473" height="149" alt="image" src="https://github.com/user-attachments/assets/e02925a4-8e60-45b7-911d-1cd29b68cf95" />

<br />

After:

<img width="473" height="148" alt="image" src="https://github.com/user-attachments/assets/64caff50-417b-4e40-bce4-74c902cac948" />


</details>
