### PR TITLE
chore: migrate FontAwesome regular icons to solid

### DIFF
--- a/cli/src/commands/new.ts
+++ b/cli/src/commands/new.ts
@@ -101,7 +101,7 @@ export async function newActivity(activity?: string) {
   }).catch(() => exit('Something went wrong.'))
 
   const metadata = {
-    $schema: 'https://schemas.premid.app/metadata/1.16',
+    $schema: 'https://schemas.premid.app/metadata/1.17',
     apiVersion: 1,
     author,
     service: activity,

--- a/cli/src/util/getSchema.ts
+++ b/cli/src/util/getSchema.ts
@@ -1,3 +1,3 @@
 export async function getSchema() {
-  return (await fetch('https://schemas.premid.app/metadata/1.16')).json()
+  return (await fetch('https://schemas.premid.app/metadata/1.17')).json()
 }

--- a/websites/C/Crowdin/metadata.json
+++ b/websites/C/Crowdin/metadata.json
@@ -33,7 +33,7 @@
     "blog.crowdin.com"
   ],
   "regExp": "^https?[:][/][/]((support|store|status|blog|[a-z]{2})[.])?crowdin[.]com[/]",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/C/Crowdin/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/C/Crowdin/assets/thumbnail.png",
   "color": "#2e3340",
@@ -49,7 +49,7 @@
     {
       "id": "showProject",
       "title": "Show project names",
-      "icon": "fa-regular fa-tag",
+      "icon": "fa-solid fa-tag",
       "value": true
     },
     {

--- a/websites/D/Dropout/metadata.json
+++ b/websites/D/Dropout/metadata.json
@@ -14,7 +14,7 @@
     "watch.dropout.tv"
   ],
   "regExp": "^https?[:][/][/](www|watch)[.]dropout[.]tv[/]",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/D/Dropout/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/D/Dropout/assets/thumbnail.jpg",
   "color": "#ffe93b",
@@ -31,7 +31,7 @@
     {
       "id": "buttons",
       "title": "Show Buttons",
-      "icon": "fa-regular fa-rectangle-list",
+      "icon": "fa-solid fa-rectangle-list",
       "value": true
     }
   ]

--- a/websites/N/Nebula/metadata.json
+++ b/websites/N/Nebula/metadata.json
@@ -17,7 +17,7 @@
   },
   "url": "nebula.tv",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*nebula[.]tv[/]",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/N/Nebula/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/N/Nebula/assets/thumbnail.jpeg",
   "color": "#67bef5",
@@ -30,7 +30,7 @@
     {
       "id": "buttons",
       "title": "Show Buttons",
-      "icon": "fa-regular fa-rectangle-list",
+      "icon": "fa-solid fa-rectangle-list",
       "value": true
     }
   ]

--- a/websites/N/neal.fun/metadata.json
+++ b/websites/N/neal.fun/metadata.json
@@ -11,7 +11,7 @@
   },
   "url": "neal.fun",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*neal[.]fun[/]",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/N/neal.fun/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/N/neal.fun/assets/thumbnail.png",
   "color": "#606060",
@@ -26,7 +26,7 @@
     {
       "id": "buttons",
       "title": "Show Buttons",
-      "icon": "fa-regular fa-rectangle-list",
+      "icon": "fa-solid fa-rectangle-list",
       "value": true
     },
     {

--- a/websites/R/Rythm/metadata.json
+++ b/websites/R/Rythm/metadata.json
@@ -21,7 +21,7 @@
   },
   "url": "rythm.fm",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*rythm[.]fm[/]",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/R/Rythm/assets/logo.gif",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/R/Rythm/assets/thumbnail.png",
   "color": "#147AFE",
