### PR TITLE
feat(ZDFmediathek): show current title, cover and add settings

### DIFF
--- a/websites/Z/ZDFmediathek/metadata.json
+++ b/websites/Z/ZDFmediathek/metadata.json
@@ -12,7 +12,7 @@
   },
   "url": "www.zdf.de",
   "regExp": "^https?[:][/][/](www[.])?zdf[.]de[/]",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/Z/ZDFmediathek/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Z/ZDFmediathek/assets/thumbnail.jpg",
   "color": "#FE7405",
@@ -20,5 +20,92 @@
   "tags": [
     "videos",
     "livestreams"
+  ],
+  "settings": [
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "icon": "fad fa-user-secret",
+      "value": false,
+      "description": "Hide what you are watching and only show that you are browsing ZDFmediathek."
+    },
+    {
+      "id": "hidePaused",
+      "title": "Hide on Pause",
+      "icon": "fad fa-pause-circle",
+      "value": false,
+      "if": {
+        "privacy": false
+      },
+      "description": "Clear the activity while the video is paused."
+    },
+    {
+      "id": "cover",
+      "title": "Show Cover Image",
+      "icon": "fas fa-image",
+      "value": true,
+      "if": {
+        "privacy": false
+      },
+      "description": "Display the show's cover as the large image instead of the ZDF logo."
+    },
+    {
+      "id": "channelLogo",
+      "title": "Show Channel Logo as Small Icon",
+      "icon": "fas fa-tv",
+      "value": true,
+      "if": {
+        "privacy": false
+      },
+      "description": "Use the broadcaster's logo (ZDF, 3sat, ZDFneo, …) as the small icon while playing. When disabled, the classic play/pause icon is shown instead."
+    },
+    {
+      "id": "timestamps",
+      "title": "Show Timestamps",
+      "icon": "fad fa-stopwatch",
+      "value": true,
+      "description": "Show the elapsed and remaining time of the video."
+    },
+    {
+      "id": "buttons",
+      "title": "Show Buttons",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "privacy": false
+      },
+      "description": "Display interactive buttons in the Discord activity."
+    },
+    {
+      "id": "vidDetail",
+      "title": "Details (top line)",
+      "icon": "fas fa-comment-alt-edit",
+      "value": "%title%",
+      "if": {
+        "privacy": false
+      },
+      "placeholder": "Use %title%, %series%, %episode%, %genre%, %year%"
+    },
+    {
+      "id": "vidState",
+      "title": "State (bottom line)",
+      "icon": "fas fa-comment-alt-edit",
+      "value": "%series%",
+      "if": {
+        "privacy": false
+      },
+      "placeholder": "Same as top line, or use {0} to remove the row completely"
+    },
+    {
+      "id": "displayType",
+      "title": "Pick Status Display",
+      "icon": "fad fa-user-edit",
+      "value": 2,
+      "values": [
+        "Activity Name",
+        "Details",
+        "State"
+      ]
+    }
   ]
 }

--- a/websites/Z/ZDFmediathek/presence.ts
+++ b/websites/Z/ZDFmediathek/presence.ts
@@ -104,7 +104,7 @@ function readOverlay(): VideoInfo | undefined {
       info.channel = token
   }
   // First token is the primary genre (skip subtitle/audio-description flags).
-  info.genre = tokens.find(t => !/^(UT|AD|F\d+|\d{4}|\d+\s*min)$/i.test(t) && !channelKey(t))
+  info.genre = tokens.find(t => !/^(?:UT|AD|F\d+|\d{4}|\d+\s*min)$/i.test(t) && !channelKey(t))
 
   return info
 }
