### PR TITLE
feat(+2Télé): add activity

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,6 +2,8 @@
   "extends": "@total-typescript/tsconfig/tsc/dom/library",
   "compilerOptions": {
     "typeRoots": ["@types"],
-    "types": ["premid"]
+    "types": ["premid"],
+    "esModuleInterop": true,
+    "resolveJsonModule": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
+    "typeRoots": [
+      "./@types"
+    ],
+    "types": [
+      "premid"
+    ],
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "websites/**/*.ts",
+    "@types/**/*.d.ts"
+  ]
+}

--- a/websites/#/+2Télé/+2Télé.json
+++ b/websites/#/+2Télé/+2Télé.json
@@ -1,0 +1,58 @@
+{
+  "plus2tele.accueil": {
+    "message": "Home",
+    "description": "Viewing home page"
+  },
+  "plus2tele.archivesList": {
+    "message": "Archives List",
+    "description": "Viewing list of archives"
+  },
+  "plus2tele.channelsList": {
+    "message": "Channels List",
+    "description": "Viewing list of channels"
+  },
+  "plus2tele.viewingChannel": {
+    "message": "Viewing channel: {0}",
+    "description": "Viewing a specific channel"
+  },
+  "plus2tele.agencesList": {
+    "message": "Agencies List",
+    "description": "Viewing list of agencies"
+  },
+  "plus2tele.viewingAgence": {
+    "message": "Viewing agency: {0}",
+    "description": "Viewing a specific agency"
+  },
+  "plus2tele.collectionsList": {
+    "message": "Collections List",
+    "description": "Viewing list of collections"
+  },
+  "plus2tele.viewingCollection": {
+    "message": "Viewing collection: {0}",
+    "description": "Viewing a specific collection"
+  },
+  "plus2tele.community": {
+    "message": "Community Presentation",
+    "description": "Viewing the community page"
+  },
+  "plus2tele.zapping": {
+    "message": "Zapping",
+    "description": "Viewing zapping (random archives)"
+  },
+  "plus2tele.watchingArchive": {
+    "message": "Watching an archive",
+    "description": "Watching/viewing a television archive"
+  },
+  "plus2tele.viewingProfile": {
+    "message": "Viewing {0}'s profile",
+    "description": "Viewing a member's profile"
+  },
+  "plus2tele.browsing": {
+    "message": "Browsing",
+    "description": "Generic browsing state"
+  },
+  "plus2tele.byAuthor": {
+    "message": "By {0}",
+    "description": "Author attribution text (e.g. By Soy Luciano)"
+  }
+}

--- a/websites/#/+2Télé/+2Télé.json
+++ b/websites/#/+2Télé/+2Télé.json
@@ -7,6 +7,10 @@
     "message": "Archives List",
     "description": "Viewing list of archives"
   },
