### PR TITLE
fix(cli/AssetsManager): use native FormData for latest got version

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -28,7 +28,6 @@
         "chokidar": "^5.0.0",
         "discord-rpc": "^4.0.1",
         "esbuild": "^0.28.0",
-        "form-data": "^4.0.5",
         "gitdiff-parser": "^0.3.1",
         "globby": "^16.2.0",
         "got": "^15.0.3",
@@ -1819,9 +1818,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1839,9 +1835,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1859,9 +1852,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1879,9 +1869,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1899,9 +1886,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1919,9 +1903,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3007,23 +2988,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3653,9 +3617,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3677,9 +3638,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3701,9 +3659,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3725,9 +3680,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/cli/package.json
+++ b/cli/package.json
@@ -33,7 +33,6 @@
     "chokidar": "^5.0.0",
     "discord-rpc": "^4.0.1",
     "esbuild": "^0.28.0",
-    "form-data": "^4.0.5",
     "gitdiff-parser": "^0.3.1",
     "globby": "^16.2.0",
     "got": "^15.0.3",

--- a/cli/src/classes/AssetsManager.test.ts
+++ b/cli/src/classes/AssetsManager.test.ts
@@ -1,7 +1,6 @@
 import type { ActivityMetadata } from './ActivityCompiler.js'
 import type { CdnAsset } from './AssetsManager.js'
 import { Blob, Buffer } from 'node:buffer'
-import { ReadStream } from 'node:fs'
 import { Readable } from 'node:stream'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AssetsManager, AssetType, MimeType } from './AssetsManager.js'

--- a/cli/src/classes/AssetsManager.test.ts
+++ b/cli/src/classes/AssetsManager.test.ts
@@ -1,6 +1,6 @@
 import type { ActivityMetadata } from './ActivityCompiler.js'
 import type { CdnAsset } from './AssetsManager.js'
