### PR TITLE
feat(MagentaTV): add activity

### DIFF
--- a/websites/M/MagentaTV Deutschland/metadata.json
+++ b/websites/M/MagentaTV Deutschland/metadata.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "id": "425706045453893642",
+    "name": "instabilspielt"
+  },
+  "service": "MagentaTV Deutschland",
+  "description": {
+    "de": "Schaue Live-TV, Filme und Serien auf MagentaTV Deutschland.",
+    "en": "Watch live TV, movies and series on MagentaTV Germany."
+  },
+  "url": "www.magenta.tv",
+  "regExp": "^https?:\\/\\/([a-z0-9-]+\\.)*magenta\\.tv\\/.*$",
+  "version": "1.0.0",
+  "logo": "https://www.telekom.de/resources/images/1066386/magenta-tv.png",
+  "thumbnail": "https://www.telekom.de/resources/images/1292150/stage-s-2x.webp",
+  "color": "#E20074",
+  "category": "videos",
+  "tags": [
+    "tv",
+    "streaming",
+    "live-tv",
+    "vod",
+    "telekom"
+  ]
+}

--- a/websites/M/MagentaTV Deutschland/metadata.json
+++ b/websites/M/MagentaTV Deutschland/metadata.json
@@ -11,9 +11,9 @@
     "en": "Watch live TV, movies and series on MagentaTV Germany."
   },
   "url": "www.magenta.tv",
-  "regExp": "^https?:\\/\\/([a-z0-9-]+\\.)*magenta\\.tv\\/.*$",
+  "regExp": "^https?:[/][/]([a-z0-9-]+[.])*magenta[.]tv[/]",
   "version": "1.0.0",
-  "logo": "https://www.telekom.de/resources/images/1066386/magenta-tv.png",
+  "logo": "https://is1-ssl.mzstatic.com/image/thumb/PurpleSource211/v4/cc/0e/46/cc0e4697-6748-4d0d-81b4-e882be3c7df6/Placeholder.mill/512x512.png",
   "thumbnail": "https://www.telekom.de/resources/images/1292150/stage-s-2x.webp",
   "color": "#E20074",
   "category": "videos",

--- a/websites/M/MagentaTV Deutschland/presence.ts
+++ b/websites/M/MagentaTV Deutschland/presence.ts
@@ -1,0 +1,91 @@
+import { ActivityType, Assets, getTimestampsFromMedia } from 'premid'
+
+const presence = new Presence({
+  clientId: '1518224294465900564',
+})
+
+presence.on('UpdateData', async () => {
+  const video = document.querySelector('video')
+
+  const title
+    = document.querySelector('#PARAGRAPH-TITLE')
+      ?.textContent
+      ?.trim()
+      || document.title.replace('MagentaTV - ', '').trim()
+
+  if (!title)
+    return presence.clearActivity()
+
+  const logoImage = document.querySelector(
+    '[id^="PARAGRAPH-LOGO"]',
+  ) as HTMLImageElement | null
+
+  const logoUrl = logoImage?.src
+    ?.replace(/x=\d+/, 'x=250')
+    ?.replace(/y=\d+/, 'y=250')
+    ?.replace('ar=keep', 'ar=ignore')
+
+  const isLive
+    = document.querySelector('#PLAYER-PREVIOUS-CHANNEL') !== null
+
+  const presenceData: PresenceData = {
+    type: ActivityType.Watching,
+    largeImageKey:
+      logoUrl
+      ?? 'https://www.telekom.de/resources/images/1066386/magenta-tv.png',
+  }
+
+  const parts = title.split(' - ')
+
+  if (parts.length >= 3) {
+    const seriesName = parts[0]!
+    const seasonEpisode = parts[1]!
+    const episodeTitle = parts.slice(2).join(' - ')
+
+    presenceData.name = seriesName
+    presenceData.details = episodeTitle
+    presenceData.state = seasonEpisode
+  }
+  else {
+    presenceData.details = title
+
+    if (isLive)
+      presenceData.state = 'Live TV'
+  }
+
+  const detailsLink = document.querySelector<HTMLAnchorElement>(
+    '#PLAYER-INFO-DETAILS',
+  )
+
+  if (detailsLink?.href) {
+    presenceData.buttons = [
+      {
+        label: 'View Details',
+        url: detailsLink.href,
+      },
+    ]
+  }
+
+  if (video instanceof HTMLVideoElement) {
+    const { paused } = video
+
+    presenceData.smallImageKey = isLive
+      ? Assets.Live
+      : paused
+        ? Assets.Pause
+        : Assets.Play
+
+    if (!paused) {
+      const [startTimestamp, endTimestamp]
+        = getTimestampsFromMedia(video)
+
+      presenceData.startTimestamp = startTimestamp
+      presenceData.endTimestamp = endTimestamp
+    }
+  }
+  else if (isLive) {
+    presenceData.smallImageKey = Assets.Live
+  }
+
+  presence.setActivity(presenceData)
+})

--- a/websites/M/MagentaTV Deutschland/presence.ts
+++ b/websites/M/MagentaTV Deutschland/presence.ts
@@ -5,7 +5,7 @@ const presence = new Presence({
 })
 
 presence.on('UpdateData', async () => {
-  const video = document.querySelector('video')
+  const video = document.querySelector<HTMLVideoElement>('video')
 
   const title
     = document.querySelector('#PARAGRAPH-TITLE')
@@ -16,9 +16,7 @@ presence.on('UpdateData', async () => {
   if (!title)
     return presence.clearActivity()
 
-  const logoImage = document.querySelector(
-    '[id^="PARAGRAPH-LOGO"]',
-  ) as HTMLImageElement | null
+  const logoImage = document.querySelector<HTMLImageElement>('[id^="PARAGRAPH-LOGO"]')
 
   const logoUrl = logoImage?.src
     ?.replace(/x=\d+/, 'x=250')
@@ -32,7 +30,7 @@ presence.on('UpdateData', async () => {
     type: ActivityType.Watching,
     largeImageKey:
       logoUrl
-      ?? 'https://www.telekom.de/resources/images/1066386/magenta-tv.png',
+      ?? 'https://is1-ssl.mzstatic.com/image/thumb/PurpleSource211/v4/cc/0e/46/cc0e4697-6748-4d0d-81b4-e882be3c7df6/Placeholder.mill/512x512.png',
   }
 
   const parts = title.split(' - ')
@@ -66,7 +64,7 @@ presence.on('UpdateData', async () => {
     ]
   }
 
-  if (video instanceof HTMLVideoElement) {
+  if (video) {
     const { paused } = video
 
     presenceData.smallImageKey = isLive


### PR DESCRIPTION
## Description
- Add a new **MagentaTV Deutschland** activity
- Detect live TV and VOD playback
- Display series name, episode title and season/episode information when available
- Show dynamic channel/service logos from the player
- Support playback timestamps and progress tracking
- Add a details button when a dedicated details page is available

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
**LiveTV Playback**, when series information is unavailable
<img width="280" height="114" alt="image" src="https://github.com/user-attachments/assets/586b22af-e69b-4671-b984-110cab9506ab" />

**LiveTV Playback**, when series information is available
<img width="277" height="114" alt="image" src="https://github.com/user-attachments/assets/3d461ae3-5b85-45f3-986b-5029084357c0" />

**VOD Playback**, when series information is available
<img width="283" height="113" alt="image" src="https://github.com/user-attachments/assets/eed0ac91-a430-402d-8eaa-8ebb76008941" />




