### PR TITLE
fix(FlickyStream): update domain

### DIFF
--- a/websites/F/FlickyStream/metadata.json
+++ b/websites/F/FlickyStream/metadata.json
@@ -11,7 +11,7 @@
   },
   "url": "flickystream.su",
   "regExp": "^https?[:][/][/](www[.])?flickystream[.]su[/]",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/F/FlickyStream/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/F/FlickyStream/assets/thumbnail.png",
   "color": "#E53935",

--- a/websites/F/FlickyStream/metadata.json
+++ b/websites/F/FlickyStream/metadata.json
@@ -9,8 +9,8 @@
   "description": {
     "en": "A streaming platform for movies, TV shows, and anime."
   },
-  "url": "flickystream.ru",
-  "regExp": "^https?[:][/][/](www[.])?flickystream[.]ru[/]",
+  "url": "flickystream.su",
+  "regExp": "^https?[:][/][/](www[.])?flickystream[.]su[/]",
   "version": "1.0.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/F/FlickyStream/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/F/FlickyStream/assets/thumbnail.png",


### PR DESCRIPTION
## Summary
- update FlickyStream metadata URL from flickystream.ru to flickystream.su
- update the activity regexp to match the new domain, including www

Closes #10879

## Verification
- git diff --check
- node metadata check: parsed websites/F/FlickyStream/metadata.json and verified the regexp matches https://flickystream.su/ and https://www.flickystream.su/ while no longer matching https://flickystream.ru/

Full repo lint was not run because dependencies are not installed in this local checkout.