### PR TITLE
fix(brkn.bio): update regex

### DIFF
--- a/websites/B/brkn.bio/metadata.json
+++ b/websites/B/brkn.bio/metadata.json
@@ -11,7 +11,7 @@
     "pt": "O link de bio definitivo para criadores e entusiastas cibernéticos. Personalize seu perfil, compartilhe suas redes sociais e acompanhe seu tráfego gratuitamente."
   },
   "url": "brkn.bio",
-  "regExp": "^https?://(www\\.)?brkn\\.bio/"
+  "regExp": "^https?[:][/][/](www[.])?brkn[.]bio[/]"
   "version": "1.0.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/B/brkn.bio/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/B/brkn.bio/assets/thumbnail.png",

--- a/websites/B/brkn.bio/metadata.json
+++ b/websites/B/brkn.bio/metadata.json
@@ -11,7 +11,7 @@
     "pt": "O link de bio definitivo para criadores e entusiastas cibernéticos. Personalize seu perfil, compartilhe suas redes sociais e acompanhe seu tráfego gratuitamente."
   },
   "url": "brkn.bio",
-  "regExp": "^https?[:][/][/]brkn[.]bio[/]",
+  "regExp": "^https?://(www\\.)?brkn\\.bio/"
   "version": "1.0.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/B/brkn.bio/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/B/brkn.bio/assets/thumbnail.png",

--- a/websites/B/brkn.bio/metadata.json
+++ b/websites/B/brkn.bio/metadata.json
@@ -11,7 +11,7 @@
     "pt": "O link de bio definitivo para criadores e entusiastas cibernéticos. Personalize seu perfil, compartilhe suas redes sociais e acompanhe seu tráfego gratuitamente."
   },
   "url": "brkn.bio",
-  "regExp": "^https?[:][/][/](www[.])?brkn[.]bio[/]"
+  "regExp": "^https?[:][/][/](www[.])?brkn[.]bio[/]",
   "version": "1.0.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/B/brkn.bio/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/B/brkn.bio/assets/thumbnail.png",

--- a/websites/B/brkn.bio/metadata.json
+++ b/websites/B/brkn.bio/metadata.json
@@ -12,7 +12,7 @@
   },
   "url": "brkn.bio",
   "regExp": "^https?[:][/][/](www[.])?brkn[.]bio[/]"
-  "version": "1.0.1",
+  "version": "1.0.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/B/brkn.bio/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/B/brkn.bio/assets/thumbnail.png",
   "color": "#ffffff",


### PR DESCRIPTION
## Description

Fix regexp to support `www.brkn.bio` URLs.

The website redirects users from `brkn.bio` to `www.brkn.bio`, but the previous regexp only matched non-www URLs, preventing the Presence from initializing correctly.

## Acknowledgements

* [x] I read the Activity Guidelines
* [x] I linted the code by running `npm run lint`
* [x] The PR title follows the repo's commit conventions

## Screenshots

<details>
<summary>Proof showing the modification is working as expected</summary>

N/A — small regexp fix.

</details>