+  "plus2tele.searchingArchives": {
+    "message": "Searching archives: {0}",
+    "description": "Searching archives for a query"
+  },
   "plus2tele.channelsList": {
     "message": "Channels List",
     "description": "Viewing list of channels"

--- a/websites/#/+2Télé/README.md
+++ b/websites/#/+2Télé/README.md
@@ -1,0 +1,34 @@
+# PreMiD Presence - +2Télé 📺
+
+Ce module apporte le support de **Discord Rich Presence** pour le site de référence d'archives télévisuelles **+2Télé** (https://plus2tele.com).
+
+## Fonctionnalités
+
+Le module détecte dynamiquement votre navigation sur la plateforme et met à jour votre statut Discord en conséquence :
+
+- **Page d'accueil** : Affiche que vous naviguez sur le site.
+- **Listes globales** : Détecte si vous parcourez la liste des archives, des chaînes, des agences, ou des collections.
+- **Chaînes & Agences & Collections** : Affiche le nom de la chaîne/agence/collection consultée ainsi que le nombre total d'archives associées (ex: `Page 1 sur 357 • 7130 archives`).
+- **Profils Utilisateurs** : Affiche le nom du membre et son volume total d'archives partagées.
+- **Zapping** : Affiche le titre de l'archive aléatoire en cours de visionnage.
+- **Lecteur Média** : Affiche le titre de l'archive vidéo, l'auteur de la publication, le bouton pour y accéder, et gère l'état de lecture/pause (avec icônes synchronisées).
+
+## Caractéristiques Techniques
+
+1. **Routage Multi-langue** : Supporte de manière transparente les préfixes linguistiques dynamiques du site (`/fr`, `/gb`, `/es`, `/de`, `/pt`, `/it`, `/pl`, `/ro`).
+2. **Extraction DOM Robuste & Multi-langue** :
+   - Recherche du nombre d'archives basée sur les sélecteurs de classes Tailwind CSS (`text-xl font-bold` pour la section "Archives"), ce qui rend l'extraction insensible aux traductions du site.
+   - Séparation propre de la pagination et du nombre total d'archives (ex. extrait et reformate `"Page 1 sur 357 • Affichage de 20 sur 7130 archives"` en `"Page 1 sur 357 • 7130 archives"` dans toutes les langues).
+3. **Fichiers de Ressources Locales** : Intègre des traductions de présence pour 8 langues (FR, EN, ES, DE, PT, IT, PL, RO).
+
+## Installation & Test en Local
+
+Pour lancer le serveur de développement local et tester le module :
+
+```bash
+# Lancer le serveur dev PreMiD
+npx pmd dev +2Télé
+
+# Compiler le module
+npx pmd build "+2Télé"
+```

--- a/websites/#/+2Télé/de/+2Télé.json
+++ b/websites/#/+2Télé/de/+2Télé.json
@@ -1,0 +1,44 @@
+{
+  "plus2tele.accueil": {
+    "message": "Startseite"
+  },
+  "plus2tele.archivesList": {
+    "message": "Archivliste"
+  },
+  "plus2tele.channelsList": {
+    "message": "Senderliste"
+  },
+  "plus2tele.viewingChannel": {
+    "message": "Ansicht des Senders: {0}"
+  },
+  "plus2tele.agencesList": {
+    "message": "Agenturenliste"
+  },
+  "plus2tele.viewingAgence": {
+    "message": "Ansicht der Agentur: {0}"
+  },
+  "plus2tele.collectionsList": {
+    "message": "Sammlungsliste"
+  },
+  "plus2tele.viewingCollection": {
+    "message": "Ansicht der Sammlung: {0}"
+  },
+  "plus2tele.community": {
+    "message": "Präsentation der Community"
+  },
+  "plus2tele.zapping": {
+    "message": "Zapping"
+  },
+  "plus2tele.watchingArchive": {
+    "message": "Ansehen eines Archivs"
+  },
+  "plus2tele.viewingProfile": {
+    "message": "Profil von {0} wird angezeigt"
+  },
+  "plus2tele.browsing": {
+    "message": "Browsen"
+  },
+  "plus2tele.byAuthor": {
+    "message": "Von {0}"
+  }
+}

--- a/websites/#/+2Télé/de/+2Télé.json
+++ b/websites/#/+2Télé/de/+2Télé.json
@@ -5,6 +5,9 @@
   "plus2tele.archivesList": {
     "message": "Archivliste"
   },
+  "plus2tele.searchingArchives": {
+    "message": "Archivsuche: {0}"
+  },
   "plus2tele.channelsList": {
     "message": "Senderliste"
   },

--- a/websites/#/+2Télé/en/+2Télé.json
+++ b/websites/#/+2Télé/en/+2Télé.json
@@ -5,6 +5,9 @@
   "plus2tele.archivesList": {
     "message": "Archives List"
   },
+  "plus2tele.searchingArchives": {
+    "message": "Searching archives: {0}"
+  },
   "plus2tele.channelsList": {
     "message": "Channels List"
   },

--- a/websites/#/+2Télé/en/+2Télé.json
+++ b/websites/#/+2Télé/en/+2Télé.json
@@ -1,0 +1,44 @@
+{
+  "plus2tele.accueil": {
+    "message": "Home"
+  },
+  "plus2tele.archivesList": {
+    "message": "Archives List"
+  },
+  "plus2tele.channelsList": {
+    "message": "Channels List"
+  },
+  "plus2tele.viewingChannel": {
+    "message": "Viewing channel: {0}"
+  },
+  "plus2tele.agencesList": {
+    "message": "Agencies List"
+  },
+  "plus2tele.viewingAgence": {
+    "message": "Viewing agency: {0}"
+  },
+  "plus2tele.collectionsList": {
+    "message": "Collections List"
+  },
+  "plus2tele.viewingCollection": {
+    "message": "Viewing collection: {0}"
+  },
+  "plus2tele.community": {
+    "message": "Community Presentation"
+  },
+  "plus2tele.zapping": {
+    "message": "Zapping"
+  },
+  "plus2tele.watchingArchive": {
+    "message": "Watching an archive"
+  },
+  "plus2tele.viewingProfile": {
+    "message": "Viewing {0}'s profile"
+  },
+  "plus2tele.browsing": {
+    "message": "Browsing"
+  },
+  "plus2tele.byAuthor": {
+    "message": "By {0}"
+  }
+}

--- a/websites/#/+2Télé/es/+2Télé.json
+++ b/websites/#/+2Télé/es/+2Télé.json
@@ -1,0 +1,44 @@
+{
+  "plus2tele.accueil": {
+    "message": "Página de inicio"
+  },
+  "plus2tele.archivesList": {
+    "message": "Lista de archivos"
+  },
+  "plus2tele.channelsList": {
+    "message": "Lista de canales"
+  },
+  "plus2tele.viewingChannel": {
+    "message": "Viendo el canal: {0}"
+  },
+  "plus2tele.agencesList": {
+    "message": "Lista de agencias"
+  },
+  "plus2tele.viewingAgence": {
+    "message": "Viendo la agencia: {0}"
+  },
+  "plus2tele.collectionsList": {
+    "message": "Lista de colecciones"
+  },
+  "plus2tele.viewingCollection": {
+    "message": "Viendo la colección: {0}"
+  },
+  "plus2tele.community": {
+    "message": "Presentación de la comunidad"
+  },
+  "plus2tele.zapping": {
+    "message": "Zapping"
+  },
+  "plus2tele.watchingArchive": {
+    "message": "Viendo un archivo"
+  },
+  "plus2tele.viewingProfile": {
+    "message": "Viendo el perfil de {0}"
+  },
+  "plus2tele.browsing": {
+    "message": "Navegación"
+  },
+  "plus2tele.byAuthor": {
+    "message": "Por {0}"
+  }
+}

--- a/websites/#/+2Télé/es/+2Télé.json
+++ b/websites/#/+2Télé/es/+2Télé.json
@@ -5,6 +5,9 @@
   "plus2tele.archivesList": {
     "message": "Lista de archivos"
   },
+  "plus2tele.searchingArchives": {
+    "message": "Búsqueda en archivos: {0}"
+  },
   "plus2tele.channelsList": {
     "message": "Lista de canales"
   },

--- a/websites/#/+2Télé/fr/+2Télé.json
+++ b/websites/#/+2Télé/fr/+2Télé.json
@@ -1,0 +1,44 @@
+{
+  "plus2tele.accueil": {
+    "message": "Page d'accueil"
+  },
+  "plus2tele.archivesList": {
+    "message": "Liste des archives"
+  },
+  "plus2tele.channelsList": {
+    "message": "Liste des chaînes"
+  },
+  "plus2tele.viewingChannel": {
+    "message": "Consulte la chaîne : {0}"
+  },
+  "plus2tele.agencesList": {
+    "message": "Liste des agences"
+  },
+  "plus2tele.viewingAgence": {
+    "message": "Consulte l'agence : {0}"
+  },
+  "plus2tele.collectionsList": {
+    "message": "Liste des collections"
+  },
+  "plus2tele.viewingCollection": {
+    "message": "Consulte la collection : {0}"
+  },
+  "plus2tele.community": {
+    "message": "Présentation de la communauté"
+  },
+  "plus2tele.zapping": {
+    "message": "Zapping"
+  },
+  "plus2tele.watchingArchive": {
+    "message": "Regarde une archive"
+  },
+  "plus2tele.viewingProfile": {
+    "message": "Consulte le profil de : {0}"
+  },
+  "plus2tele.browsing": {
+    "message": "Navigation"
+  },
+  "plus2tele.byAuthor": {
+    "message": "Par {0}"
+  }
+}

--- a/websites/#/+2Télé/fr/+2Télé.json
+++ b/websites/#/+2Télé/fr/+2Télé.json
@@ -5,6 +5,9 @@
   "plus2tele.archivesList": {
     "message": "Liste des archives"
   },
+  "plus2tele.searchingArchives": {
+    "message": "Recherche d'archives : {0}"
+  },
   "plus2tele.channelsList": {
     "message": "Liste des chaînes"
   },

--- a/websites/#/+2Télé/it/+2Télé.json
+++ b/websites/#/+2Télé/it/+2Télé.json
@@ -1,0 +1,44 @@
+{
+  "plus2tele.accueil": {
+    "message": "Pagina iniziale"
+  },
+  "plus2tele.archivesList": {
+    "message": "Lista degli archivi"
+  },
+  "plus2tele.channelsList": {
+    "message": "Lista dei canali"
+  },
+  "plus2tele.viewingChannel": {
+    "message": "Visualizzazione del canale: {0}"
+  },
+  "plus2tele.agencesList": {
+    "message": "Lista delle agenzie"
+  },
+  "plus2tele.viewingAgence": {
+    "message": "Visualizzazione dell'agenzia: {0}"
+  },
+  "plus2tele.collectionsList": {
+    "message": "Lista delle collezioni"
+  },
+  "plus2tele.viewingCollection": {
+    "message": "Visualizzazione della collezione: {0}"
+  },
+  "plus2tele.community": {
+    "message": "Presentazione della community"
+  },
+  "plus2tele.zapping": {
+    "message": "Zapping"
+  },
+  "plus2tele.watchingArchive": {
+    "message": "Guardando un archivio"
+  },
+  "plus2tele.viewingProfile": {
+    "message": "Visualizzazione del profilo di {0}"
+  },
+  "plus2tele.browsing": {
+    "message": "Navigazione"
+  },
+  "plus2tele.byAuthor": {
+    "message": "Da {0}"
+  }
+}

--- a/websites/#/+2Télé/it/+2Télé.json
+++ b/websites/#/+2Télé/it/+2Télé.json
@@ -5,6 +5,9 @@
   "plus2tele.archivesList": {
     "message": "Lista degli archivi"
   },
+  "plus2tele.searchingArchives": {
+    "message": "Ricerca negli archivi: {0}"
+  },
   "plus2tele.channelsList": {
     "message": "Lista dei canali"
   },

--- a/websites/#/+2Télé/metadata.json
+++ b/websites/#/+2Télé/metadata.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "name": "!gatx",
+    "id": "199902444442877952"
+  },
+  "service": "+2Télé",
+  "description": {
+    "en": "PreMiD Presence for +2Télé, a French television archives website.",
+    "fr": "Présence PreMiD pour +2Télé, un site d'archives de la télévision.",
+    "es": "Presencia de PreMiD para +2Télé, un sitio web de archivos de televisión francesa.",
+    "de": "PreMiD-Präsenz für +2Télé, eine Website für französische Fernseharchive.",
+    "pt": "Presença do PreMiD para +2Télé, um site de arquivos de televisão francesa.",
+    "it": "Presenza di PreMiD per +2Télé, un sito web di archivi televisivi francesi.",
+    "pl": "PreMiD Presence dla +2Télé, francuskiej witryny z archiwami telewizyjnymi.",
+    "ro": "Prezență PreMiD pentru +2Télé, un site de arhive ale televiziunii franceze."
+  },
+  "url": "plus2tele.com",
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*plus2tele[.]com[/]",
+  "version": "1.0.0",
+  "logo": "https://i.ibb.co/ZRjtGH0X/P6-T-PP-CGI-1-1.png",
+  "thumbnail": "https://i.ibb.co/q37P2sS1/P2-T-bannierev1.png",
+  "color": "#4F70CE",
+  "category": "videos",
+  "tags": [
+    "archives",
+    "television",
+    "replay",
+    "tv"
+  ]
+}

