### PR TITLE
refactor: deprecate empty setActivity

### DIFF
--- a/@types/premid/index.d.ts
+++ b/@types/premid/index.d.ts
@@ -458,6 +458,12 @@ declare global {
      */
     getActivity(): PresenceData
     /**
+     * @deprecated this does not clear the activity. This just displays an Activity with just a name and an icon.
+     *
+     * Use `Presence#clearActivity` instead.
+     */
+    setActivity(): Promise<void>
+    /**
      * Sets the presence activity and sends it to the application.
      * @param data PresenceData or Slideshow
      * @link https://docs.premid.app/dev/presence/class#setactivitypresencedata-boolean


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Although an empty `.setActivity()` has its uses, most of the time the Activity developer meant to use `.clearActivity()`

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)
