### PR TITLE
feat(Terousd): add activity

### DIFF
--- a/websites/T/Terousd/iframe.ts
+++ b/websites/T/Terousd/iframe.ts
@@ -1,0 +1,13 @@
+const iframe = new iFrame()
+
+iframe.on('UpdateData', () => {
+  const video = document.querySelector<HTMLVideoElement>('video')
+
+  if (video && !Number.isNaN(video.duration)) {
+    iframe.send({
+      currTime: video.currentTime,
+      duration: video.duration,
+      paused: video.paused,
+    })
+  }
+})

--- a/websites/T/Terousd/metadata.json
+++ b/websites/T/Terousd/metadata.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "id": "1009426635780542475",
+    "name": "aethxrix"
+  },
+  "service": "Terousd",
+  "description": {
+    "en": "Terousd is a streaming site for movies and TV series."
+  },
+  "url": "stream.terousd.online",
+  "regExp": "^https?[:][/][/]stream[.]terousd[.]online[/]",
+  "version": "1.0.0",
+  "logo": "https://raw.githubusercontent.com/aethxrix/premid-assets/master/terousd/logo.png",
+  "thumbnail": "https://raw.githubusercontent.com/aethxrix/premid-assets/master/terousd/thumbnail.jpg",
+  "color": "#E50914",
+  "category": "videos",
+  "tags": [
+    "video",
+    "media",
+    "movies",
+    "shows"
+  ],
+  "iframe": true,
+  "iFrameRegExp": "^https?[:][/][/]((stream[.]terousd[.]online[/]api[/]embed)|(([a-z0-9-]+[.])*(vsembed[.]su|vidking[.]net|vidnest[.]fun|vidlink[.]pro))[/])",
+  "settings": [
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "icon": "fad fa-user-secret",
+      "value": false
+    },
+    {
+      "id": "thumbnail",
+      "title": "Show Thumbnail",
+      "icon": "fad fa-images",
+      "value": true
+    },
+    {
+      "id": "browsingStatus",
+      "title": "Show Browsing Status",
+      "icon": "fad fa-book-reader",
+      "value": true
+    },
+    {
+      "id": "hideWhenPaused",
+      "title": "Hide When Paused",
+      "icon": "fas fa-pause",
+      "value": false
+    }
+  ]
+}

