### PR TITLE
feat(OpenJam): add activity

### DIFF
--- a/websites/O/OpenJam/metadata.json
+++ b/websites/O/OpenJam/metadata.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "name": "Chaitanyahoon",
+    "id": "161548359"
+  },
+  "service": "OpenJam",
+  "description": {
+    "de": "Gemeinsam in Echtzeit hören. OpenJam ist eine synchronisierte Musik-Hörparty-Plattform.",
+    "en": "Listen together in real-time. OpenJam is a synchronized music listening party platform.",
+    "es": "Escuchen juntos en tiempo real. OpenJam es una plataforma de fiestas de escucha musical sincronizadas.",
+    "fr": "Écoutez ensemble en temps réel. OpenJam est une plateforme de soirée d'écoute musicale synchronisée.",
+    "pt": "Ouçam juntos em tempo real. OpenJam é uma plataforma de festa de audição musical sincronizada."
+  },
+  "url": "openjam.fun",
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*openjam[.]fun[/]",
+  "version": "1.0.0",
+  "logo": "https://files.catbox.moe/oz8aca.png",
+  "thumbnail": "https://files.catbox.moe/yjqyp3.png",
+  "color": "#6366f1",
+  "category": "music",
+  "tags": [
+    "music",
+    "spotify",
+    "youtube",
+    "listen-together",
+    "party",
+    "synchronized"
+  ],
+  "settings": [
+    {
+      "id": "buttons",
+      "title": "Show Join Button",
+      "icon": "fas fa-link",
+      "value": true
+    },
+    {
+      "id": "timestamps",
+      "title": "Show Timestamps",
+      "icon": "fas fa-clock",
+      "value": true
+    }
+  ]
+}

--- a/websites/O/OpenJam/presence.ts
+++ b/websites/O/OpenJam/presence.ts
@@ -1,0 +1,70 @@
+const presence = new Presence({
+  clientId: '1514249657549586482',
+})
+
+let lastTrackTitle = ''
+let lastArtist = ''
+let elapsedSinceChange = 0
+
+presence.on('UpdateData', async () => {
+  const presenceData: PresenceData = {
+    largeImageKey: 'https://files.catbox.moe/oz8aca.png',
+  }
+
+  const [showButtons, showTimestamps] = await Promise.all([
+    presence.getSetting<boolean>('buttons'),
+    presence.getSetting<boolean>('timestamps'),
+  ])
+  const path = document.location.pathname
+
+  const roomMatch = path.match(/^\/room\/(.+)/)
+
+  if (roomMatch) {
+    const roomId = roomMatch[1]
+    const trackTitleEl = document.querySelector('[data-presence="track-name"], .mp-track-title')
+    const artistEl = document.querySelector('[data-presence="artist"], .mp-track-artist')
+    const playBtn = document.querySelector<HTMLButtonElement>('.mp-play-btn-large')
+    const isPlaying = playBtn?.title === 'Pause'
+
+    const trackTitle = trackTitleEl?.textContent?.trim() || ''
+    const artist = artistEl?.textContent?.trim() || ''
+
+    if (trackTitle && artist && trackTitle !== 'Nothing playing' && isPlaying) {
+      if (trackTitle !== lastTrackTitle || artist !== lastArtist) {
+        lastTrackTitle = trackTitle
+        lastArtist = artist
+        elapsedSinceChange = Date.now()
+      }
+
+      presenceData.details = trackTitle.substring(0, 127)
+      presenceData.state = `by ${artist.substring(0, 120)}`
+
+      if (showTimestamps) {
+        presenceData.startTimestamp = Math.floor(elapsedSinceChange / 1000)
+      }
+    }
+    else {
+      lastTrackTitle = ''
+      lastArtist = ''
+
+      presenceData.details = 'In a Jam Room'
+      presenceData.state = 'Waiting for music...'
+    }
+
+    if (showButtons) {
+      presenceData.buttons = [
+        {
+          label: 'Join Jam Room',
+          url: `${document.location.origin}/room/${roomId}`,
+        },
+      ]
+    }
+  }
+  else {
+    presenceData.details = 'Browsing OpenJam'
+    lastTrackTitle = ''
+    lastArtist = ''
+  }
+
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
Resubmitting the presence for OpenJam. The website is now hosted on a paid TLD: https://openjam.fun.

This is a clean recreation of the previous PR #10906 with a squashed commit history and all review comments addressed.

Closes #10901.