### PR TITLE
feat(4thewords): add activity

### DIFF
--- a/websites/0-9/4thewords/metadata.json
+++ b/websites/0-9/4thewords/metadata.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "id": "1382387301459558412",
+    "name": "ivan.shiratori"
+  },
+  "service": "4thewords",
+  "description": {
+    "en": "Playing 4thewords, a writing game where you write to defeat monsters and explore an adventure world."
+  },
+  "url": "4thewords.com",
+  "regExp": "^https?://(app\\.)?4thewords\\.com/",
+  "version": "1.0.0",
+  "logo": "https://4thewords.com/favicon.ico",
+  "thumbnail": "https://4thewords.com/favicon.ico",
+  "color": "#000000",
+  "category": "games",
+  "tags": [
+    "games"
+  ]
+}

--- a/websites/0-9/4thewords/presence.ts
+++ b/websites/0-9/4thewords/presence.ts
@@ -1,0 +1,20 @@
+import { Assets } from 'premid'
+
+const presence = new Presence({
+  clientId: '1511211031706341386',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets { // Other default assets can be found at index.d.ts
+  Logo = 'https://4thewords.com/images/globalactivity/1569536977_upvote.webp',
+}
+
+presence.on('UpdateData', async () => {
+  if (document.location.href.includes('app.4thewords.com')) {
+    presence.setActivity({
+      details: 'Writing in the Adventure World',
+      state: 'Playing 4thewords',
+      largeImageKey: ActivityAssets.Logo,
+    });
+  }
+});


### PR DESCRIPTION
## Description
i add 4thewords as an activity. It's a web-based writing game platform.

## Acknowledgements
- [x ] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x ] I linted the code by running `npm run lint`
- [x ]1 The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
The activity works well. If I open 4thewords, it reflects to my Discord profile with the logo. Here is the proof:
<img width="291" height="609" alt="image" src="https://github.com/user-attachments/assets/223f2aa0-51c6-4a2b-afdf-34a83621f2a0" />
<img width="1366" height="671" alt="image" src="https://github.com/user-attachments/assets/1ae9f6fd-ba53-46e1-9b74-230469c8d93a" />




</details>
