### PR TITLE
feat(Comix): Add new URLs

### DIFF
--- a/websites/C/Comix/metadata.json
+++ b/websites/C/Comix/metadata.json
@@ -5,13 +5,19 @@
     "id": "339316517558681610",
     "name": "firstoften"
   },
+  "contributors": [
+    {
+      "id": "932176594045378590",
+      "name": "niko_vax"
+    }
+  ],
   "service": "Comix",
   "description": {
     "en": "Next-Gen Manga Experience."
   },
   "url": "comix.to",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*comix[.]to[/]",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/C/Comix/assets/thumbnail.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/C/Comix/assets/thumbnail.png",
   "color": "#000000",

--- a/websites/C/Comix/presence.ts
+++ b/websites/C/Comix/presence.ts
@@ -9,14 +9,24 @@ enum ActivityAssets {
   Notification = 'https://cdn.rcd.gg/PreMiD/websites/C/Comix/assets/1.png',
 }
 
+let sessionStartTime: number | null = null
+
 presence.on('UpdateData', async () => {
+  if (sessionStartTime === null)
+    sessionStartTime = Math.floor(Date.now() / 1000)
+
   const presenceData: PresenceData = {
     largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/C/Comix/assets/thumbnail.png',
+    startTimestamp: sessionStartTime,
   }
 
   const { pathname, search } = document.location
   const searchParams = new URLSearchParams(search)
   const tab = searchParams.get('tab')?.toLowerCase()
+  const sort = searchParams.get('sort')?.toLowerCase()
+  const scope = searchParams.get('scope')?.toLowerCase()
+  const sub = searchParams.get('sub')?.toLowerCase()
+  const filter = searchParams.get('filter')?.toLowerCase()
   const normalizedPathname = pathname.replace(/\/+$/, '') || '/'
 
   const dataEl = document.getElementById('initial-data')
@@ -25,113 +35,180 @@ presence.on('UpdateData', async () => {
   const mangaKey = data ? Object.keys(data.queries).find(k => k.includes('manga') && k.includes('detail')) : null
   const manga = mangaKey && data ? data.queries[mangaKey] : null
 
-  const groupKey = data ? Object.keys(data.queries).find(k => k.includes('groups') && k.includes('detail')) : null
-  const group = groupKey && data ? data.queries[groupKey] : null
-
   const mangaName = manga?.title || 'Manga'
-  const groupName = group?.name
   const mangaPoster = manga?.poster?.large || manga?.poster?.medium
 
   const chapterNum = data?.read?.chapterNumber
-  const chapter = chapterNum ? `Chapter: ${chapterNum}` : 'Reading'
-
-  const getImg = (selector: string) => {
-    const el = document.querySelector(selector)
-    const src = el?.getAttribute('data-src') || el?.getAttribute('src')
-    return src ? new URL(src, document.location.href).href : null
-  }
-
-  const poster = getImg('.poster div img') || getImg('.poster img')
+  const isChapterPage = data?.page === 'read'
 
   if (pathname === '/') {
-    presenceData.state = 'Stepping into magical world...'
+    presenceData.state = 'Browsing homepage...'
   }
   else if (pathname === '/home') {
     presenceData.state = 'Browsing homepage...'
     presenceData.smallImageKey = Assets.Search
   }
-  else if (pathname === '/genres') {
+  else if (normalizedPathname === '/genres') {
     presenceData.details = 'Browsing genres...'
     presenceData.smallImageKey = Assets.Search
   }
-  else if (pathname === '/groups/popular') {
-    presenceData.details = 'Browsing popular groups...'
+  else if (normalizedPathname === '/groups') {
+    presenceData.details = 'Browsing scanlation groups...'
     presenceData.smallImageKey = Assets.Search
   }
-  else if (pathname === '/groups') {
-    presenceData.details = 'Browsing groups...'
+  else if (normalizedPathname === '/groups/popular') {
+    presenceData.details = 'Browsing popular scanlation groups...'
     presenceData.smallImageKey = Assets.Search
   }
-  else if (/\/groups\/\d+/.test(pathname)) {
-    presenceData.details = `Watching at '${groupName || 'Unknown'}' group`
-  }
-  else if (normalizedPathname === '/user') {
-    presenceData.details = 'Editing profile...'
-    presenceData.smallImageKey = Assets.Writing
-  }
-  else if (normalizedPathname === '/user/notifications') {
-    if (tab === 'chapter') {
-      presenceData.details = 'Viewing chapter notifications...'
-      presenceData.smallImageKey = ActivityAssets.Notification
-    }
-    else if (tab === 'community') {
-      presenceData.details = 'Viewing community notifications...'
-      presenceData.smallImageKey = ActivityAssets.Notification
-    }
-    else {
-      presenceData.details = 'Viewing chapter notifications...'
-      presenceData.smallImageKey = ActivityAssets.Notification
-    }
-  }
-  else if (normalizedPathname === '/user/history') {
-    presenceData.details = 'Viewing reading history...'
+  else if (/\/groups\/\w+/.test(pathname)) {
+    const gpName = document.querySelector('.gp__name')?.textContent?.trim()
+    const gpMetaItems = document.querySelectorAll('.gp__meta-item')
+    const gpReleases = gpMetaItems[1]?.querySelector('strong')?.textContent?.trim()
+    const gpTitles = gpMetaItems[2]?.querySelector('strong')?.textContent?.trim()
+
+    presenceData.details = `Viewing "${gpName || 'Unknown'}" group`
+
+    const stateParts = [
+      gpReleases !== undefined ? `${gpReleases} releases` : null,
+      gpTitles !== undefined ? `${gpTitles} titles` : null,
+    ].filter(Boolean)
+
+    if (stateParts.length > 0)
+      presenceData.state = stateParts.join(' · ')
+
     presenceData.smallImageKey = Assets.Viewing
   }
-  else if (normalizedPathname === '/user/settings') {
-    presenceData.details = 'Managing account settings...'
-    presenceData.smallImageKey = ActivityAssets.Settings
-  }
-  else if (normalizedPathname === '/user/bookmarks') {
-    if (tab === 'list') {
-      presenceData.details = 'Managing bookmark list...'
-      presenceData.smallImageKey = ActivityAssets.Settings
-    }
-    else if (tab === 'import') {
-      presenceData.details = 'Importing bookmarks...'
-      presenceData.smallImageKey = Assets.Downloading
-    }
-    else if (tab === 'export') {
-      presenceData.details = 'Exporting bookmarks...'
-      presenceData.smallImageKey = Assets.Uploading
-    }
-    else if (tab === 'folder') {
-      presenceData.details = 'Managing bookmark folders...'
-      presenceData.smallImageKey = ActivityAssets.Settings
-    }
-    else {
-      presenceData.details = 'Managing bookmarks list...'
-      presenceData.smallImageKey = ActivityAssets.Settings
-    }
-  }
-  else if (pathname.includes('/browse')) {
-    const searchQuery = searchParams.get('q') || ''
-    presenceData.details = searchQuery ? `Searching for "${searchQuery}"` : 'Searching for manga...'
+  else if (normalizedPathname === '/browse') {
+    presenceData.details = 'Browsing comix...'
     presenceData.smallImageKey = Assets.Search
   }
+  else if (normalizedPathname === '/user') {
+    if (!tab || tab === 'edit') {
+      presenceData.details = 'Editing profile...'
+      presenceData.smallImageKey = Assets.Writing
+    }
+    else if (tab === 'groups') {
+      if (sort === 'az') {
+        presenceData.details = 'Viewing followed groups (A-Z)...'
+      }
+      else if (sort === 'members') {
+        presenceData.details = 'Viewing followed groups by members...'
+      }
+      else {
+        presenceData.details = 'Viewing followed groups...'
+      }
+      presenceData.smallImageKey = Assets.Viewing
+    }
+    else if (tab === 'titles') {
+      presenceData.details = 'Viewing followed titles...'
+      presenceData.smallImageKey = Assets.Viewing
+    }
+    else if (tab === 'history') {
+      presenceData.details = 'Viewing read history...'
+      presenceData.smallImageKey = Assets.Viewing
+    }
+    else if (tab === 'collections') {
+      if (sub === 'liked') {
+        presenceData.details = 'Browsing liked collections...'
+      }
+      else {
+        presenceData.details = 'Browsing owned collections...'
+      }
+      presenceData.smallImageKey = Assets.Viewing
+    }
+    else if (tab === 'feed') {
+      if (scope === 'groups') {
+        presenceData.details = 'Viewing groups feed...'
+      }
+      else {
+        presenceData.details = 'Viewing titles feed...'
+      }
+      presenceData.smallImageKey = Assets.Viewing
+    }
+    else if (tab === 'notifs') {
+      if (scope === 'community') {
+        presenceData.details = 'Viewing community notifications...'
+      }
+      else {
+        presenceData.details = 'Viewing notifications...'
+      }
+      presenceData.smallImageKey = ActivityAssets.Notification
+    }
+    else if (tab === 'comments') {
+      if (sort === 'liked') {
+        presenceData.details = 'Viewing comments sorted by likes...'
+      }
+      else if (sort === 'replies') {
+        presenceData.details = 'Viewing comments sorted by replies...'
+      }
+      else {
+        presenceData.details = 'Viewing comments...'
+      }
+      presenceData.smallImageKey = Assets.Viewing
+    }
+    else if (tab === 'uploads') {
+      if (filter === 'visible') {
+        presenceData.details = 'Managing visible uploads...'
+      }
+      else if (filter === 'accepted') {
+        presenceData.details = 'Managing accepted uploads...'
+      }
+      else if (filter === 'pending') {
+        presenceData.details = 'Viewing pending uploads...'
+      }
+      else if (filter === 'rejected') {
+        presenceData.details = 'Viewing rejected uploads...'
+      }
+      else {
+        presenceData.details = 'Managing uploads...'
+      }
+      presenceData.smallImageKey = Assets.Uploading
+    }
+    else if (tab === 'backup') {
+      presenceData.details = 'Managing Import / Export...'
+      presenceData.smallImageKey = Assets.Downloading
+    }
+    else if (tab === 'settings') {
+      presenceData.details = 'Managing account settings...'
+      presenceData.smallImageKey = ActivityAssets.Settings
+    }
+  }
+  else if (normalizedPathname === '/collections') {
+    presenceData.details = 'Browsing Public Collections...'
+    presenceData.smallImageKey = Assets.Search
+  }
+  else if (/\/collections\/\w+/.test(pathname)) {
+    const collectionTitle = document.querySelector('.cdp__head .cdp__title')?.textContent?.trim()
+    const ownerName = document.querySelector('.cdp__owner-name')?.textContent?.trim()
+    const titlesItem = document.querySelectorAll('.cdp__meta-item')[1]
+    const totalTitles = titlesItem?.textContent?.trim().replace(/\s+/g, ' ')
 
+    presenceData.details = collectionTitle
+      ? `Viewing collection: ${collectionTitle}`
+      : 'Viewing a collection...'
+
+    if (ownerName) {
+      presenceData.state = `By ${ownerName}${totalTitles ? ` · ${totalTitles}` : ''}`
+    }
+
+    presenceData.smallImageKey = Assets.Viewing
+  }
+  else if (/\/u\/\w+/.test(pathname)) {
+    presenceData.details = 'Viewing a User\'s Profile'
+    presenceData.smallImageKey = Assets.Viewing
+  }
   if (pathname.includes('/title')) {
-    const isReading = /\/title\/[\w-]+\/\d+/.test(pathname) || data?.read
-    if (!isReading) {
+    if (!isChapterPage) {
       presenceData.details = `Viewing "${mangaName}" mainpage`
-      presenceData.largeImageKey = poster || mangaPoster || presenceData.largeImageKey
+      presenceData.largeImageKey = mangaPoster || presenceData.largeImageKey
       presenceData.smallImageKey = Assets.Viewing
     }
     else {
       presenceData.details = mangaName
-      presenceData.state = chapter || 'Reading'
-      presenceData.largeImageKey = mangaPoster || poster || presenceData.largeImageKey
+      presenceData.state = `Chapter: ${chapterNum ?? 'Unknown'}`
+      presenceData.largeImageKey = mangaPoster || presenceData.largeImageKey
       presenceData.smallImageKey = Assets.Reading
-      presenceData.smallImageText = 'Reading'
+      presenceData.smallImageText = `Chapter: ${chapterNum}`
     }
   }
 


### PR DESCRIPTION
## Description
Comix has rewritten their site and there are many changes.

### New Changes:
**New Routes:**
- `/collections` - Browse public collections
- `/collections/:id` - View specific collection, shows the collection title, owner name & total titles
- `/groups/:id` - Shows group name, total releases & total titles
- `/u/:userid` - View a user's profile
- `/user` now has all pages tucked under tabs:
  - Edit Profile (`user?tab=edit`)
  - Following Groups (`user?tab=groups`)
  - Following Titles (`user?tab=titles`)
  - Read History (`user?tab=history`)
  - Collections (`user?tab=collections`)
  - Feed (`user?tab=feed`)
  - Notifications (`user?tab=notifs`)
  - Comments (`user?tab=comments`)
  - Upload Chapters (`user?tab=uploads`)
  - Import / Export (`user?tab=backup`)
  - Settings (`user?tab=settings`)

**Followed Groups** can be sorted by a-z & members, **Collections** sorted by liked, **Feed** sorted by followed titles & groups, **Comments** sorted by most like & replies, **Upload** sorted by visible, accepted, pending & rejected.
## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)