--- a/websites/#/+2Télé/metadata.json
+++ b/websites/#/+2Télé/metadata.json
@@ -7,13 +7,13 @@
   },
   "service": "+2Télé",
   "description": {
-    "en": "PreMiD Presence for +2Télé, a French television archives website.",
-    "fr": "Présence PreMiD pour +2Télé, un site d'archives de la télévision.",
-    "es": "Presencia de PreMiD para +2Télé, un sitio web de archivos de televisión francesa.",
     "de": "PreMiD-Präsenz für +2Télé, eine Website für französische Fernseharchive.",
-    "pt": "Presença do PreMiD para +2Télé, um site de arquivos de televisão francesa.",
+    "en": "PreMiD Presence for +2Télé, a French television archives website.",
+    "es": "Presencia de PreMiD para +2Télé, un sitio web de archivos de televisión francesa.",
+    "fr": "Présence PreMiD pour +2Télé, un site d'archives de la télévision.",
     "it": "Presenza di PreMiD per +2Télé, un sito web di archivi televisivi francesi.",
     "pl": "PreMiD Presence dla +2Télé, francuskiej witryny z archiwami telewizyjnymi.",
+    "pt": "Presença do PreMiD para +2Télé, um site de arquivos de televisão francesa.",
     "ro": "Prezență PreMiD pentru +2Télé, un site de arhive ale televiziunii franceze."
   },
   "url": "plus2tele.com",