-import { Buffer } from 'node:buffer'
+import { Blob, Buffer } from 'node:buffer'
 import { ReadStream } from 'node:fs'
 import { Readable } from 'node:stream'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -21,13 +21,11 @@ const mocks = vi.hoisted(() => ({
   ),
   sharp: vi.fn(),
 
-  formData: vi.fn().mockImplementation(function () {
-    const appendSpy = vi.fn()
-    this.append = appendSpy
-    this.getHeaders = vi.fn().mockReturnValue({ 'content-type': 'multipart/form-data' })
-    this.getBuffer = vi.fn().mockReturnValue(Buffer.from('mock-buffer'))
+  formData: vi.fn(class {
+    appendSpy = vi.fn()
+    append = this.appendSpy
     //* Track the last appended values for assertions
-    this._lastAppended = () => appendSpy.mock.calls[appendSpy.mock.calls.length - 1]
+    _lastAppended = () => this.appendSpy.mock.calls[this.appendSpy.mock.calls.length - 1]
   }),
 }))
 
@@ -49,12 +47,7 @@ vi.mock('node:fs/promises', () => ({
   writeFile: mocks.writeFile,
 }))
 
-vi.mock('form-data', () => {
-  return {
-    __esModule: true,
-    default: mocks.formData,
-  }
-})
+vi.stubGlobal('FormData', mocks.formData)
 
 const mockActivity: ActivityMetadata = {
   service: 'TestService',
@@ -66,6 +59,8 @@ const mockActivity: ActivityMetadata = {
     en: 'Test description',
   },
   tags: ['test', 'activity'],
+  url: '',
+  regExp: '',
 }
 
 describe('assetsManager', () => {
@@ -471,14 +466,21 @@ describe('assetsManager', () => {
       const formInstances = mocks.formData.mock.results
       expect(formInstances[0].value._lastAppended()).toEqual([
         'file',
-        expect.any(ReadStream),
-        { contentType: MimeType.PNG },
+        expect.any(Blob),
+        expect.any(String),
+      ])
+      expect(formInstances[0].value._lastAppended()[1].type).toEqual(MimeType.PNG)
+      expect(formInstances[0].value._lastAppended()).toEqual([
+        'file',
+        expect.any(Blob),
+        expect.any(String),
       ])
       expect(formInstances[1].value._lastAppended()).toEqual([
         'file',
-        expect.any(ReadStream),
-        { contentType: MimeType.JPG },
+        expect.any(Blob),
+        expect.any(String),
       ])
+      expect(formInstances[1].value._lastAppended()[1].type).toEqual(MimeType.JPG)
 
       //* Verify file content updates
       expect(mocks.writeFile).toHaveBeenCalledWith(

--- a/cli/src/classes/AssetsManager.ts
+++ b/cli/src/classes/AssetsManager.ts
@@ -1,12 +1,11 @@
 import type { ActivityMetadata } from './ActivityCompiler.js'
-import { createReadStream, createWriteStream } from 'node:fs'
+import { createWriteStream, openAsBlob } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { extname, join, resolve } from 'node:path'
 import process from 'node:process'
 import { pipeline } from 'node:stream/promises'
 import * as core from '@actions/core'
-import FormData from 'form-data'
 import { globby } from 'globby'
 import got from 'got'
 import { inc } from 'semver'
@@ -540,7 +539,8 @@ export class AssetsManager {
 
       await Promise.all(
         batch.map(async ([url, { url: newUrl, method }]) => {
-          const tempFile = join(tmpdir(), `premid-assetmanager-${Math.random().toString(36).substring(2, 15)}${this.getExtensionFromUrl(url)}`)
+          const tempFileName = `premid-assetmanager-${Math.random().toString(36).substring(2, 15)}${this.getExtensionFromUrl(url)}`
+          const tempFile = join(tmpdir(), tempFileName)
 
           core.info(`Uploading ${url} to ${newUrl}, method: ${method}`)
 
@@ -553,16 +553,16 @@ export class AssetsManager {
             },
           }), createWriteStream(tempFile))
 
-          const form = new FormData()
-          form.append('file', createReadStream(tempFile), {
-            contentType: this.getMimeTypeFromExtension(this.getExtensionFromUrl(url).slice(1)),
+          const data = await openAsBlob(tempFile, {
+            type: this.getMimeTypeFromExtension(this.getExtensionFromUrl(url).slice(1)),
           })
+          const form = new FormData()
+          form.append('file', data, tempFileName)
 
           await got(newUrl, {
             method,
             headers: {
               Authorization: process.env.CDN_TOKEN,
-              ...form.getHeaders(),
             },
             body: form,
             retry: {

--- a/websites/0-9/1Shows/metadata.json
+++ b/websites/0-9/1Shows/metadata.json
@@ -11,7 +11,7 @@
   },
   "url": "www.1shows.ru",
   "regExp": "^https?[:][/][/](www[.])?1shows[.]ru[/]",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/GhoM28H.png",
   "thumbnail": "https://i.imgur.com/HCpF6JV.png",
   "color": "#121212",

--- a/websites/A/AMLL TTML Tool/metadata.json
+++ b/websites/A/AMLL TTML Tool/metadata.json
@@ -15,7 +15,7 @@
     "verycool-ttml-tool-trust.vercel.app"
   ],
   "regExp": "^https?[:][/][/](amll-ttml-tool(-test[.]vercel[.]app|[.]stevexmh[.]net)|verycool-ttml-tool-trust[.]vercel[.]app)[/]",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/78zp1Xo.png",
   "thumbnail": "https://i.imgur.com/u1ojO04.png",
   "color": "#18a058",

--- a/websites/A/Anime Nexus/metadata.json
+++ b/websites/A/Anime Nexus/metadata.json
@@ -11,7 +11,7 @@
   },
   "url": "anime.nexus",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*anime[.]nexus[/]",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "logo": "https://i.imgur.com/bSgz75K.png",
   "thumbnail": "https://i.imgur.com/lMeW3B0.png",
   "color": "#000000",

--- a/websites/A/Asya Animeleri/metadata.json
+++ b/websites/A/Asya Animeleri/metadata.json
@@ -18,7 +18,7 @@
   },
   "url": "asyaanimeleri.top",
   "regExp": "^https?[:][/][/]asyaanimeleri[.]top[/]",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/4lU3x0V.png",
   "thumbnail": "https://i.imgur.com/3Y6rAAg.png",
   "color": "#e74c3c",

--- a/websites/B/Bourges Télévision/metadata.json
+++ b/websites/B/Bourges Télévision/metadata.json
@@ -12,7 +12,7 @@
   },
   "url": "bourgestelevision.fr",
   "regExp": "^https?[:][/][/]bourgestelevision[.]fr[/]",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.ibb.co/yBY6V8RK/OAuth-Icon-512.png",
   "thumbnail": "https://bourgestelevision.fr/og-image.jpg",
   "color": "#E63329",

--- a/websites/C/Comix/metadata.json
+++ b/websites/C/Comix/metadata.json
@@ -11,7 +11,7 @@
   },
   "url": "comix.to",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*comix[.]to[/]",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "logo": "https://raw.githubusercontent.com/sirschubert/assets/refs/heads/main/assets/communityIcon_p626ghkfd91g1.png",
   "thumbnail": "https://styles.redditmedia.com/t5_4vwp6n/styles/bannerBackgroundImage_iye1rp7mj91g1.png",
   "color": "#000000",

--- a/websites/C/ccLeaf/metadata.json
+++ b/websites/C/ccLeaf/metadata.json
@@ -11,7 +11,7 @@
   },
   "url": ["ccleaf.com", "app.ccleaf.com"],
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*ccleaf[.]com[/]",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/fv1VJQR.png",
   "thumbnail": "https://i.imgur.com/qhIVv23.png",
   "color": "#000000",

--- a/websites/D/Deokwave/metadata.json
+++ b/websites/D/Deokwave/metadata.json
@@ -12,7 +12,7 @@
   },
   "url": "deokwave.com",
   "regExp": "^https?[:][/][/](deokwave[.]com)[/]",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/SbmVetu.png",
   "thumbnail": "https://i.imgur.com/MoEBLvd.jpeg",
   "color": "#8b5cf6",

--- a/websites/F/FACEIT/metadata.json
+++ b/websites/F/FACEIT/metadata.json
@@ -12,7 +12,7 @@
   },
   "url": "faceit.com",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*faceit[.]com[/]",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/n5ielUx.png",
   "thumbnail": "https://i.imgur.com/b68sdF6.png",
   "color": "#FF5500",

--- a/websites/F/Faucet Crypto/metadata.json
+++ b/websites/F/Faucet Crypto/metadata.json
@@ -14,7 +14,7 @@
     "status.faucetcrypto.com"
   ],
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*faucetcrypto[.]com[/]",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/37tBbHi.jpeg",
   "thumbnail": "https://faucetcrypto.com/banner-widget.jpg",
   "color": "#50a2ff",

--- a/websites/F/Find A Grave/metadata.json
+++ b/websites/F/Find A Grave/metadata.json
@@ -11,7 +11,7 @@
   },
   "url": ["findagrave.com", "pt.findagrave.com", "es.findagrave.com", "fr.findagrave.com", "de.findagrave.com", "it.findagrave.com"],
   "regExp": "^https?:[/][/]([a-z0-9-]+[.])*findagrave[.]com[/]",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://raw.githubusercontent.com/ikeblo/Activities/a2edab809/websites/F/Find%20A%20Grave/logo.png",
   "thumbnail": "https://raw.githubusercontent.com/ikeblo/Activities/35cfa747a/websites/F/Find%20A%20Grave/thumbnail.png",
   "color": "#4a7c59",

--- a/websites/H/Hipobuy/metadata.json
+++ b/websites/H/Hipobuy/metadata.json
@@ -22,7 +22,7 @@
     "www.hipobuy.com"
   ],
   "regExp": "^https?[:][/][/](www[.])?hipobuy[.]com[/]?",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/pyXT0kP.png",
   "thumbnail": "https://i.imgur.com/yfEp1n3.png",
   "color": "#FF6600",