--- a/websites/T/Terousd/presence.ts
+++ b/websites/T/Terousd/presence.ts
@@ -1,0 +1,142 @@
+import { ActivityType, Assets, getTimestamps, getTimestampsFromMedia } from 'premid'
+
+const presence = new Presence({
+  clientId: '1495463888920117410',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://raw.githubusercontent.com/aethxrix/premid-assets/master/terousd/logo.png',
+}
+
+interface VideoInfo {
+  currTime: number
+  duration: number
+  paused: boolean
+}
+
+let iframeVideo: VideoInfo | undefined
+
+presence.on('iFrameData', (data) => {
+  iframeVideo = data as VideoInfo
+})
+
+function getTitle() {
+  return document
+    .querySelector('.details-title, .detail-title, h1')
+    ?.textContent
+    ?.trim()
+    || document.title.replace(/\s[-\u2014]\sTerousd$/, '').trim()
+}
+
+function getPoster() {
+  return document
+    .querySelector<HTMLImageElement>('#details-poster, #detail-poster, .detail-poster-img')
+    ?.src
+}
+
+function getEpisodeInfo() {
+  return document
+    .querySelector('.episode-name')
+    ?.textContent
+    ?.trim()
+    || [
+      document.querySelector<HTMLSelectElement>('.watch-season-select')?.selectedOptions[0]?.textContent,
+      document.querySelector<HTMLSelectElement>('.watch-episode-select')?.selectedOptions[0]?.textContent,
+    ].filter(Boolean).join(', ')
+}
+
+presence.on('UpdateData', async () => {
+  const [privacy, thumbnail, browsingStatus, hideWhenPaused] = await Promise.all([
+    presence.getSetting<boolean>('privacy'),
+    presence.getSetting<boolean>('thumbnail'),
+    presence.getSetting<boolean>('browsingStatus'),
+    presence.getSetting<boolean>('hideWhenPaused'),
+  ])
+
+  const { href, pathname, search } = document.location
+  const searchParams = new URLSearchParams(search)
+  const title = getTitle()
+  const poster = getPoster()
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    type: ActivityType.Watching,
+    startTimestamp: browsingTimestamp,
+  }
+
+  if (pathname.startsWith('/watch')) {
+    presenceData.details = 'Watching'
+    presenceData.state = privacy ? 'A title' : title
+
+    const episodeInfo = getEpisodeInfo()
+    if (!privacy && episodeInfo)
+      presenceData.largeImageText = episodeInfo
+
+    const video = document.querySelector<HTMLVideoElement>('video')
+    if (video && !Number.isNaN(video.duration)) {
+      if (!video.paused)
+        [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestampsFromMedia(video)
+      else if (hideWhenPaused)
+        return presence.clearActivity()
+
+      presenceData.smallImageKey = video.paused ? Assets.Pause : Assets.Play
+      presenceData.smallImageText = video.paused ? 'Paused' : 'Playing'
+    }
+    else if (iframeVideo && !Number.isNaN(iframeVideo.duration)) {
+      if (!iframeVideo.paused && iframeVideo.duration) {
+        [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestamps(
+          Math.floor(iframeVideo.currTime),
+          Math.floor(iframeVideo.duration),
+        )
+      }
+      else if (hideWhenPaused) {
+        return presence.clearActivity()
+      }
+
+      presenceData.smallImageKey = iframeVideo.paused ? Assets.Pause : Assets.Play
+      presenceData.smallImageText = iframeVideo.paused ? 'Paused' : 'Playing'
+    }
+    else {
+      presenceData.smallImageKey = Assets.Play
+      presenceData.smallImageText = 'Watching'
+    }
+  }
+  else if (browsingStatus) {
+    presenceData.smallImageKey = Assets.Reading
+    presenceData.smallImageText = 'Browsing'
+
+    if (pathname === '/' || pathname.startsWith('/home')) {
+      presenceData.details = 'Browsing'
+      presenceData.state = 'Home'
+    }
+    else if (pathname.startsWith('/movies')) {
+      presenceData.details = 'Browsing'
+      presenceData.state = 'Movies'
+    }
+    else if (pathname.startsWith('/tvshows')) {
+      presenceData.details = 'Browsing'
+      presenceData.state = 'TV Shows'
+    }
+    else if (pathname.startsWith('/search')) {
+      presenceData.details = 'Searching'
+      presenceData.state = privacy ? 'Titles' : searchParams.get('q') || 'Titles'
+      presenceData.smallImageKey = Assets.Search
+      presenceData.smallImageText = 'Searching'
+    }
+    else if (pathname.startsWith('/title')) {
+      presenceData.details = 'Viewing a title'
+      presenceData.state = privacy ? 'Details' : title
+      presenceData.buttons = [{ label: 'View Title', url: href }]
+    }
+  }
+  else {
+    return presence.clearActivity()
+  }
+
+  if (thumbnail && poster && !privacy)
+    presenceData.largeImageKey = poster
+
+  if (presenceData.details)
+    presence.setActivity(presenceData)
+  else presence.clearActivity()
+})


### PR DESCRIPTION
﻿## Summary
- Add a new PreMiD activity for Terousd (`stream.terousd.online`)
- Show browsing, search, title detail, and watch-page rich presence states
- Add iframe video playback support for supported embed providers

## Validation
- `npx.cmd pmd build "Terousd" --validate --no-kill`
- `npx.cmd eslint websites/T/Terousd/presence.ts websites/T/Terousd/iframe.ts`
- Locally verified Discord rich presence for browsing and watching states