--- a/websites/#/+2Télé/pl/+2Télé.json
+++ b/websites/#/+2Télé/pl/+2Télé.json
@@ -1,0 +1,44 @@
+{
+  "plus2tele.accueil": {
+    "message": "Strona główna"
+  },
+  "plus2tele.archivesList": {
+    "message": "Lista archiwów"
+  },
+  "plus2tele.channelsList": {
+    "message": "Lista kanałów"
+  },
+  "plus2tele.viewingChannel": {
+    "message": "Przeglądanie kanału: {0}"
+  },
+  "plus2tele.agencesList": {
+    "message": "Lista agencji"
+  },
+  "plus2tele.viewingAgence": {
+    "message": "Przeglądanie agencji: {0}"
+  },
+  "plus2tele.collectionsList": {
+    "message": "Lista kolekcji"
+  },
+  "plus2tele.viewingCollection": {
+    "message": "Przeglądanie kolekcji: {0}"
+  },
+  "plus2tele.community": {
+    "message": "Prezentacja społeczności"
+  },
+  "plus2tele.zapping": {
+    "message": "Zapping"
+  },
+  "plus2tele.watchingArchive": {
+    "message": "Oglądanie archiwum"
+  },
+  "plus2tele.viewingProfile": {
+    "message": "Przeglądanie profilu użytkownika {0}"
+  },
+  "plus2tele.browsing": {
+    "message": "Przeglądanie"
+  },
+  "plus2tele.byAuthor": {
+    "message": "Przez {0}"
+  }
+}