--- a/websites/P/Pawsy/metadata.json
+++ b/websites/P/Pawsy/metadata.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
   "author": {
     "id": "1117890204569718885",
     "name": "rapositosa"
@@ -10,7 +12,7 @@
   },
   "url": "pawsy.fun",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*pawsy[.]fun[/]",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "logo": "https://i.imgur.com/DZb1KAE.jpeg",
   "thumbnail": "https://i.imgur.com/YRnNFnj.png",
   "color": "#f4efeb",

--- a/websites/P/Pawsy/metadata.json
+++ b/websites/P/Pawsy/metadata.json
@@ -10,7 +10,7 @@
   },
   "url": "pawsy.fun",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*pawsy[.]fun[/]",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/DZb1KAE.jpeg",
   "thumbnail": "https://i.imgur.com/YRnNFnj.png",
   "color": "#f4efeb",

--- a/websites/P/ProtonDB/metadata.json
+++ b/websites/P/ProtonDB/metadata.json
@@ -11,7 +11,7 @@
   },
   "url": "www.protondb.com",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*protondb[.]com[/]",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/l4Z6mwH.png",
   "thumbnail": "https://i.imgur.com/dI94BPN.jpeg",
   "color": "#cfb53b",

--- a/websites/S/Sakura Mangas/metadata.json
+++ b/websites/S/Sakura Mangas/metadata.json
@@ -12,7 +12,7 @@
   },
   "url": ["www.sakuramangas.org", "sakuramangas.org"],
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*sakuramangas[.]org[/]",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/8EhCZKg.png",
   "thumbnail": "https://i.imgur.com/BPYoKf7.png",
   "color": "#ea6db5",

--- a/websites/S/Sdamgia/metadata.json
+++ b/websites/S/Sdamgia/metadata.json
@@ -11,7 +11,7 @@
   },
   "url": "sdamgia.ru",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*sdamgia[.]ru[/]",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/7uZXeCU.png",
   "thumbnail": "https://i.imgur.com/eahvVq3.png",
   "color": "#000000",

--- a/websites/S/Snipp/metadata.json
+++ b/websites/S/Snipp/metadata.json
@@ -11,7 +11,7 @@
   },
   "url": "snipp.gg",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*snipp[.]gg[/]",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.snipp.gg/4918533360320604/7752ca257a27f7badca8708e45daf998.png",
   "thumbnail": "https://cdn.snipp.gg/banner.png",
   "color": "#f0b100",

--- a/websites/U/USACO Guide/metadata.json
+++ b/websites/U/USACO Guide/metadata.json
@@ -11,7 +11,7 @@
   },
   "url": "usaco.guide",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*usaco[.]guide[/]",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/oRapkfu.png",
   "thumbnail": "https://i.imgur.com/cxOe02L.jpeg",
   "color": "#1e90ff",

--- a/websites/V/Voirdrama/metadata.json
+++ b/websites/V/Voirdrama/metadata.json
@@ -18,7 +18,7 @@
   },
   "url": "voirdrama.to",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*voirdrama[.]to[/]",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "logo": "https://i.imgur.com/RkcVWHJ.png",
   "thumbnail": "https://i.imgur.com/ioAhLcH.png",
   "color": "#c41f32",


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Migrates to native FormData usage which is not supported by latest versions of got

## Acknowledgements
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)