@@ -188,7 +188,9 @@ presence.on('UpdateData', async () => {
     const fallbackTitle = info.title ?? ogTitle ?? document.title
 
     const hasMedia = !!video && !Number.isNaN(video.duration)
-    const live = !!video && !Number.isFinite(video.duration)
+    // Only treat as live once metadata has loaded, otherwise a NaN duration
+    // (still loading) would briefly flag a VOD as live.
+    const live = hasMedia && !Number.isFinite(video!.duration)
 
     presenceData.name = info.series ?? ogTitle ?? 'ZDFmediathek'
     presenceData.details = format(vidDetail || '%title%', info, fallbackTitle) || fallbackTitle
@@ -275,6 +277,7 @@ presence.on('UpdateData', async () => {
 
   // Privacy mode: only reveal that the user is on ZDFmediathek.
   if (privacy) {
+    presenceData.name = 'ZDFmediathek'
     presenceData.details = localized.browsing
     delete presenceData.state
     delete presenceData.smallImageKey
@@ -293,5 +296,5 @@ presence.on('UpdateData', async () => {
 
   if (presenceData.details)
     presence.setActivity(presenceData)
-  else presence.setActivity()
+  else presence.clearActivity()
 })

--- a/websites/Z/ZDFmediathek/presence.ts
+++ b/websites/Z/ZDFmediathek/presence.ts
@@ -1,9 +1,30 @@
-import { ActivityType, Assets, getTimestamps } from 'premid'
+import { ActivityType, Assets, getTimestampsFromMedia, StatusDisplayType } from 'premid'
 
-let elapsed = Math.floor(Date.now() / 1000)
-let prevUrl = document.location.href
+const presence = new Presence({
+  clientId: '854999470357217290',
+})
 
-const assets = {
+// Localized strings: displayed in the viewer's Discord language.
+const strings = presence.getStrings({
+  play: 'general.playing',
+  pause: 'general.paused',
+  live: 'general.live',
+  browsing: 'general.browsing',
+  search: 'general.search',
+  viewHome: 'general.viewHome',
+  viewSeries: 'general.viewSeries',
+  buttonWatchVideo: 'general.buttonWatchVideo',
+  buttonWatchStream: 'general.buttonWatchStream',
+  buttonViewSeries: 'general.buttonViewSeries',
+})
+
+enum ActivityAssets {
+  Logo = 'https://cdn.rcd.gg/PreMiD/websites/Z/ZDFmediathek/assets/logo.png',
+}
+
+// Broadcaster logos (existing assets) keyed by the brand shown in a video's
+// info line / live channel name.
+const channelAssets: Record<string, string> = {
   'zdf': 'https://cdn.rcd.gg/PreMiD/websites/Z/ZDFmediathek/assets/0.png',
   '3sat': 'https://cdn.rcd.gg/PreMiD/websites/Z/ZDFmediathek/assets/1.png',
   'phoenix': 'https://cdn.rcd.gg/PreMiD/websites/Z/ZDFmediathek/assets/2.png',
@@ -12,119 +33,262 @@ const assets = {
   'zdfneo': 'https://cdn.rcd.gg/PreMiD/websites/Z/ZDFmediathek/assets/5.png',
   'kika': 'https://cdn.rcd.gg/PreMiD/websites/Z/ZDFmediathek/assets/6.png',
 }
-const presence = new Presence({
-  clientId: '854999470357217290',
-})
-// TODO: Add multiLang
-const strings = presence.getStrings({
-  play: 'general.playing',
-  pause: 'general.paused',
-  browsing: 'general.browsing',
-  browsingThrough: 'discord.browseThrough',
-  buttonWatchVideo: 'general.buttonWatchVideo',
-  buttonWatchStream: 'general.buttonWatchStream',
-})
+
+interface VideoInfo {
+  series?: string
+  seriesUrl?: string
+  title?: string
+  episode?: string
+  genre?: string
+  year?: string
+  channel?: string
+}
+
+/**
+ * The player overlay (series link, episode title, info line) only lives in the
+ * DOM while the controls/overlay are visible. The values never change for a
+ * given video, so we capture them per-URL and keep showing them during
+ * playback even after the overlay fades out. The `<meta og:*>` tags in the head
+ * are always present and act as a fallback.
+ */
+const infoCache = new Map<string, VideoInfo>()
+
+let browsingTimestamp = Math.floor(Date.now() / 1000)
+let prevPath = document.location.pathname
+
+function getMeta(property: string): string | undefined {
+  return (
+    document.querySelector<HTMLMetaElement>(`meta[property="${property}"]`)?.content
+    ?? document.querySelector<HTMLMetaElement>(`meta[name="${property}"]`)?.content
+    ?? undefined
+  )
+}
+
+/** Normalizes a broadcaster name ("KiKA", "3sat", "ZDFinfo") to an asset key. */
+function channelKey(name?: string): string | undefined {
+  if (!name)
+    return undefined
+  const key = name.toLowerCase().replace(/[\s.]/g, '').replace('ki.ka', 'kika')
+  return key in channelAssets ? key : undefined
+}
+
+/**
+ * Reads the player overlay around the "more about this show" link.
+ * Anchored on the stable `.zdfplayer-icon-return` player-library class rather
+ * than the build-hashed Svelte class names, which change on every deploy.
+ */
+function readOverlay(): VideoInfo | undefined {
+  const link
+    = document.querySelector<HTMLAnchorElement>('a[title^="mehr zu"]')
+      ?? document.querySelector('.zdfplayer-icon-return')?.closest('a')
+  if (!link)
+    return undefined
+
+  const info: VideoInfo = {}
+  info.series = (link.querySelector('span')?.textContent ?? link.textContent)?.trim()
+  info.seriesUrl = link.href
+
+  // The link sits in a wrapper next to the <h2> title and <p> info line.
+  const container = link.closest('div')?.parentElement
+  info.title = container?.querySelector('h2')?.textContent?.trim()
+
+  const infoLine = container?.querySelector('p')?.textContent ?? ''
+  // e.g. "Musik • Dokumentation • authentisch • UT • F03 • 27 min • 2026 • ZDF"
+  const tokens = infoLine.split('•').map(t => t.trim()).filter(Boolean)
+  for (const token of tokens) {
+    if (/^\d{4}$/.test(token))
+      info.year = token
+    else if (/^F\d+$/i.test(token))
+      info.episode = `Folge ${Number(token.slice(1))}`
+    else if (channelKey(token))
+      info.channel = token
+  }
+  // First token is the primary genre (skip subtitle/audio-description flags).
+  info.genre = tokens.find(t => !/^(UT|AD|F\d+|\d{4}|\d+\s*min)$/i.test(t) && !channelKey(t))
+
+  return info
+}
+
+function format(template: string, info: VideoInfo, fallbackTitle: string): string {
+  return template
+    .replace(/%title%/gi, info.title || fallbackTitle)
+    .replace(/%series%/gi, info.series ?? '')
+    .replace(/%episode%/gi, info.episode ?? '')
+    .replace(/%genre%/gi, info.genre ?? '')
+    .replace(/%year%/gi, info.year ?? '')
+    .trim()
+}
 
 presence.on('UpdateData', async () => {
-  const presenceData: PresenceData = {
-    largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/Z/ZDFmediathek/assets/logo.png',
-  } as PresenceData
-  const video = document.querySelector<HTMLVideoElement>(
-    'div.zdfplayer-video-container video',
-  )
+  const { pathname, href, search } = document.location
 
-  if (document.location.href !== prevUrl) {
-    prevUrl = document.location.href
-    elapsed = Math.floor(Date.now() / 1000)
+  if (pathname !== prevPath) {
+    prevPath = pathname
+    browsingTimestamp = Math.floor(Date.now() / 1000)
   }
 
-  if (video) {
-    presenceData.type = ActivityType.Watching
-    if (location.pathname.startsWith('/live-tv')) {
-      // Livestream
-      const mediathekLivechannel = document
-        .querySelector<HTMLHeadingElement>(
-          'div.m-active h2[class=\'visuallyhidden\']',
-        )
-        ?.textContent
-        ?.replace(/ {2}/g, ' ')
-        .replaceAll(' im Livestream', '')
-        .replaceAll(' Livestream', '')
-      let livename = mediathekLivechannel
-      switch (livename) {
-        case 'phoenix':
-          livename = 'PHOENIX'
-          break
-        case 'KiKA':
-          livename = 'KI\\.KA'
-          break
-        default:
-      }
-      const channel = document.querySelector<HTMLHeadingElement>(
-        `section.timeline-${livename} ul li.m-live h4 a span`,
-      )
-      const videoInfoTag = document
-        .querySelector<HTMLHeadingElement>(
-          `section.timeline-${livename} ul li.m-live h4 a`,
-        )
-        ?.getAttribute('aria-label')
-        ?.replace(mediathekLivechannel ?? '', '')
-      let channelname = ''
-      if (channel?.textContent && channel.textContent !== ':')
-        channelname = channel.textContent.replace(':', ' -')
-      presenceData.largeImageKey = assets[mediathekLivechannel?.toLowerCase() as keyof typeof assets]
-      presenceData.smallImageKey = Assets.Live
-      presenceData.smallImageText = 'Live'
-      presenceData.details = videoInfoTag
-      presenceData.state = `${channelname}${mediathekLivechannel} Live`
-      presenceData.startTimestamp = elapsed
-      presenceData.buttons = [
-        { label: (await strings).buttonWatchStream, url: prevUrl },
-      ]
+  const [
+    privacy,
+    hidePaused,
+    showCover,
+    channelLogo,
+    timestamps,
+    showButtons,
+    vidDetail,
+    vidState,
+    displayType,
+  ] = await Promise.all([
+    presence.getSetting<boolean>('privacy'),
+    presence.getSetting<boolean>('hidePaused'),
+    presence.getSetting<boolean>('cover'),
+    presence.getSetting<boolean>('channelLogo'),
+    presence.getSetting<boolean>('timestamps'),
+    presence.getSetting<boolean>('buttons'),
+    presence.getSetting<string>('vidDetail'),
+    presence.getSetting<string>('vidState'),
+    presence.getSetting<number>('displayType'),
+  ])
 
-      if (
-        document.querySelector<HTMLVideoElement>(
-          'div.m-active div figure div div video',
-        )?.paused
-      ) {
-        presenceData.smallImageKey = Assets.Pause
-        presenceData.smallImageText = (await strings).pause
-        delete presenceData.startTimestamp
-        delete presenceData.endTimestamp
-      }
+  const localized = await strings
+  const video = document.querySelector<HTMLVideoElement>(
+    '.zdfplayer-video-container video',
+  )
+  // The selector only matches the main player, so a mounted player is a
+  // reliable "watching" signal even on live URLs that aren't under /play.
+  const isWatchPage
+    = /^\/(?:play|video)\//.test(pathname)
+      || (!!video && !Number.isNaN(video.duration))
+
+  const presenceData: PresenceData = {
+    type: ActivityType.Watching,
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+  }
+
+  switch (displayType) {
+    case 0:
+      presenceData.statusDisplayType = StatusDisplayType.Name
+      break
+    case 1:
+      presenceData.statusDisplayType = StatusDisplayType.Details
+      break
+    default:
+      presenceData.statusDisplayType = StatusDisplayType.State
+  }
+
+  if (isWatchPage) {
+    // Keep the per-URL info cache warm whenever the overlay is in the DOM.
+    const overlay = readOverlay()
+    if (overlay && (overlay.title || overlay.series))
+      infoCache.set(href, overlay)
+    const info = infoCache.get(href) ?? overlay ?? {}
+
+    const ogTitle = getMeta('og:title')
+    const cover = getMeta('og:image')
+    const fallbackTitle = info.title ?? ogTitle ?? document.title
+
+    const hasMedia = !!video && !Number.isNaN(video.duration)
+    const live = !!video && !Number.isFinite(video.duration)
+
+    presenceData.name = info.series ?? ogTitle ?? 'ZDFmediathek'
+    presenceData.details = format(vidDetail || '%title%', info, fallbackTitle) || fallbackTitle
+
+    const stateText = vidState?.includes('{0}')
+      ? ''
+      : format(vidState || '%series%', info, fallbackTitle)
+    if (stateText)
+      presenceData.state = stateText
+
+    presenceData.largeImageKey = showCover !== false && cover ? cover : ActivityAssets.Logo
+    presenceData.largeImageText = info.series ?? ogTitle
+
+    const channel = channelKey(info.channel)
+    const paused = !!video?.paused
+
+    if (channelLogo !== false && channel && hasMedia && !paused) {
+      presenceData.smallImageKey = channelAssets[channel]
+      presenceData.smallImageText = info.channel
+    }
+    else if (live) {
+      presenceData.smallImageKey = Assets.Live
+      presenceData.smallImageText = localized.live
     }
     else {
-      // Video-on-demand
-      presenceData.largeImageKey = 'https://cdn.rcd.gg/PreMiD/websites/Z/ZDFmediathek/assets/logo.png'
-      presenceData.smallImageKey = Assets.Play
-      presenceData.smallImageText = (await strings).play
+      presenceData.smallImageKey = paused ? Assets.Pause : Assets.Play
+      presenceData.smallImageText = paused ? localized.pause : localized.play
+    }
 
-      presenceData.state = document.querySelector(
-        'ol li:nth-last-child(2) a',
-      )?.textContent
-      presenceData.details = document.querySelector(
-        'ol li:nth-last-child(1) span',
-      )?.textContent;
-      [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestamps(
-        Math.floor(video.currentTime),
-        Math.floor(video.duration),
-      )
+    if (hasMedia && !paused && !live && timestamps !== false) {
+      [presenceData.startTimestamp, presenceData.endTimestamp]
+        = getTimestampsFromMedia(video!)
+    }
+    else {
+      delete presenceData.endTimestamp
+    }
+
+    if (hidePaused && hasMedia && paused)
+      return presence.clearActivity()
+
+    if (showButtons !== false) {
       presenceData.buttons = [
-        { label: (await strings).buttonWatchVideo, url: prevUrl },
+        { label: live ? localized.buttonWatchStream : localized.buttonWatchVideo, url: href },
       ]
-      if (video.paused) {
-        presenceData.smallImageKey = Assets.Pause
-        presenceData.smallImageText = (await strings).pause
-        delete presenceData.startTimestamp
-        delete presenceData.endTimestamp
+      if (info.seriesUrl) {
+        presenceData.buttons.push({
+          label: localized.buttonViewSeries,
+          url: info.seriesUrl,
+        })
       }
     }
   }
-  else {
+  else if (pathname === '/') {
+    presenceData.details = localized.viewHome
+  }
+  else if (pathname.startsWith('/suche')) {
+    presenceData.details = localized.search
+    presenceData.state
+      = document.querySelector<HTMLInputElement>('input[type="search"], input[type="text"]')?.value
+        || new URLSearchParams(search).get('q')
+        || undefined
+    presenceData.smallImageKey = Assets.Search
+  }
+  else if (pathname === '/live-tv') {
+    presenceData.details = localized.browsing
+    presenceData.state = 'Live & TV'
     presenceData.smallImageKey = Assets.Reading
-    presenceData.smallImageText = (await strings).browsingThrough
-    presenceData.details = (await strings).browsing
-    presenceData.startTimestamp = elapsed
+  }
+  else {
+    const segments = pathname.split('/').filter(Boolean)
+    const heading = document.querySelector('h1')?.textContent?.trim()
+    // A show/series detail page ends in a "-<number>" content slug.
+    if (segments.length > 1 && /-\d+$/.test(segments.at(-1)!)) {
+      presenceData.details = localized.viewSeries
+      presenceData.state = heading ?? getMeta('og:title')
+    }
+    else {
+      // Category landing pages (/dokus, /serien, /filme, /kinder …).
+      presenceData.details = localized.browsing
+      presenceData.state = heading ?? document.title
+    }
+    presenceData.smallImageKey = Assets.Reading
+  }
+
+  // Privacy mode: only reveal that the user is on ZDFmediathek.
+  if (privacy) {
+    presenceData.details = localized.browsing
+    delete presenceData.state
+    delete presenceData.smallImageKey
+    delete presenceData.smallImageText
+    delete presenceData.largeImageText
+    delete presenceData.buttons
+    delete presenceData.endTimestamp
+    presenceData.largeImageKey = ActivityAssets.Logo
+    presenceData.startTimestamp = browsingTimestamp
+  }
+
+  if (timestamps === false) {
+    delete presenceData.startTimestamp
+    delete presenceData.endTimestamp
   }
 
   if (presenceData.details)


### PR DESCRIPTION
## Description

Reworks the **ZDFmediathek** activity for the current (Svelte-based) ZDF site. The redesign of `zdf.de` (`/play/…`, `/dokus/…`) broke the old breadcrumb-based selectors, so the activity showed essentially nothing on video-on-demand pages.

### Watching
- Shows the playing video's **title**, **series** and parsed info (**episode**, **genre**, **year**, **broadcaster**) with the **cover art** as the large image.
- Anchored on stable selectors (`og:` meta tags, `.zdfplayer-*` player classes) instead of the build-hashed Svelte class names, which change on every deploy.
- Caches the player overlay (series / episode / info line) **per URL**, so the details persist while the controls overlay is hidden during playback.
- Detects **live streams** via the media duration instead of the URL path (live now also plays via `/play/` URLs).
- Reuses the existing broadcaster assets (ZDF, 3sat, ZDFneo, ZDFinfo, arte, KiKA, phoenix) as the small icon.

### Browsing
- Adds presence for series pages, category landing pages (`/dokus`, `/serien`, `/filme`, `/kinder`, …), search (`/suche`) and the live overview (`/live-tv`).

### Settings (new)
Privacy mode · Hide on pause · Cover image · Channel logo as small icon · Timestamps · Buttons · Format strings (`%title%`, `%series%`, `%episode%`, `%genre%`, `%year%`) · Status display type.

Version bumped `1.1.1` → `2.0.0`. No new assets required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)