--- a/websites/#/+2Télé/pl/+2Télé.json
+++ b/websites/#/+2Télé/pl/+2Télé.json
@@ -5,6 +5,9 @@
   "plus2tele.archivesList": {
     "message": "Lista archiwów"
   },
+  "plus2tele.searchingArchives": {
+    "message": "Wyszukiwanie w archiwach: {0}"
+  },
   "plus2tele.channelsList": {
     "message": "Lista kanałów"
   },

--- a/websites/#/+2Télé/presence.ts
+++ b/websites/#/+2Télé/presence.ts
@@ -55,6 +55,7 @@ presence.on('UpdateData', async () => {
   const strings = await presence.getStrings({
     accueil: 'plus2tele.accueil',
     archivesList: 'plus2tele.archivesList',
+    searchingArchives: 'plus2tele.searchingArchives',
     channelsList: 'plus2tele.channelsList',
     viewingChannel: 'plus2tele.viewingChannel',
     agencesList: 'plus2tele.agencesList',
@@ -92,7 +93,13 @@ presence.on('UpdateData', async () => {
   }
   else if (paths.length === 1 && firstSegment === 'archives') {
     // Archives List
-    presenceData.details = strings.archivesList
+    const query = new URL(href).searchParams.get('query')
+    if (query) {
+      presenceData.details = strings.searchingArchives.replace('{0}', query)
+    }
+    else {
+      presenceData.details = strings.archivesList
+    }
     presenceData.state = getArchivesListStats() || strings.browsing
   }
   else if (paths.length === 1 && firstSegment === 'channels') {

--- a/websites/#/+2Télé/presence.ts
+++ b/websites/#/+2Télé/presence.ts
@@ -1,0 +1,227 @@
+import type ActivityStrings from './+2Télé.json'
+import { ActivityType, Assets } from 'premid'
+
+const presence = new Presence({
+  clientId: '1507813260563452116',
+})
+
+const startTimestamp = Math.floor(Date.now() / 1000)
+
+declare global {
+  interface StringKeys {
+    plus2tele: keyof typeof ActivityStrings
+  }
+}
+
+enum ActivityAssets {
+  Logo = 'https://i.ibb.co/ZRjtGH0X/P6-T-PP-CGI-1-1.png',
+}
+
+function getArchivesCount(): string {
+  const archivesHeading = Array.from(document.querySelectorAll('h2')).find(
+    el => el.classList.contains('text-xl') && el.classList.contains('font-bold'),
+  )
+  const archivesSpan = archivesHeading?.nextElementSibling
+    || archivesHeading?.parentElement?.querySelector('span.text-brand-blue, span.bg-brand-blue\\/20')
+    || archivesHeading?.parentElement?.querySelector('span')
+    || document.querySelector('h2 + span.bg-brand-blue\\/20')
+    || document.querySelector('div.flex.items-center.gap-3 > span.text-brand-blue')
+  return archivesSpan?.textContent?.trim() || ''
+}
+
+function getArchivesListStats(): string {
+  const p = document.querySelector('p.text-white\\/40.text-xs')
+    || Array.from(document.querySelectorAll('p')).find(
+      el => el.textContent?.includes('•') && /\d+/.test(el.textContent || ''),
+    )
+  const statsText = p?.textContent?.trim() || ''
+  if (statsText.includes('•')) {
+    const parts = statsText.split('•')
+    const part1 = parts[0]?.trim()
+    const part2 = parts[1]?.trim()
+    if (part1 && part2) {
+      const words = part2.split(/\s+/).filter(Boolean)
+      const total = words[words.length - 2]
+      const label = words[words.length - 1]
+      if (total && label && /^\d+$/.test(total)) {
+        return `${part1} • ${total} ${label}`
+      }
+    }
+  }
+  return statsText
+}
+
+presence.on('UpdateData', async () => {
+  const strings = await presence.getStrings({
+    accueil: 'plus2tele.accueil',
+    archivesList: 'plus2tele.archivesList',
+    channelsList: 'plus2tele.channelsList',
+    viewingChannel: 'plus2tele.viewingChannel',
+    agencesList: 'plus2tele.agencesList',
+    viewingAgence: 'plus2tele.viewingAgence',
+    collectionsList: 'plus2tele.collectionsList',
+    viewingCollection: 'plus2tele.viewingCollection',
+    community: 'plus2tele.community',
+    zapping: 'plus2tele.zapping',
+    watchingArchive: 'plus2tele.watchingArchive',
+    viewingProfile: 'plus2tele.viewingProfile',
+    browsing: 'plus2tele.browsing',
+    byAuthor: 'plus2tele.byAuthor',
+  })
+
+  const { pathname, href } = document.location
+  const paths = pathname.split('/').filter(Boolean)
+
+  // Shift/discard the dynamic [pays] prefix (e.g. 'fr', 'gb', 'es', 'de', 'pt', 'it', 'pl', 'ro') if present
+  if (paths[0] && /^[a-z]{2}(?:-[a-z]{2,4})?$/i.test(paths[0])) {
+    paths.shift()
+  }
+
+  const firstSegment = paths[0]
+
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp,
+  }
+
+  // Determine current page and set details/state
+  if (paths.length === 0 || !firstSegment) {
+    // Home Page
+    presenceData.details = strings.accueil
+    presenceData.state = strings.browsing
+  }
+  else if (paths.length === 1 && firstSegment === 'archives') {
+    // Archives List
+    presenceData.details = strings.archivesList
+    presenceData.state = getArchivesListStats() || strings.browsing
+  }
+  else if (paths.length === 1 && firstSegment === 'channels') {
+    // Channels List
+    presenceData.details = strings.channelsList
+    presenceData.state = strings.browsing
+  }
+  else if (firstSegment === 'channel' && paths.length >= 2) {
+    // Channel Detail
+    const h1 = document.querySelector('h1')
+    const channelName = h1?.textContent?.trim()
+    const archivesText = getArchivesCount()
+
+    presenceData.details = strings.viewingChannel.replace('{0}', channelName || 'Inconnu')
+    presenceData.state = archivesText || strings.browsing
+    presenceData.buttons = [
+      {
+        label: 'Voir la chaîne',
+        url: href,
+      },
+    ]
+  }
+  else if (paths.length === 1 && firstSegment === 'agences') {
+    // Agencies List
+    presenceData.details = strings.agencesList
+    presenceData.state = strings.browsing
+  }
+  else if (firstSegment === 'agence' && paths.length >= 2) {
+    // Agency Detail
+    const h1 = document.querySelector('h1')
+    const agencyName = h1?.textContent?.trim()
+    const archivesText = getArchivesCount()
+    let archivesDisplay = archivesText
+    if (archivesText && /^\d+$/.test(archivesText)) {
+      archivesDisplay = `${archivesText} archives`
+    }
+
+    presenceData.details = strings.viewingAgence.replace('{0}', agencyName || 'Inconnu')
+    presenceData.state = archivesDisplay || strings.browsing
+    presenceData.buttons = [
+      {
+        label: 'Voir l\'agence',
+        url: href,
+      },
+    ]
+  }
+  else if (paths.length === 1 && firstSegment === 'collections') {
+    // Collections List
+    presenceData.details = strings.collectionsList
+    presenceData.state = strings.browsing
+  }
+  else if (firstSegment === 'collection' && paths.length >= 2) {
+    // Collection Detail
+    const collectionName = document.querySelector('h1')?.textContent?.trim()
+    const archivesText = getArchivesCount()
+    let archivesDisplay = archivesText
+    if (archivesText && /^\d+$/.test(archivesText)) {
+      archivesDisplay = `${archivesText} archives`
+    }
+
+    presenceData.details = strings.viewingCollection.replace('{0}', collectionName || 'Inconnu')
+    presenceData.state = archivesDisplay || strings.browsing
+    presenceData.buttons = [
+      {
+        label: 'Voir la collection',
+        url: href,
+      },
+    ]
+  }
+  else if (paths.length === 1 && firstSegment === 'community') {
+    // Community Page
+    presenceData.details = strings.community
+    presenceData.state = strings.browsing
+  }
+  else if (paths.length === 1 && firstSegment === 'zapping') {
+    // Zapping (Random archives)
+    const zappingTitle = document.querySelector('h1.text-2xl.font-bold.text-white.mb-2, h1')?.textContent?.trim()
+    presenceData.details = strings.zapping
+    presenceData.state = zappingTitle || strings.browsing
+  }
+  else if (firstSegment === 'player') {
+    // Player Page (Watching archive)
+    const playerTitle = document.querySelector('h1.text-xl.md\\:text-2xl.font-bold.text-white.leading-tight, h1')?.textContent?.trim()
+    const authorLink = document.querySelector('a[href*="/profile/"]')
+    const authorText = authorLink?.textContent?.trim() || ''
+
+    presenceData.details = playerTitle || strings.watchingArchive
+    presenceData.state = authorText || strings.browsing
+    ;(presenceData as PresenceData).type = ActivityType.Watching
+
+    const video = document.querySelector('video')
+    if (video) {
+      const isPlaying = !video.paused && !video.ended
+      presenceData.smallImageKey = isPlaying ? Assets.Play : Assets.Pause
+      presenceData.smallImageText = isPlaying ? 'Lecture' : 'Pause'
+    }
+
+    presenceData.buttons = [
+      {
+        label: 'Regarder l\'archive',
+        url: href,
+      },
+    ]
+  }
+  else if (firstSegment === 'profile' && paths.length >= 2) {
+    // Profile Detail
+    const profileName = document.querySelector('h1.text-3xl.font-bold.text-white, h1')?.textContent?.trim()
+    const archivesSpan = Array.from(document.querySelectorAll('span')).find(el => el.textContent?.includes('au total'))
+    const profileArchivesText = archivesSpan?.textContent?.trim() || ''
+
+    presenceData.details = strings.viewingProfile.replace('{0}', profileName || 'Inconnu')
+    presenceData.state = profileArchivesText || strings.browsing
+    presenceData.buttons = [
+      {
+        label: 'Voir le profil',
+        url: href,
+      },
+    ]
+  }
+  else {
+    // Fallback
+    presenceData.details = strings.accueil
+    presenceData.state = strings.browsing
+  }
+
+  if (presenceData.details) {
+    presence.setActivity(presenceData)
+  }
+  else {
+    presence.setActivity()
+  }
+})

--- a/websites/#/+2Télé/pt/+2Télé.json
+++ b/websites/#/+2Télé/pt/+2Télé.json
@@ -5,6 +5,9 @@
   "plus2tele.archivesList": {
     "message": "Lista de arquivos"
   },
+  "plus2tele.searchingArchives": {
+    "message": "Pesquisa nos arquivos: {0}"
+  },
   "plus2tele.channelsList": {
     "message": "Lista de canais"
   },

--- a/websites/#/+2Télé/pt/+2Télé.json
+++ b/websites/#/+2Télé/pt/+2Télé.json
@@ -1,0 +1,44 @@
+{
+  "plus2tele.accueil": {
+    "message": "Página inicial"
+  },
+  "plus2tele.archivesList": {
+    "message": "Lista de arquivos"
+  },
+  "plus2tele.channelsList": {
+    "message": "Lista de canais"
+  },
+  "plus2tele.viewingChannel": {
+    "message": "Visualizando o canal: {0}"
+  },
+  "plus2tele.agencesList": {
+    "message": "Lista de agências"
+  },
+  "plus2tele.viewingAgence": {
+    "message": "Visualizando a agência: {0}"
+  },
+  "plus2tele.collectionsList": {
+    "message": "Lista de coleções"
+  },
+  "plus2tele.viewingCollection": {
+    "message": "Visualizando a coleção: {0}"
+  },
+  "plus2tele.community": {
+    "message": "Apresentação da comunidade"
+  },
+  "plus2tele.zapping": {
+    "message": "Zapping"
+  },
+  "plus2tele.watchingArchive": {
+    "message": "Assistindo a um arquivo"
+  },
+  "plus2tele.viewingProfile": {
+    "message": "Visualizando o perfil de {0}"
+  },
+  "plus2tele.browsing": {
+    "message": "Navegação"
+  },
+  "plus2tele.byAuthor": {
+    "message": "Por {0}"
+  }
+}

--- a/websites/#/+2Télé/ro/+2Télé.json
+++ b/websites/#/+2Télé/ro/+2Télé.json
@@ -1,0 +1,44 @@
+{
+  "plus2tele.accueil": {
+    "message": "Pagina principală"
+  },
+  "plus2tele.archivesList": {
+    "message": "Lista arhivelor"
+  },
+  "plus2tele.channelsList": {
+    "message": "Lista canalelor"
+  },
+  "plus2tele.viewingChannel": {
+    "message": "Vizualizare canal: {0}"
+  },
+  "plus2tele.agencesList": {
+    "message": "Lista agențiilor"
+  },
+  "plus2tele.viewingAgence": {
+    "message": "Vizualizare agenție: {0}"
+  },
+  "plus2tele.collectionsList": {
+    "message": "Lista colecțiilor"
+  },
+  "plus2tele.viewingCollection": {
+    "message": "Vizualizare colecție: {0}"
+  },
+  "plus2tele.community": {
+    "message": "Prezentarea comunității"
+  },
+  "plus2tele.zapping": {
+    "message": "Zapping"
+  },
+  "plus2tele.watchingArchive": {
+    "message": "Vizionarea unei arhive"
+  },
+  "plus2tele.viewingProfile": {
+    "message": "Vizualizarea profilului lui {0}"
+  },
+  "plus2tele.browsing": {
+    "message": "Navigare"
+  },
+  "plus2tele.byAuthor": {
+    "message": "De {0}"
+  }
+}

--- a/websites/#/+2Télé/ro/+2Télé.json
+++ b/websites/#/+2Télé/ro/+2Télé.json
@@ -5,6 +5,9 @@
   "plus2tele.archivesList": {
     "message": "Lista arhivelor"
   },
+  "plus2tele.searchingArchives": {
+    "message": "Căutare în arhive: {0}"
+  },
   "plus2tele.channelsList": {
     "message": "Lista canalelor"
   },


### PR DESCRIPTION
This PR adds the Discord Rich Presence support for **+2Télé** (https://plus2tele.com). It tracks navigation across all main sections (home, archives list, channel/agency/collection lists and detail pages, user profiles, zapping, and media player with lecture/pause tracking). It has been tested and compiled successfully.