@@ -41,7 +41,7 @@
     {
       "id": "hidePaused",
       "title": "Hide Paused",
-      "icon": "fa-regular fa-circle-pause",
+      "icon": "fa-solid fa-circle-pause",
       "value": false,
       "if": {
         "privacy": false
@@ -59,7 +59,7 @@
     {
       "id": "timesTamps",
       "title": "Hide Timestamps",
-      "icon": "fa-regular fa-hourglass",
+      "icon": "fa-solid fa-hourglass",
       "value": false,
       "if": {
         "privacy": false

--- a/websites/S/SDVX Index/metadata.json
+++ b/websites/S/SDVX Index/metadata.json
@@ -11,7 +11,7 @@
   },
   "url": "sdvxindex.com",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*sdvxindex[.]com[/]",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/S/SDVX%20Index/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/S/SDVX%20Index/assets/thumbnail.png",
   "color": "#365191",
@@ -25,7 +25,7 @@
     {
       "id": "buttons",
       "title": "Show Buttons",
-      "icon": "fa-regular fa-rectangle-list",
+      "icon": "fa-solid fa-rectangle-list",
       "value": true
     }
   ]

--- a/websites/W/Wolvesville/metadata.json
+++ b/websites/W/Wolvesville/metadata.json
@@ -57,7 +57,7 @@
     "app.wolvesville.com"
   ],
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*wolvesville[.]com[/]",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/W/Wolvesville/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/W/Wolvesville/assets/thumbnail.png",
   "color": "#FF4181",
@@ -72,7 +72,7 @@
     {
       "id": "privacy",
       "title": "Privacy Mode",
-      "icon": "far fa-user-secret",
+      "icon": "fas fa-user-secret",
       "value": false
     },
     {
@@ -81,7 +81,7 @@
         "privacy": false
       },
       "title": "Hide Clan Tag",
-      "icon": "far fa-tag",
+      "icon": "fas fa-tag",
       "value": false
     },
     {
@@ -90,7 +90,7 @@
         "privacy": false
       },
       "title": "Hide Chat Recipient",
-      "icon": "far fa-comment-slash",
+      "icon": "fas fa-comment-slash",
       "value": false
     },
     {
@@ -99,7 +99,7 @@
         "privacy": false
       },
       "title": "Show Status",
-      "icon": "far fa-play-circle",
+      "icon": "fas fa-play-circle",
       "value": true
     },
     {
@@ -108,19 +108,19 @@
         "privacy": false
       },
       "title": "Hide Name When Invisible",
-      "icon": "far fa-ghost",
+      "icon": "fas fa-ghost",
       "value": false
     },
     {
       "id": "showTimestamp",
       "title": "Show Timestamp",
-      "icon": "far fa-stopwatch",
+      "icon": "fas fa-stopwatch",
       "value": true
     },
     {
       "id": "logo",
       "title": "Icon",
-      "icon": "far fa-images",
+      "icon": "fas fa-images",
       "value": 0,
       "values": [
         "Normal",


### PR DESCRIPTION
## Why

The PreMiD extension is dropping the FontAwesome **regular** (Pro-400) webfont (along with light/thin/v4compat) to shrink the shipped bundle — keeping only **duotone, solid, and brands**. (Companion extension PR: PreMiD/Extension#775.)

Activity setting `icon`s that use `far` / `fa-regular` would stop rendering once that font is gone. These 7 activities are the only ones in the repo using the regular family, so they're migrated to the **solid** equivalents (identical icon names, just the filled weight) and given a patch version bump.

## Changes

| Activity | Icons migrated | Version |
|---|---|---|
| Wolvesville | 7 (`fa-user-secret`, `fa-tag`, `fa-comment-slash`, `fa-play-circle`, `fa-ghost`, `fa-stopwatch`, `fa-images`) | 1.5.1 → 1.5.2 |
| Crowdin | 1 (`fa-tag`) | 4.1.1 → 4.1.2 |
| SDVX Index | 1 (`fa-rectangle-list`) | 1.1.0 → 1.1.1 |
| Nebula | 1 (`fa-rectangle-list`) | 1.1.1 → 1.1.2 |
| neal.fun | 1 (`fa-rectangle-list`) | 1.2.0 → 1.2.1 |
| Dropout | 1 (`fa-rectangle-list`) | 1.1.1 → 1.1.2 |
| Rythm | 2 (`fa-circle-pause`, `fa-hourglass`) | 1.2.0 → 1.2.1 |

Every changed `metadata.json` parses; the diff is icon-family + version lines only.