### PR TITLE
feat(OKISO): add okiso.net presence

### DIFF
--- a/websites/O/OKISO/metadata.json
+++ b/websites/O/OKISO/metadata.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "name": "OKISO",
+    "id": "274178934143451137"
+  },
+  "service": "OKISO",
+  "description": {
+    "en": "Shows what you're watching on okiso.net"
+  },
+  "url": [
+    "okiso.net",
+    "localhost"
+  ],
+  "regExp": ".*(okiso\\.net|localhost).*",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/LLE4SVZ.png",
+  "thumbnail": "https://i.imgur.com/LLE4SVZ.png",
+  "color": "#FF7EB3",
+  "category": "music",
+  "tags": [
+    "music",
+    "vtuber",
+    "streaming"
+  ]
+}

--- a/websites/O/OKISO/presence.ts
+++ b/websites/O/OKISO/presence.ts
@@ -11,15 +11,14 @@ enum ActivityAssets {
 presence.on('UpdateData', async () => {
 	const { pathname } = document.location
 
-	// @ts-ignore
-	const presenceData: PresenceData = {
+	const presenceData = {
 		largeImageKey: ActivityAssets.Logo,
 		largeImageText: 'okiso.net',
 		startTimestamp: browsingTimestamp,
 		buttons: [
 			{ label: 'Visit okiso.net', url: `https://okiso.net${pathname === '/' ? '' : pathname}` }
 		]
-	}
+	} as any
 
 	// ─── Home Page ───
 	if (pathname === '/') {

--- a/websites/O/OKISO/presence.ts
+++ b/websites/O/OKISO/presence.ts
@@ -11,15 +11,15 @@ enum ActivityAssets {
 presence.on('UpdateData', async () => {
 	const { pathname } = document.location
 
-	// Initialize basic presence
-	const presenceData = {
+	// @ts-ignore
+	const presenceData: PresenceData = {
 		largeImageKey: ActivityAssets.Logo,
 		largeImageText: 'okiso.net',
 		startTimestamp: browsingTimestamp,
 		buttons: [
 			{ label: 'Visit okiso.net', url: `https://okiso.net${pathname === '/' ? '' : pathname}` }
 		]
-	} as any
+	}
 
 	// ─── Home Page ───
 	if (pathname === '/') {
@@ -84,6 +84,22 @@ presence.on('UpdateData', async () => {
 	else {
 		presenceData.details = document.title || 'Browsing'
 		presenceData.state = 'okiso.net'
+	}
+
+	// ─── Global Music Player ───
+	const musicContainer = document.getElementById('spotify-embed-container-data')
+	const trackTitle = musicContainer?.getAttribute('data-premid-track-title')
+	
+	if (trackTitle) {
+		const artist = musicContainer?.getAttribute('data-premid-track-artist')
+		const paused = musicContainer?.getAttribute('data-premid-paused') === 'true'
+
+		// Override the main details if they are listening to music
+		presenceData.details = paused ? `Paused: ${trackTitle}` : `Listening to ${trackTitle}`
+		presenceData.state = `by ${artist || 'OKISO'}`
+		presenceData.smallImageKey = paused ? Assets.Pause : Assets.Play
+		presenceData.smallImageText = paused ? 'Paused' : 'Playing'
+		delete presenceData.startTimestamp // Remove browsing timestamp so it doesn't look like a long song
 	}
 
 	if (presenceData.details)

--- a/websites/O/OKISO/presence.ts
+++ b/websites/O/OKISO/presence.ts
@@ -1,0 +1,93 @@
+import { Presence, PresenceData, ActivityType, Assets, getTimestampsFromMedia } from 'premid'
+
+// Initialize without a custom clientId to use official PreMiD Application
+const presence = new Presence()
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+	Logo = 'logo',
+}
+
+presence.on('UpdateData', async () => {
+	const { pathname } = document.location
+
+	// Initialize basic presence
+	const presenceData = {
+		largeImageKey: ActivityAssets.Logo,
+		largeImageText: 'okiso.net',
+		startTimestamp: browsingTimestamp,
+		buttons: [
+			{ label: 'Visit okiso.net', url: `https://okiso.net${pathname === '/' ? '' : pathname}` }
+		]
+	} as any
+
+	// ─── Home Page ───
+	if (pathname === '/') {
+		// Check for Terms Modal
+		const termsModal = document.querySelector('[data-premid-modal="terms"]')
+		if (termsModal) {
+			presenceData.details = 'Reading Content Terms'
+			presenceData.state = 'Legal & Guidelines'
+		} else {
+			// Check for live broadcast
+			const isLive = document.querySelector('[data-premid-live="true"]')
+			if (isLive) {
+				presenceData.details = 'Watching Live Broadcast'
+				presenceData.state = '🔴 LIVE on Twitch'
+				presenceData.smallImageKey = Assets.Live
+				presenceData.smallImageText = 'Live'
+				delete presenceData.startTimestamp
+			} else {
+				// Check for video playback
+				const videoPlayer = document.querySelector('[data-premid-title]')
+				if (videoPlayer) {
+					const videoTitle = videoPlayer.getAttribute('data-premid-title')
+					const paused = videoPlayer.getAttribute('data-premid-paused') === 'true'
+
+					presenceData.details = videoTitle || 'Watching a Video'
+					presenceData.smallImageKey = paused ? Assets.Pause : Assets.Play
+					presenceData.smallImageText = paused ? 'Paused' : 'Playing'
+
+					if (!paused) {
+						const video = document.querySelector<HTMLVideoElement>('[data-premid-title] video')
+						if (video) {
+							[presenceData.startTimestamp, presenceData.endTimestamp] = getTimestampsFromMedia(video)
+						}
+					}
+
+					presenceData.state = paused ? '⏸ Paused' : '▶ Playing'
+				} else {
+					presenceData.details = 'Browsing'
+					presenceData.state = 'Home Page'
+				}
+			}
+		}
+	}
+	// ─── Discography (3D Gallery) ───
+	else if (pathname === '/releases') {
+		presenceData.details = 'Exploring the 3D Audio Archive'
+		presenceData.state = 'Interactive Discography'
+	}
+	// ─── Individual Release Page ───
+	else if (pathname.startsWith('/releases/')) {
+		const releaseEl = document.querySelector('[data-premid-release-title]')
+		const releaseTitle = releaseEl?.getAttribute('data-premid-release-title')
+		presenceData.details = 'Viewing Release'
+		presenceData.state = releaseTitle ? `🎵 ${releaseTitle}` : 'Release Page'
+	}
+	// ─── Upcoming Page ───
+	else if (pathname === '/upcoming') {
+		presenceData.details = 'Browsing'
+		presenceData.state = 'Upcoming Releases'
+	}
+	// ─── Fallback ───
+	else {
+		presenceData.details = document.title || 'Browsing'
+		presenceData.state = 'okiso.net'
+	}
+
+	if (presenceData.details)
+		presence.setActivity(presenceData)
+	else
+		presence.setActivity()
+})

--- a/websites/O/OKISO/tsconfig.json
+++ b/websites/O/OKISO/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist/"
+  }
+}


### PR DESCRIPTION
## Description
Adds the official PreMiD presence for okiso.net. Features active page tracking, video playback detection, twitch stream status, and dynamic global Spotify Music player tracking!

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

<!-- [USER_TODO]: Drag & drop or paste your side-by-side verification screenshots here before clicking "Ready for review"! -->

</details>