### PR TITLE
fix(Nintendo Music): use MediaSession API

### DIFF
--- a/websites/N/Nintendo Music/metadata.json
+++ b/websites/N/Nintendo Music/metadata.json
@@ -16,7 +16,7 @@
   },
   "url": "music.nintendo.com",
   "regExp": "^https?[:][/][/]music[.]nintendo[.]com[/]",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/N/Nintendo%20Music/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/N/Nintendo%20Music/assets/thumbnail.png",
   "color": "#FC2C00",

--- a/websites/N/Nintendo Music/presence.ts
+++ b/websites/N/Nintendo Music/presence.ts
@@ -9,13 +9,13 @@ presence.on('UpdateData', async () => {
   const { pathname } = document.location
   const title = document.title
   const audio = document.querySelector('audio')
-  const isPlaying = !!document.querySelector('[aria-label="Pause"]')
-  const currentTime = audio?.currentTime || 0
-  const duration = audio?.duration || 0
+  const mediaSession = navigator.mediaSession
+  const isPlaying = mediaSession.playbackState === 'playing'
+  const currentTime = audio?.currentTime ?? 0
+  const duration = audio?.duration || 0 // NOTE: audio.duration is NaN before loadedmetadata fires
   const now = Math.floor(Date.now() / 1000)
 
-  const songArt = document.querySelector<HTMLImageElement>('[aria-label="Playback panel"] img')?.src || NintendoMusicLogo
-  const albumArt = document.querySelector<HTMLImageElement>('#main-column img')?.src || NintendoMusicLogo
+  const albumArt = document.querySelector<HTMLImageElement>('#main-column img')?.src ?? NintendoMusicLogo
 
   const [showTimestamps, showSongArt] = await Promise.all([
     presence.getSetting<boolean>('showTimestamps'),
@@ -27,10 +27,10 @@ presence.on('UpdateData', async () => {
     type: ActivityType.Listening,
   }
 
-  if (isPlaying && title.includes(' - Nintendo Music')) {
-    const parts = title.replace(' - Nintendo Music', '').trim().split(/[・·]/)
-    const songName = parts[0]?.trim() || 'Unknown'
-    const gameName = parts[1]?.trim() || 'Nintendo'
+  if (isPlaying && mediaSession?.metadata) {
+    const songArt = mediaSession.metadata.artwork?.[0]?.src ?? NintendoMusicLogo
+    const songName = mediaSession.metadata.title ?? 'Unknown'
+    const gameName = mediaSession.metadata.album ?? 'Nintendo'
 
     presenceData.details = songName
     presenceData.state = gameName
@@ -47,7 +47,7 @@ presence.on('UpdateData', async () => {
   }
   else if (pathname.includes('/game')) {
     const parts = title.replace(' - Nintendo Music', '').trim().split(/[・·]/)
-    const gameName = parts[1]?.trim() || 'Nintendo'
+    const gameName = parts[1]?.trim() ?? 'Nintendo'
     const mainTitle = document.querySelector('#main-column h1')?.textContent
 
     presenceData.details = `Browsing ${mainTitle}`
@@ -60,7 +60,7 @@ presence.on('UpdateData', async () => {
   }
   else if (pathname.includes('/user-playlist')) {
     const parts = title.replace(' - Nintendo Music', '').trim().split(/[・·]/)
-    const songName = parts[0]?.trim() || 'Unknown'
+    const songName = parts[0]?.trim() ?? 'Unknown'
 
     presenceData.details = songName
     presenceData.state = 'Personal Playlist'
@@ -72,7 +72,7 @@ presence.on('UpdateData', async () => {
   }
   else if (pathname.includes('/playlist')) {
     const parts = title.replace(' - Nintendo Music', '').trim().split(/[・·]/)
-    const songName = parts[0]?.trim() || 'Unknown'
+    const songName = parts[0]?.trim() ?? 'Unknown'
 
     presenceData.details = songName
     presenceData.state = 'Official Playlist'


### PR DESCRIPTION
## Description
Replaced DOM-based detection with the MediaSession API.

| | Before | After |
|---|---|---|
| Playback state | `[aria-label="Pause"]` selector | `mediaSession.playbackState` |
| Song name | `document.title` parse | `mediaSession.metadata.title` |
| Game name | `document.title` parse | `mediaSession.metadata.album` |
| Artwork | `[aria-label="Playback panel"] img` | `mediaSession.metadata.artwork` |

* `aria-label` values may not work due to localization

Also replaces `||` with `??` for string fallbacks.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

Search Official PlayList
<img width="438" height="155" alt="image" src="https://github.com/user-attachments/assets/49daf675-164d-46a4-9b8c-983b0c941d80" />

Playing Music
<img width="438" height="155" alt="image" src="https://github.com/user-attachments/assets/7d0f6356-b9a9-4c7b-9649-ee0f8d1c76dc" />

<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
