### PR TITLE
chore(schemas): host metadata schemas as the source of truth

### DIFF
--- a/schemas/metadata/1.0.json
+++ b/schemas/metadata/1.0.json
@@ -1,0 +1,241 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.premid.app/metadata/1.0",
+
+  "title": "Metadata",
+  "type": "object",
+  "description": "Metadata that describes a presence.",
+
+  "definitions": {
+    "user": {
+      "type": "object",
+      "description": "User information.",
+
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user."
+        },
+
+        "id": {
+          "type": "string",
+          "description": "The Discord snowflake of the user.",
+          "pattern": "^\\d+$"
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["name", "id"]
+    }
+  },
+
+  "properties": {
+    "$schema": {
+      "$comment": "This is required otherwise the schema will fail itself when it is applied to a document via $schema. This is optional so that validators that use this schema don't fail if the metadata doesn't have the $schema property.",
+
+      "type": "string",
+      "description": "The metadata schema URL."
+    },
+
+    "author": {
+      "$ref": "#/definitions/user",
+      "description": "The author of this presence."
+    },
+
+    "contributors": {
+      "type": "array",
+      "description": "Any extra contributors to this presence.",
+
+      "items": {
+        "$ref": "#/definitions/user"
+      }
+    },
+
+    "service": {
+      "type": "string",
+      "description": "The service this presence is for."
+    },
+
+    "description": {
+      "type": "object",
+      "description": "A description of the presence in multiple languages.",
+
+      "propertyNames": {
+        "type": "string",
+        "description": "The language key. The key must be languagecode(_REGIONCODE).",
+        "pattern": "^[a-z]{2}(_[A-Z]{2})?$"
+      },
+      "patternProperties": {
+        "^[a-z]{2}(_[A-Z]{2})?$": {
+          "type": "string",
+          "description": "The description of the presence in the key's language."
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["en"]
+    },
+
+    "url": {
+      "type": ["string", "array"],
+      "description": "The service's website URL, or an array of URLs. Protocols should not be added.",
+      "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$",
+
+      "items": {
+        "type": "string",
+        "description": "One of the service's website URLs.",
+        "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$"
+      },
+      "minItems": 2
+    },
+
+    "version": {
+      "type": "string",
+      "description": "The SemVer version of the presence. Must just be major.minor.patch.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+
+    "logo": {
+      "type": "string",
+      "description": "The logo of the service this presence is for.",
+      "pattern": "^https?:\\/\\/?(?:[a-z0-9-]+\\.)*[0-9a-z_-]+(?:\\.[a-z]+)+\\/.*$"
+    },
+
+    "thumbnail": {
+      "type": "string",
+      "description": "A thumbnail of the service this presence is for.",
+      "pattern": "^https?:\\/\\/?([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+\\/.*$"
+    },
+
+    "color": {
+      "type": "string",
+      "description": "The theme color of the service this presence is for. Must be either a 6 digit or a 3 digit hex code.",
+      "pattern": "^#([A-Fa-f0-9]{3}){1,2}$"
+    },
+
+    "tags": {
+      "type": ["array"],
+      "description": "The tags for the presence.",
+
+      "items": {
+        "type": "string",
+        "description": "A tag.",
+        "pattern": "^[^A-Z\\s!\"#$%&'()*+,./:;<=>?@\\[\\\\\\]^_`{|}~]+$"
+      },
+      "minItems": 1
+    },
+
+    "category": {
+      "type": "string",
+      "description": "The category the presence falls under.",
+      "enum": ["anime", "games", "music", "socials", "videos", "other"]
+    },
+
+    "iframe": {
+      "type": "boolean",
+      "description": "Whether or not the presence should run in IFrames."
+    },
+
+    "regExp": {
+      "type": "string",
+      "description": "A regular expression used to match URLs for the presence to inject into."
+    },
+
+    "iFrameRegExp": {
+      "type": "string",
+      "description": "A regular expression used to match IFrames for the presence to inject into."
+    },
+
+    "button": {
+      "type": "boolean",
+      "description": "Controls whether the presence is automatically added when the extension is installed. For partner presences only."
+    },
+
+    "warning": {
+      "type": "boolean",
+      "description": "Shows a warning saying that it requires additional steps for the presence to function correctly."
+    },
+
+    "settings": {
+      "type": "array",
+      "description": "An array of settings the user can change in the presence.",
+
+      "items": {
+        "type": "object",
+        "description": "A setting.",
+
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the setting."
+          },
+
+          "title": {
+            "type": "string",
+            "description": "The title of the setting. Required only if `multiLanguage` is disabled."
+          },
+
+          "icon": {
+            "type": "string",
+            "description": "The icon of the setting. Required only if `multiLanguage` is disabled.",
+            "pattern": "^fa[bs] fa-[0-9a-z-]+$"
+          },
+
+          "if": {
+            "type": "object",
+            "description": "Restrict showing this setting if another setting is the defined value.",
+
+            "propertyNames": {
+              "type": "string",
+              "description": "The ID of the setting."
+            },
+
+            "patternProperties": {
+              "": {
+                "type": ["string", "number", "boolean"],
+                "description": "The value of the setting."
+              }
+            },
+
+            "additionalProperties": false
+          },
+
+          "placeholder": {
+            "type": "string",
+            "description": "The placeholder for settings that require input. Shown when the input is empty."
+          },
+
+          "value": {
+            "type": ["string", "number", "boolean"],
+            "description": "The default value of the setting. Not compatible with `values`."
+          },
+
+          "values": {
+            "type": "array",
+            "description": "The default values of the setting. Not compatible with `value`.",
+
+            "items": {
+              "type": ["string", "number", "boolean"],
+              "description": "The value of the setting."
+            }
+          },
+
+          "multiLanguage": {
+            "type": ["string", "boolean", "array"],
+            "description": "When false, multi-localization is disabled. When true, strings from the `general.json` file are available for use. When a string, it is the name of a file (excluding .json) of a used language from the localization GitHub repo. When an array of strings, it is all of the file names (excluding .json) of used languages from the localization GitHub repo.",
+
+            "items": {
+              "type": "string",
+              "description": "The name of a file from the localization GitHub repository."
+            }
+          }
+        },
+
+        "additionalProperties": false
+      }
+    }
+  },
+
+  "additionalProperties": false,
+  "required": ["author", "service", "description", "url", "version", "logo", "thumbnail", "color", "tags", "category"]
+}

--- a/schemas/metadata/1.1.json
+++ b/schemas/metadata/1.1.json
@@ -1,0 +1,252 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.premid.app/metadata/1.0",
+
+  "title": "Metadata",
+  "type": "object",
+  "description": "Metadata that describes a presence.",
+
+  "definitions": {
+    "user": {
+      "type": "object",
+      "description": "User information.",
+
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user."
+        },
+
+        "id": {
+          "type": "string",
+          "description": "The Discord snowflake of the user.",
+          "pattern": "^\\d+$"
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["name", "id"]
+    }
+  },
+
+  "properties": {
+    "$schema": {
+      "$comment": "This is required otherwise the schema will fail itself when it is applied to a document via $schema. This is optional so that validators that use this schema don't fail if the metadata doesn't have the $schema property.",
+
+      "type": "string",
+      "description": "The metadata schema URL."
+    },
+
+    "author": {
+      "$ref": "#/definitions/user",
+      "description": "The author of this presence."
+    },
+
+    "contributors": {
+      "type": "array",
+      "description": "Any extra contributors to this presence.",
+
+      "items": {
+        "$ref": "#/definitions/user"
+      }
+    },
+
+    "service": {
+      "type": "string",
+      "description": "The service this presence is for."
+    },
+
+    "altnames": {
+      "type": "array",
+      "description": "Alternative names for the service.",
+
+      "items": {
+        "type": "string",
+        "description": "An alternative name."
+      },
+      "minItems": 1
+    },
+
+    "description": {
+      "type": "object",
+      "description": "A description of the presence in multiple languages.",
+
+      "propertyNames": {
+        "type": "string",
+        "description": "The language key. The key must be languagecode(_REGIONCODE).",
+        "pattern": "^[a-z]{2}(_[A-Z]{2})?$"
+      },
+      "patternProperties": {
+        "^[a-z]{2}(_[A-Z]{2})?$": {
+          "type": "string",
+          "description": "The description of the presence in the key's language."
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["en"]
+    },
+
+    "url": {
+      "type": ["string", "array"],
+      "description": "The service's website URL, or an array of URLs. Protocols should not be added.",
+      "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$",
+
+      "items": {
+        "type": "string",
+        "description": "One of the service's website URLs.",
+        "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$"
+      },
+      "minItems": 2
+    },
+
+    "version": {
+      "type": "string",
+      "description": "The SemVer version of the presence. Must just be major.minor.patch.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+
+    "logo": {
+      "type": "string",
+      "description": "The logo of the service this presence is for.",
+      "pattern": "^https?:\\/\\/?(?:[a-z0-9-]+\\.)*[0-9a-z_-]+(?:\\.[a-z]+)+\\/.*$"
+    },
+
+    "thumbnail": {
+      "type": "string",
+      "description": "A thumbnail of the service this presence is for.",
+      "pattern": "^https?:\\/\\/?([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+\\/.*$"
+    },
+
+    "color": {
+      "type": "string",
+      "description": "The theme color of the service this presence is for. Must be either a 6 digit or a 3 digit hex code.",
+      "pattern": "^#([A-Fa-f0-9]{3}){1,2}$"
+    },
+
+    "tags": {
+      "type": ["array"],
+      "description": "The tags for the presence.",
+
+      "items": {
+        "type": "string",
+        "description": "A tag.",
+        "pattern": "^[^A-Z\\s!\"#$%&'()*+,./:;<=>?@\\[\\\\\\]^_`{|}~]+$"
+      },
+      "minItems": 1
+    },
+
+    "category": {
+      "type": "string",
+      "description": "The category the presence falls under.",
+      "enum": ["anime", "games", "music", "socials", "videos", "other"]
+    },
+
+    "iframe": {
+      "type": "boolean",
+      "description": "Whether or not the presence should run in IFrames."
+    },
+
+    "regExp": {
+      "type": "string",
+      "description": "A regular expression used to match URLs for the presence to inject into."
+    },
+
+    "iFrameRegExp": {
+      "type": "string",
+      "description": "A regular expression used to match IFrames for the presence to inject into."
+    },
+
+    "button": {
+      "type": "boolean",
+      "description": "Controls whether the presence is automatically added when the extension is installed. For partner presences only."
+    },
+
+    "warning": {
+      "type": "boolean",
+      "description": "Shows a warning saying that it requires additional steps for the presence to function correctly."
+    },
+
+    "settings": {
+      "type": "array",
+      "description": "An array of settings the user can change in the presence.",
+
+      "items": {
+        "type": "object",
+        "description": "A setting.",
+
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the setting."
+          },
+
+          "title": {
+            "type": "string",
+            "description": "The title of the setting. Required only if `multiLanguage` is disabled."
+          },
+
+          "icon": {
+            "type": "string",
+            "description": "The icon of the setting. Required only if `multiLanguage` is disabled.",
+            "pattern": "^fa[bs] fa-[0-9a-z-]+$"
+          },
+
+          "if": {
+            "type": "object",
+            "description": "Restrict showing this setting if another setting is the defined value.",
+
+            "propertyNames": {
+              "type": "string",
+              "description": "The ID of the setting."
+            },
+
+            "patternProperties": {
+              "": {
+                "type": ["string", "number", "boolean"],
+                "description": "The value of the setting."
+              }
+            },
+
+            "additionalProperties": false
+          },
+
+          "placeholder": {
+            "type": "string",
+            "description": "The placeholder for settings that require input. Shown when the input is empty."
+          },
+
+          "value": {
+            "type": ["string", "number", "boolean"],
+            "description": "The default value of the setting. Not compatible with `values`."
+          },
+
+          "values": {
+            "type": "array",
+            "description": "The default values of the setting. Not compatible with `value`.",
+
+            "items": {
+              "type": ["string", "number", "boolean"],
+              "description": "The value of the setting."
+            }
+          },
+
+          "multiLanguage": {
+            "type": ["string", "boolean", "array"],
+            "description": "When false, multi-localization is disabled. When true, strings from the `general.json` file are available for use. When a string, it is the name of a file (excluding .json) of a used language from the localization GitHub repo. When an array of strings, it is all of the file names (excluding .json) of used languages from the localization GitHub repo.",
+
+            "items": {
+              "type": "string",
+              "description": "The name of a file from the localization GitHub repository."
+            }
+          }
+        },
+
+        "additionalProperties": false
+      }
+    }
+  },
+
+  "additionalProperties": false,
+  "required": ["author", "service", "description", "url", "version", "logo", "thumbnail", "color", "tags", "category"]
+}

--- a/schemas/metadata/1.10.json
+++ b/schemas/metadata/1.10.json
@@ -1,0 +1,277 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.premid.app/metadata/1.10",
+
+  "title": "Metadata",
+  "type": "object",
+  "description": "Metadata that describes a presence.",
+
+  "definitions": {
+    "user": {
+      "type": "object",
+      "description": "User information.",
+
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user."
+        },
+
+        "id": {
+          "type": "string",
+          "description": "The Discord snowflake of the user.",
+          "pattern": "^\\d+$"
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["name", "id"]
+    }
+  },
+
+  "properties": {
+    "$schema": {
+      "$comment": "This is required otherwise the schema will fail itself when it is applied to a document via $schema. This is optional so that validators that use this schema don't fail if the metadata doesn't have the $schema property.",
+
+      "type": "string",
+      "description": "The metadata schema URL."
+    },
+
+    "author": {
+      "$ref": "#/definitions/user",
+      "description": "The author of this presence."
+    },
+
+    "contributors": {
+      "type": "array",
+      "description": "Any extra contributors to this presence.",
+
+      "items": {
+        "$ref": "#/definitions/user"
+      }
+    },
+
+    "service": {
+      "type": "string",
+      "description": "The service this presence is for."
+    },
+
+    "altnames": {
+      "type": "array",
+      "description": "Alternative names for the service.",
+
+      "items": {
+        "type": "string",
+        "description": "An alternative name."
+      },
+      "minItems": 1
+    },
+
+    "description": {
+      "type": "object",
+      "description": "A description of the presence in multiple languages.",
+
+      "propertyNames": {
+        "type": "string",
+        "description": "The language key. The key must be languagecode(_REGIONCODE).",
+        "pattern": "^[a-z]{2}(?:_(?:[A-Z]{2}|[0-9]{1,3}))?$"
+      },
+      "patternProperties": {
+        "^[a-z]{2}(?:_(?:[A-Z]{2}|[0-9]{1,3}))?$": {
+          "type": "string",
+          "description": "The description of the presence in the key's language."
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["en"]
+    },
+
+    "url": {
+      "type": ["string", "array"],
+      "description": "The service's website URL, or an array of URLs. Protocols should not be added.",
+      "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$",
+
+      "items": {
+        "type": "string",
+        "description": "One of the service's website URLs.",
+        "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$"
+      },
+      "minItems": 2
+    },
+
+    "version": {
+      "type": "string",
+      "description": "The SemVer version of the presence. Must just be major.minor.patch.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+
+    "logo": {
+      "type": "string",
+      "description": "The logo of the service this presence is for.",
+      "pattern": "^https?://.+\\.(png|jpe?g|gif|webp)$"
+    },
+
+    "thumbnail": {
+      "type": "string",
+      "description": "A thumbnail of the service this presence is for.",
+      "pattern": "^https?://.+\\.(png|jpe?g|gif|webp)$"
+    },
+
+    "color": {
+      "type": "string",
+      "description": "The theme color of the service this presence is for. Must be either a 6 digit or a 3 digit hex code.",
+      "pattern": "^#([A-Fa-f0-9]{3}){1,2}$"
+    },
+
+    "tags": {
+      "type": ["array"],
+      "description": "The tags for the presence.",
+
+      "items": {
+        "type": "string",
+        "description": "A tag.",
+        "pattern": "^[^A-Z\\s!\"#$%&'()*+,./:;<=>?@\\[\\\\\\]^_`{|}~]+$"
+      },
+      "minItems": 1
+    },
+
+    "category": {
+      "type": "string",
+      "description": "The category the presence falls under.",
+      "enum": ["anime", "games", "music", "socials", "videos", "other"]
+    },
+
+    "iframe": {
+      "type": "boolean",
+      "description": "Whether or not the presence should run in IFrames."
+    },
+
+    "readLogs": {
+      "type": "boolean",
+      "description": "Whether or not the extension should be reading logs."
+    },
+
+    "regExp": {
+      "type": "string",
+      "description": "A regular expression used to match URLs for the presence to inject into."
+    },
+
+    "matches": {
+      "type": "array",
+      "description": "A glob pattern required to match Google's match pattern (https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns). This is required for Presences.",
+      "items": {
+        "type": "string",
+        "description": "A glob pattern.",
+        "pattern": "^(https|http|[*])://.*/.*"
+      }
+    },
+
+    "iFrameMatches": {
+      "type": "array",
+      "description": "A glob pattern required to match Google's match pattern (https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns). This is required for Presences.",
+      "items": {
+        "type": "string",
+        "description": "A glob pattern.",
+        "pattern": "^(https|http|[*])://.*/.*"
+      }
+    },
+
+    "iFrameRegExp": {
+      "type": "string",
+      "description": "A regular expression used to match IFrames for the presence to inject into."
+    },
+
+    "button": {
+      "type": "boolean",
+      "description": "Controls whether the presence is automatically added when the extension is installed. For partner presences only."
+    },
+
+    "warning": {
+      "type": "boolean",
+      "description": "Shows a warning saying that it requires additional steps for the presence to function correctly."
+    },
+
+    "settings": {
+      "type": "array",
+      "description": "An array of settings the user can change in the presence.",
+
+      "items": {
+        "type": "object",
+        "description": "A setting.",
+
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the setting."
+          },
+
+          "title": {
+            "type": "string",
+            "description": "The title of the setting. Required only if `multiLanguage` is disabled."
+          },
+
+          "icon": {
+            "type": "string",
+            "description": "The icon of the setting. Required only if `multiLanguage` is disabled.",
+            "pattern": "^fa([bsdrlt]|([-](brands|solid|duotone|regular|light|thin))) fa-[0-9a-z-]+$"
+          },
+
+          "if": {
+            "type": "object",
+            "description": "Restrict showing this setting if another setting is the defined value.",
+
+            "propertyNames": {
+              "type": "string",
+              "description": "The ID of the setting."
+            },
+
+            "patternProperties": {
+              "": {
+                "type": ["string", "number", "boolean"],
+                "description": "The value of the setting."
+              }
+            },
+
+            "additionalProperties": false
+          },
+
+          "placeholder": {
+            "type": "string",
+            "description": "The placeholder for settings that require input. Shown when the input is empty."
+          },
+
+          "value": {
+            "type": ["string", "number", "boolean"],
+            "description": "The default value of the setting. Not compatible with `values`."
+          },
+
+          "values": {
+            "type": "array",
+            "description": "The default values of the setting. Not compatible with `value`.",
+
+            "items": {
+              "type": ["string", "number", "boolean"],
+              "description": "The value of the setting."
+            }
+          },
+
+          "multiLanguage": {
+            "type": ["string", "boolean", "array"],
+            "description": "When false, multi-localization is disabled. When true, strings from the `general.json` file are available for use. When a string, it is the name of a file (excluding .json) of a used language from the localization GitHub repo. When an array of strings, it is all of the file names (excluding .json) of used languages from the localization GitHub repo.",
+
+            "items": {
+              "type": "string",
+              "description": "The name of a file from the localization GitHub repository."
+            }
+          }
+        },
+
+        "additionalProperties": false
+      }
+    }
+  },
+
+  "additionalProperties": false,
+  "required": ["author", "service", "description", "url", "version", "logo", "thumbnail", "color", "tags", "category"]
+}

--- a/schemas/metadata/1.11.json
+++ b/schemas/metadata/1.11.json
@@ -1,0 +1,260 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.premid.app/metadata/1.11",
+  "title": "Metadata",
+  "type": "object",
+  "description": "Metadata that describes a presence.",
+  "definitions": {
+    "user": {
+      "type": "object",
+      "description": "User information.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user."
+        },
+        "id": {
+          "type": "string",
+          "description": "The Discord snowflake of the user.",
+          "pattern": "^\\d+$"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "id"
+      ]
+    }
+  },
+  "properties": {
+    "$schema": {
+      "$comment": "This is required otherwise the schema will fail itself when it is applied to a document via $schema. This is optional so that validators that use this schema don't fail if the metadata doesn't have the $schema property.",
+      "type": "string",
+      "description": "The metadata schema URL."
+    },
+    "author": {
+      "$ref": "#/definitions/user",
+      "description": "The author of this presence."
+    },
+    "contributors": {
+      "type": "array",
+      "description": "Any extra contributors to this presence.",
+      "items": {
+        "$ref": "#/definitions/user"
+      }
+    },
+    "service": {
+      "type": "string",
+      "description": "The service this presence is for."
+    },
+    "altnames": {
+      "type": "array",
+      "description": "Alternative names for the service.",
+      "items": {
+        "type": "string",
+        "description": "An alternative name."
+      },
+      "minItems": 1
+    },
+    "description": {
+      "type": "object",
+      "description": "A description of the presence in multiple languages.",
+      "propertyNames": {
+        "type": "string",
+        "description": "The language key. The key must be languagecode(_REGIONCODE).",
+        "pattern": "^[a-z]{2}(?:_(?:[A-Z]{2}|[0-9]{1,3}))?$"
+      },
+      "patternProperties": {
+        "^[a-z]{2}(?:_(?:[A-Z]{2}|[0-9]{1,3}))?$": {
+          "type": "string",
+          "description": "The description of the presence in the key's language."
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "en"
+      ]
+    },
+    "url": {
+      "type": [
+        "string",
+        "array"
+      ],
+      "description": "The service's website URL, or an array of URLs. Protocols should not be added.",
+      "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$",
+      "items": {
+        "type": "string",
+        "description": "One of the service's website URLs.",
+        "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$"
+      },
+      "minItems": 2
+    },
+    "version": {
+      "type": "string",
+      "description": "The SemVer version of the presence. Must just be major.minor.patch.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "apiVersion": {
+      "type": "integer",
+      "description": "The Presence System version this Presence supports.",
+      "minimum": 1,
+      "maximum": 2
+    },
+    "logo": {
+      "type": "string",
+      "description": "The logo of the service this presence is for.",
+      "pattern": "^https?://.+\\.(png|jpe?g|gif|webp)$"
+    },
+    "thumbnail": {
+      "type": "string",
+      "description": "A thumbnail of the service this presence is for.",
+      "pattern": "^https?://.+\\.(png|jpe?g|gif|webp)$"
+    },
+    "color": {
+      "type": "string",
+      "description": "The theme color of the service this presence is for. Must be either a 6 digit or a 3 digit hex code.",
+      "pattern": "^#([A-Fa-f0-9]{3}){1,2}$"
+    },
+    "tags": {
+      "type": [
+        "array"
+      ],
+      "description": "The tags for the presence.",
+      "items": {
+        "type": "string",
+        "description": "A tag.",
+        "pattern": "^[^A-Z\\s!\"#$%&'()*+,./:;<=>?@\\[\\\\\\]^_`{|}~]+$"
+      },
+      "minItems": 1
+    },
+    "category": {
+      "type": "string",
+      "description": "The category the presence falls under.",
+      "enum": [
+        "anime",
+        "games",
+        "music",
+        "socials",
+        "videos",
+        "other"
+      ]
+    },
+    "iframe": {
+      "type": "boolean",
+      "description": "Whether or not the presence should run in IFrames."
+    },
+    "readLogs": {
+      "type": "boolean",
+      "description": "Whether or not the extension should be reading logs."
+    },
+    "regExp": {
+      "type": "string",
+      "description": "A regular expression used to match URLs for the presence to inject into."
+    },
+    "iFrameRegExp": {
+      "type": "string",
+      "description": "A regular expression used to match IFrames for the presence to inject into."
+    },
+    "button": {
+      "type": "boolean",
+      "description": "Controls whether the presence is automatically added when the extension is installed. For partner presences only."
+    },
+    "warning": {
+      "type": "boolean",
+      "description": "Shows a warning saying that it requires additional steps for the presence to function correctly."
+    },
+    "settings": {
+      "type": "array",
+      "description": "An array of settings the user can change in the presence.",
+      "items": {
+        "type": "object",
+        "description": "A setting.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the setting."
+          },
+          "title": {
+            "type": "string",
+            "description": "The title of the setting. Required only if `multiLanguage` is disabled."
+          },
+          "icon": {
+            "type": "string",
+            "description": "The icon of the setting. Required only if `multiLanguage` is disabled.",
+            "pattern": "^fa([bsdrlt]|([-](brands|solid|duotone|regular|light|thin))) fa-[0-9a-z-]+$"
+          },
+          "if": {
+            "type": "object",
+            "description": "Restrict showing this setting if another setting is the defined value.",
+            "propertyNames": {
+              "type": "string",
+              "description": "The ID of the setting."
+            },
+            "patternProperties": {
+              "": {
+                "type": [
+                  "string",
+                  "number",
+                  "boolean"
+                ],
+                "description": "The value of the setting."
+              }
+            },
+            "additionalProperties": false
+          },
+          "placeholder": {
+            "type": "string",
+            "description": "The placeholder for settings that require input. Shown when the input is empty."
+          },
+          "value": {
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ],
+            "description": "The default value of the setting. Not compatible with `values`."
+          },
+          "values": {
+            "type": "array",
+            "description": "The default values of the setting. Not compatible with `value`.",
+            "items": {
+              "type": [
+                "string",
+                "number",
+                "boolean"
+              ],
+              "description": "The value of the setting."
+            }
+          },
+          "multiLanguage": {
+            "type": [
+              "string",
+              "boolean",
+              "array"
+            ],
+            "description": "When false, multi-localization is disabled. When true, strings from the `general.json` file are available for use. When a string, it is the name of a file (excluding .json) of a used language from the localization GitHub repo. When an array of strings, it is all of the file names (excluding .json) of used languages from the localization GitHub repo.",
+            "items": {
+              "type": "string",
+              "description": "The name of a file from the localization GitHub repository."
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "author",
+    "service",
+    "description",
+    "url",
+    "version",
+    "apiVersion",
+    "logo",
+    "thumbnail",
+    "color",
+    "tags",
+    "category"
+  ]
+}

--- a/schemas/metadata/1.12.json
+++ b/schemas/metadata/1.12.json
@@ -1,0 +1,252 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.premid.app/metadata/1.12",
+  "title": "Metadata",
+  "type": "object",
+  "description": "Metadata that describes a presence.",
+  "definitions": {
+    "user": {
+      "type": "object",
+      "description": "User information.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user."
+        },
+        "id": {
+          "type": "string",
+          "description": "The Discord snowflake of the user.",
+          "pattern": "^\\d+$"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "id"
+      ]
+    }
+  },
+  "properties": {
+    "$schema": {
+      "$comment": "This is required otherwise the schema will fail itself when it is applied to a document via $schema. This is optional so that validators that use this schema don't fail if the metadata doesn't have the $schema property.",
+      "type": "string",
+      "description": "The metadata schema URL."
+    },
+    "author": {
+      "$ref": "#/definitions/user",
+      "description": "The author of this presence."
+    },
+    "contributors": {
+      "type": "array",
+      "description": "Any extra contributors to this presence.",
+      "items": {
+        "$ref": "#/definitions/user"
+      }
+    },
+    "service": {
+      "type": "string",
+      "description": "The service this presence is for."
+    },
+    "altnames": {
+      "type": "array",
+      "description": "Alternative names for the service.",
+      "items": {
+        "type": "string",
+        "description": "An alternative name."
+      },
+      "minItems": 1
+    },
+    "description": {
+      "type": "object",
+      "description": "A description of the presence in multiple languages.",
+      "propertyNames": {
+        "type": "string",
+        "description": "The language key. The key must be languagecode(_REGIONCODE).",
+        "pattern": "^[a-z]{2}(?:_(?:[A-Z]{2}|[0-9]{1,3}))?$"
+      },
+      "patternProperties": {
+        "^[a-z]{2}(?:_(?:[A-Z]{2}|[0-9]{1,3}))?$": {
+          "type": "string",
+          "description": "The description of the presence in the key's language."
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "en"
+      ]
+    },
+    "url": {
+      "type": [
+        "string",
+        "array"
+      ],
+      "description": "The service's website URL, or an array of URLs. Protocols should not be added.",
+      "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$",
+      "items": {
+        "type": "string",
+        "description": "One of the service's website URLs.",
+        "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$"
+      },
+      "minItems": 2
+    },
+    "version": {
+      "type": "string",
+      "description": "The SemVer version of the presence. Must just be major.minor.patch.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "apiVersion": {
+      "type": "integer",
+      "description": "The Presence System version this Presence supports.",
+      "minimum": 1,
+      "maximum": 2
+    },
+    "logo": {
+      "type": "string",
+      "description": "The logo of the service this presence is for.",
+      "pattern": "^https?://.+\\.(png|jpe?g|gif|webp)$"
+    },
+    "thumbnail": {
+      "type": "string",
+      "description": "A thumbnail of the service this presence is for.",
+      "pattern": "^https?://.+\\.(png|jpe?g|gif|webp)$"
+    },
+    "color": {
+      "type": "string",
+      "description": "The theme color of the service this presence is for. Must be either a 6 digit or a 3 digit hex code.",
+      "pattern": "^#([A-Fa-f0-9]{3}){1,2}$"
+    },
+    "tags": {
+      "type": [
+        "array"
+      ],
+      "description": "The tags for the presence.",
+      "items": {
+        "type": "string",
+        "description": "A tag.",
+        "pattern": "^[^A-Z\\s!\"#$%&'()*+,./:;<=>?@\\[\\\\\\]^_`{|}~]+$"
+      },
+      "minItems": 1
+    },
+    "category": {
+      "type": "string",
+      "description": "The category the presence falls under.",
+      "enum": [
+        "anime",
+        "games",
+        "music",
+        "socials",
+        "videos",
+        "other"
+      ]
+    },
+    "iframe": {
+      "type": "boolean",
+      "description": "Whether or not the presence should run in IFrames."
+    },
+    "readLogs": {
+      "type": "boolean",
+      "description": "Whether or not the extension should be reading logs."
+    },
+    "regExp": {
+      "type": "string",
+      "description": "A regular expression used to match URLs for the presence to inject into."
+    },
+    "iFrameRegExp": {
+      "type": "string",
+      "description": "A regular expression used to match IFrames for the presence to inject into."
+    },
+    "button": {
+      "type": "boolean",
+      "description": "Controls whether the presence is automatically added when the extension is installed. For partner presences only."
+    },
+    "warning": {
+      "type": "boolean",
+      "description": "Shows a warning saying that it requires additional steps for the presence to function correctly."
+    },
+    "settings": {
+      "type": "array",
+      "description": "An array of settings the user can change in the presence.",
+      "items": {
+        "type": "object",
+        "description": "A setting.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the setting."
+          },
+          "title": {
+            "type": "string",
+            "description": "The title of the setting. Required only if `multiLanguage` is disabled."
+          },
+          "icon": {
+            "type": "string",
+            "description": "The icon of the setting. Required only if `multiLanguage` is disabled.",
+            "pattern": "^fa([bsdrlt]|([-](brands|solid|duotone|regular|light|thin))) fa-[0-9a-z-]+$"
+          },
+          "if": {
+            "type": "object",
+            "description": "Restrict showing this setting if another setting is the defined value.",
+            "propertyNames": {
+              "type": "string",
+              "description": "The ID of the setting."
+            },
+            "patternProperties": {
+              "": {
+                "type": [
+                  "string",
+                  "number",
+                  "boolean"
+                ],
+                "description": "The value of the setting."
+              }
+            },
+            "additionalProperties": false
+          },
+          "placeholder": {
+            "type": "string",
+            "description": "The placeholder for settings that require input. Shown when the input is empty."
+          },
+          "value": {
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ],
+            "description": "The default value of the setting. Not compatible with `values`."
+          },
+          "values": {
+            "type": "array",
+            "description": "The default values of the setting. Not compatible with `value`.",
+            "items": {
+              "type": [
+                "string",
+                "number",
+                "boolean"
+              ],
+              "description": "The value of the setting."
+            }
+          },
+          "multiLanguage": {
+            "type": "boolean",
+            "description": "When true, strings from the `general.json` file are available for use, plus the <service>.json file. False is not allowed."
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "author",
+    "service",
+    "description",
+    "url",
+    "version",
+    "apiVersion",
+    "logo",
+    "thumbnail",
+    "color",
+    "tags",
+    "category"
+  ]
+}

--- a/schemas/metadata/1.13.json
+++ b/schemas/metadata/1.13.json
@@ -1,0 +1,248 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.premid.app/metadata/1.13",
+  "title": "Metadata",
+  "type": "object",
+  "description": "Metadata that describes a activity.",
+  "definitions": {
+    "user": {
+      "type": "object",
+      "description": "User information.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user."
+        },
+        "id": {
+          "type": "string",
+          "description": "The Discord snowflake of the user.",
+          "pattern": "^\\d+$"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "id"
+      ]
+    }
+  },
+  "properties": {
+    "$schema": {
+      "$comment": "This is required otherwise the schema will fail itself when it is applied to a document via $schema. This is optional so that validators that use this schema don't fail if the metadata doesn't have the $schema property.",
+      "type": "string",
+      "description": "The metadata schema URL."
+    },
+    "author": {
+      "$ref": "#/definitions/user",
+      "description": "The author of this activity."
+    },
+    "contributors": {
+      "type": "array",
+      "description": "Any extra contributors to this activity.",
+      "items": {
+        "$ref": "#/definitions/user"
+      }
+    },
+    "service": {
+      "type": "string",
+      "description": "The service this activity is for."
+    },
+    "altnames": {
+      "type": "array",
+      "description": "Alternative names for the service.",
+      "items": {
+        "type": "string",
+        "description": "An alternative name."
+      },
+      "minItems": 1
+    },
+    "description": {
+      "type": "object",
+      "description": "A description of the activity in multiple languages.",
+      "propertyNames": {
+        "type": "string",
+        "description": "The language key. The key must be languagecode(-regioncode).",
+        "pattern": "^[a-z]{2,3}(?:-(?:[a-z]{2}|[0-9]{1,3}))?$"
+      },
+      "patternProperties": {
+        "^[a-z]{2,3}(?:-(?:[a-z]{2}|[0-9]{1,3}))?$": {
+          "type": "string",
+          "description": "The description of the activity in the key's language."
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "en"
+      ]
+    },
+    "url": {
+      "type": [
+        "string",
+        "array"
+      ],
+      "description": "The service's website URL, or an array of URLs. Protocols should not be added.",
+      "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$",
+      "items": {
+        "type": "string",
+        "description": "One of the service's website URLs.",
+        "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$"
+      },
+      "minItems": 2
+    },
+    "version": {
+      "type": "string",
+      "description": "The SemVer version of the activity. Must just be major.minor.patch.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "apiVersion": {
+      "type": "integer",
+      "description": "The Activity System version this activity supports.",
+      "minimum": 1,
+      "maximum": 2
+    },
+    "logo": {
+      "type": "string",
+      "description": "The logo of the service this activity is for.",
+      "pattern": "^https?://.+\\.(png|jpe?g|gif|webp)$"
+    },
+    "thumbnail": {
+      "type": "string",
+      "description": "A thumbnail of the service this activity is for.",
+      "pattern": "^https?://.+\\.(png|jpe?g|gif|webp)$"
+    },
+    "color": {
+      "type": "string",
+      "description": "The theme color of the service this activity is for. Must be either a 6 digit or a 3 digit hex code.",
+      "pattern": "^#([A-Fa-f0-9]{3}){1,2}$"
+    },
+    "tags": {
+      "type": [
+        "array"
+      ],
+      "description": "The tags for the activity.",
+      "items": {
+        "type": "string",
+        "description": "A tag.",
+        "pattern": "^[^A-Z\\s!\"#$%&'()*+,./:;<=>?@\\[\\\\\\]^_`{|}~]+$"
+      },
+      "minItems": 1
+    },
+    "category": {
+      "type": "string",
+      "description": "The category the activity falls under.",
+      "enum": [
+        "anime",
+        "games",
+        "music",
+        "socials",
+        "videos",
+        "other"
+      ]
+    },
+    "iframe": {
+      "type": "boolean",
+      "description": "Whether or not the activity should run in IFrames."
+    },
+    "readLogs": {
+      "type": "boolean",
+      "description": "Whether or not the extension should be reading logs."
+    },
+    "regExp": {
+      "type": "string",
+      "description": "A regular expression used to match URLs for the activity to inject into."
+    },
+    "iFrameRegExp": {
+      "type": "string",
+      "description": "A regular expression used to match IFrames for the activity to inject into."
+    },
+    "settings": {
+      "type": "array",
+      "description": "An array of settings the user can change in the activity.",
+      "items": {
+        "type": "object",
+        "description": "A setting.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the setting."
+          },
+          "title": {
+            "type": "string",
+            "description": "The title of the setting. Required only if `multiLanguage` is disabled."
+          },
+          "icon": {
+            "type": "string",
+            "description": "The icon of the setting. Required only if `multiLanguage` is disabled.",
+            "pattern": "^fa([bsdrlt]|([-](brands|solid|duotone|regular|light|thin))) fa-[0-9a-z-]+$"
+          },
+          "if": {
+            "type": "object",
+            "description": "Restrict showing this setting if another setting is the defined value.",
+            "propertyNames": {
+              "type": "string",
+              "description": "The ID of the setting."
+            },
+            "patternProperties": {
+              "": {
+                "type": [
+                  "string",
+                  "number",
+                  "boolean"
+                ],
+                "description": "The value of the setting."
+              }
+            },
+            "additionalProperties": false
+          },
+          "placeholder": {
+            "type": "string",
+            "description": "The placeholder for settings that require input. Shown when the input is empty."
+          },
+          "value": {
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ],
+            "description": "The default value of the setting. Not compatible with `values`."
+          },
+          "values": {
+            "type": "array",
+            "description": "The default values of the setting. Not compatible with `value`.",
+            "items": {
+              "type": [
+                "string",
+                "number",
+                "boolean"
+              ],
+              "description": "The value of the setting."
+            }
+          },
+          "multiLanguage": {
+            "type": "boolean",
+            "description": "When true, strings from the `general.json` file are available for use, plus the <service>.json file. False is not allowed."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "mobile": {
+      "type": "boolean",
+      "description": "Whether or not the activity has support for mobile devices."
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "author",
+    "service",
+    "description",
+    "url",
+    "version",
+    "apiVersion",
+    "logo",
+    "thumbnail",
+    "color",
+    "tags",
+    "category"
+  ]
+}

--- a/schemas/metadata/1.14.json
+++ b/schemas/metadata/1.14.json
@@ -1,0 +1,252 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.premid.app/metadata/1.14",
+  "title": "Metadata",
+  "type": "object",
+  "description": "Metadata that describes a activity.",
+  "definitions": {
+    "user": {
+      "type": "object",
+      "description": "User information.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user."
+        },
+        "id": {
+          "type": "string",
+          "description": "The Discord snowflake of the user.",
+          "pattern": "^\\d+$"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "id"
+      ]
+    }
+  },
+  "properties": {
+    "$schema": {
+      "$comment": "This is required otherwise the schema will fail itself when it is applied to a document via $schema. This is optional so that validators that use this schema don't fail if the metadata doesn't have the $schema property.",
+      "type": "string",
+      "description": "The metadata schema URL."
+    },
+    "author": {
+      "$ref": "#/definitions/user",
+      "description": "The author of this activity."
+    },
+    "contributors": {
+      "type": "array",
+      "description": "Any extra contributors to this activity.",
+      "items": {
+        "$ref": "#/definitions/user"
+      }
+    },
+    "service": {
+      "type": "string",
+      "description": "The service this activity is for."
+    },
+    "altnames": {
+      "type": "array",
+      "description": "Alternative names for the service.",
+      "items": {
+        "type": "string",
+        "description": "An alternative name."
+      },
+      "minItems": 1
+    },
+    "description": {
+      "type": "object",
+      "description": "A description of the activity in multiple languages.",
+      "propertyNames": {
+        "type": "string",
+        "description": "The language key. The key must be languagecode(-regioncode).",
+        "pattern": "^[a-z]{2,3}(?:-(?:[a-z]{2}|[0-9]{1,3}))?$"
+      },
+      "patternProperties": {
+        "^[a-z]{2,3}(?:-(?:[a-z]{2}|[0-9]{1,3}))?$": {
+          "type": "string",
+          "description": "The description of the activity in the key's language."
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "en"
+      ]
+    },
+    "url": {
+      "type": [
+        "string",
+        "array"
+      ],
+      "description": "The service's website URL, or an array of URLs. Protocols should not be added.",
+      "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$",
+      "items": {
+        "type": "string",
+        "description": "One of the service's website URLs.",
+        "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$"
+      },
+      "minItems": 2
+    },
+    "version": {
+      "type": "string",
+      "description": "The SemVer version of the activity. Must just be major.minor.patch.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "apiVersion": {
+      "type": "integer",
+      "description": "The Activity System version this activity supports.",
+      "minimum": 1,
+      "maximum": 2
+    },
+    "logo": {
+      "type": "string",
+      "description": "The logo of the service this activity is for.",
+      "pattern": "^https?://.+\\.(png|jpe?g|gif|webp)$"
+    },
+    "thumbnail": {
+      "type": "string",
+      "description": "A thumbnail of the service this activity is for.",
+      "pattern": "^https?://.+\\.(png|jpe?g|gif|webp)$"
+    },
+    "color": {
+      "type": "string",
+      "description": "The theme color of the service this activity is for. Must be either a 6 digit or a 3 digit hex code.",
+      "pattern": "^#([A-Fa-f0-9]{3}){1,2}$"
+    },
+    "tags": {
+      "type": [
+        "array"
+      ],
+      "description": "The tags for the activity.",
+      "items": {
+        "type": "string",
+        "description": "A tag.",
+        "pattern": "^[^A-Z\\s!\"#$%&'()*+,./:;<=>?@\\[\\\\\\]^_`{|}~]+$"
+      },
+      "minItems": 1
+    },
+    "category": {
+      "type": "string",
+      "description": "The category the activity falls under.",
+      "enum": [
+        "anime",
+        "games",
+        "music",
+        "socials",
+        "videos",
+        "other"
+      ]
+    },
+    "iframe": {
+      "type": "boolean",
+      "description": "Whether or not the activity should run in IFrames."
+    },
+    "readLogs": {
+      "type": "boolean",
+      "description": "Whether or not the extension should be reading logs."
+    },
+    "regExp": {
+      "type": "string",
+      "description": "A regular expression used to match URLs for the activity to inject into."
+    },
+    "iFrameRegExp": {
+      "type": "string",
+      "description": "A regular expression used to match IFrames for the activity to inject into."
+    },
+    "settings": {
+      "type": "array",
+      "description": "An array of settings the user can change in the activity.",
+      "items": {
+        "type": "object",
+        "description": "A setting.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the setting."
+          },
+          "title": {
+            "type": "string",
+            "description": "The title of the setting. Required only if `multiLanguage` is disabled."
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the setting. Only applicable if `multiLanguage` is disabled."
+          },
+          "icon": {
+            "type": "string",
+            "description": "The icon of the setting. Required only if `multiLanguage` is disabled.",
+            "pattern": "^fa([bsdrlt]|([-](brands|solid|duotone|regular|light|thin))) fa-[0-9a-z-]+$"
+          },
+          "if": {
+            "type": "object",
+            "description": "Restrict showing this setting if another setting is the defined value.",
+            "propertyNames": {
+              "type": "string",
+              "description": "The ID of the setting."
+            },
+            "patternProperties": {
+              "": {
+                "type": [
+                  "string",
+                  "number",
+                  "boolean"
+                ],
+                "description": "The value of the setting."
+              }
+            },
+            "additionalProperties": false
+          },
+          "placeholder": {
+            "type": "string",
+            "description": "The placeholder for settings that require input. Shown when the input is empty."
+          },
+          "value": {
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ],
+            "description": "The default value of the setting. Not compatible with `values`."
+          },
+          "values": {
+            "type": "array",
+            "description": "The default values of the setting. Not compatible with `value`.",
+            "items": {
+              "type": [
+                "string",
+                "number",
+                "boolean"
+              ],
+              "description": "The value of the setting."
+            }
+          },
+          "multiLanguage": {
+            "type": "boolean",
+            "description": "When true, strings from the `general.json` file are available for use, plus the <service>.json file. False is not allowed."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "mobile": {
+      "type": "boolean",
+      "description": "Whether or not the activity has support for mobile devices."
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "author",
+    "service",
+    "description",
+    "url",
+    "version",
+    "apiVersion",
+    "logo",
+    "thumbnail",
+    "color",
+    "tags",
+    "category"
+  ]
+}

--- a/schemas/metadata/1.15.json
+++ b/schemas/metadata/1.15.json
@@ -1,0 +1,256 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.premid.app/metadata/1.15",
+  "title": "Metadata",
+  "type": "object",
+  "description": "Metadata that describes a activity.",
+  "definitions": {
+    "user": {
+      "type": "object",
+      "description": "User information.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user."
+        },
+        "id": {
+          "type": "string",
+          "description": "The Discord snowflake of the user.",
+          "pattern": "^\\d+$"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "id"
+      ]
+    }
+  },
+  "properties": {
+    "$schema": {
+      "$comment": "This is required otherwise the schema will fail itself when it is applied to a document via $schema. This is optional so that validators that use this schema don't fail if the metadata doesn't have the $schema property.",
+      "type": "string",
+      "description": "The metadata schema URL."
+    },
+    "author": {
+      "$ref": "#/definitions/user",
+      "description": "The author of this activity."
+    },
+    "contributors": {
+      "type": "array",
+      "description": "Any extra contributors to this activity.",
+      "items": {
+        "$ref": "#/definitions/user"
+      }
+    },
+    "service": {
+      "type": "string",
+      "description": "The service this activity is for."
+    },
+    "altnames": {
+      "type": "array",
+      "description": "Alternative names for the service.",
+      "items": {
+        "type": "string",
+        "description": "An alternative name."
+      },
+      "minItems": 1
+    },
+    "description": {
+      "type": "object",
+      "description": "A description of the activity in multiple languages.",
+      "propertyNames": {
+        "type": "string",
+        "description": "The language key. The key must be languagecode(-regioncode).",
+        "pattern": "^[a-z]{2,3}(?:-(?:[a-z]{2}|[0-9]{1,3}))?$"
+      },
+      "patternProperties": {
+        "^[a-z]{2,3}(?:-(?:[a-z]{2}|[0-9]{1,3}))?$": {
+          "type": "string",
+          "description": "The description of the activity in the key's language."
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "en"
+      ]
+    },
+    "url": {
+      "type": [
+        "string",
+        "array"
+      ],
+      "description": "The service's website URL, or an array of URLs. Protocols should not be added.",
+      "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$",
+      "items": {
+        "type": "string",
+        "description": "One of the service's website URLs.",
+        "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$"
+      },
+      "minItems": 2
+    },
+    "version": {
+      "type": "string",
+      "description": "The SemVer version of the activity. Must just be major.minor.patch.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "apiVersion": {
+      "type": "integer",
+      "description": "The Activity System version this activity supports.",
+      "minimum": 1,
+      "maximum": 2
+    },
+    "logo": {
+      "type": "string",
+      "description": "The logo of the service this activity is for.",
+      "pattern": "^https?://.+\\.(png|jpe?g|gif|webp)$"
+    },
+    "thumbnail": {
+      "type": "string",
+      "description": "A thumbnail of the service this activity is for.",
+      "pattern": "^https?://.+\\.(png|jpe?g|gif|webp)$"
+    },
+    "color": {
+      "type": "string",
+      "description": "The theme color of the service this activity is for. Must be either a 6 digit or a 3 digit hex code.",
+      "pattern": "^#([A-Fa-f0-9]{3}){1,2}$"
+    },
+    "tags": {
+      "type": [
+        "array"
+      ],
+      "description": "The tags for the activity.",
+      "items": {
+        "type": "string",
+        "description": "A tag.",
+        "pattern": "^[^A-Z\\s!\"#$%&'()*+,./:;<=>?@\\[\\\\\\]^_`{|}~]+$"
+      },
+      "minItems": 1
+    },
+    "category": {
+      "type": "string",
+      "description": "The category the activity falls under.",
+      "enum": [
+        "anime",
+        "games",
+        "music",
+        "socials",
+        "videos",
+        "other"
+      ]
+    },
+    "iframe": {
+      "type": "boolean",
+      "description": "Whether or not the activity should run in IFrames."
+    },
+    "readLogs": {
+      "type": "boolean",
+      "description": "Whether or not the extension should be reading logs."
+    },
+    "regExp": {
+      "type": "string",
+      "description": "A regular expression used to match URLs for the activity to inject into."
+    },
+    "iFrameRegExp": {
+      "type": "string",
+      "description": "A regular expression used to match IFrames for the activity to inject into."
+    },
+    "allowURLOverrides": {
+      "type": "boolean",
+      "description": "Whether or not the activity should allow URL overrides."
+    },
+    "settings": {
+      "type": "array",
+      "description": "An array of settings the user can change in the activity.",
+      "items": {
+        "type": "object",
+        "description": "A setting.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the setting."
+          },
+          "title": {
+            "type": "string",
+            "description": "The title of the setting. Required only if `multiLanguage` is disabled."
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the setting. Only applicable if `multiLanguage` is disabled."
+          },
+          "icon": {
+            "type": "string",
+            "description": "The icon of the setting. Required only if `multiLanguage` is disabled.",
+            "pattern": "^fa([bsdrlt]|([-](brands|solid|duotone|regular|light|thin))) fa-[0-9a-z-]+$"
+          },
+          "if": {
+            "type": "object",
+            "description": "Restrict showing this setting if another setting is the defined value.",
+            "propertyNames": {
+              "type": "string",
+              "description": "The ID of the setting."
+            },
+            "patternProperties": {
+              "": {
+                "type": [
+                  "string",
+                  "number",
+                  "boolean"
+                ],
+                "description": "The value of the setting."
+              }
+            },
+            "additionalProperties": false
+          },
+          "placeholder": {
+            "type": "string",
+            "description": "The placeholder for settings that require input. Shown when the input is empty."
+          },
+          "value": {
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ],
+            "description": "The default value of the setting. Not compatible with `values`."
+          },
+          "values": {
+            "type": "array",
+            "description": "The default values of the setting. Not compatible with `value`.",
+            "items": {
+              "type": [
+                "string",
+                "number",
+                "boolean"
+              ],
+              "description": "The value of the setting."
+            }
+          },
+          "multiLanguage": {
+            "type": "boolean",
+            "description": "When true, strings from the `general.json` file are available for use, plus the <service>.json file. False is not allowed."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "mobile": {
+      "type": "boolean",
+      "description": "Whether or not the activity has support for mobile devices."
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "author",
+    "service",
+    "description",
+    "url",
+    "version",
+    "apiVersion",
+    "logo",
+    "thumbnail",
+    "color",
+    "tags",
+    "category"
+  ]
+}

--- a/schemas/metadata/1.16.json
+++ b/schemas/metadata/1.16.json
@@ -1,0 +1,255 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.premid.app/metadata/1.16",
+  "title": "Metadata",
+  "type": "object",
+  "description": "Metadata that describes an activity.",
+  "definitions": {
+    "user": {
+      "type": "object",
+      "description": "User information.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user."
+        },
+        "id": {
+          "type": "string",
+          "description": "The Discord snowflake of the user.",
+          "pattern": "^\\d+$"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "id"
+      ]
+    }
+  },
+  "properties": {
+    "$schema": {
+      "$comment": "This is required otherwise the schema will fail itself when it is applied to a document via $schema. This is optional so that validators that use this schema don't fail if the metadata doesn't have the $schema property.",
+      "type": "string",
+      "description": "The metadata schema URL."
+    },
+    "author": {
+      "$ref": "#/definitions/user",
+      "description": "The author of this activity."
+    },
+    "contributors": {
+      "type": "array",
+      "description": "Any extra contributors to this activity.",
+      "items": {
+        "$ref": "#/definitions/user"
+      }
+    },
+    "service": {
+      "type": "string",
+      "description": "The service this activity is for."
+    },
+    "altnames": {
+      "type": "array",
+      "description": "Alternative names for the service.",
+      "items": {
+        "type": "string",
+        "description": "An alternative name."
+      },
+      "minItems": 1
+    },
+    "description": {
+      "type": "object",
+      "description": "A description of the activity in multiple languages.",
+      "propertyNames": {
+        "type": "string",
+        "description": "The language key in the format: languagecode or languagecode-regioncode.",
+        "pattern": "^[a-z]{2,3}(?:-(?:[a-z]{2}|[0-9]{1,3}))?$"
+      },
+      "patternProperties": {
+        "^[a-z]{2,3}(?:-(?:[a-z]{2}|[0-9]{1,3}))?$": {
+          "type": "string",
+          "description": "The description of the activity in the key's language."
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "en"
+      ]
+    },
+    "url": {
+      "type": [
+        "string",
+        "array"
+      ],
+      "description": "The service's website URL, or an array of URLs. Protocols should not be added. Not used for matching.",
+      "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$",
+      "items": {
+        "type": "string",
+        "description": "One of the service's website URLs.",
+        "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$"
+      },
+      "minItems": 2
+    },
+    "version": {
+      "type": "string",
+      "description": "The SemVer version of the activity in the format: major.minor.patch.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "apiVersion": {
+      "type": "integer",
+      "description": "The Activity System version this activity supports.",
+      "minimum": 1,
+      "maximum": 2
+    },
+    "logo": {
+      "type": "string",
+      "description": "The logo of the service this activity is for.",
+      "pattern": "^https?://.+\\.(png|jpe?g|gif|webp)$"
+    },
+    "thumbnail": {
+      "type": "string",
+      "description": "A thumbnail of the service this activity is for.",
+      "pattern": "^https?://.+\\.(png|jpe?g|gif|webp)$"
+    },
+    "color": {
+      "type": "string",
+      "description": "The theme color of the service this activity is for. Must be either a 6 digit or a 3 digit hex code.",
+      "pattern": "^#([A-Fa-f0-9]{3}){1,2}$"
+    },
+    "tags": {
+      "type": "array",
+      "description": "The tags for the activity.",
+      "items": {
+        "type": "string",
+        "description": "A tag.",
+        "pattern": "^[^A-Z\\s!\"#$%&'()*+,./:;<=>?@\\[\\\\\\]^_`{|}~]+$"
+      },
+      "minItems": 1
+    },
+    "category": {
+      "type": "string",
+      "description": "The category the activity falls under.",
+      "enum": [
+        "anime",
+        "games",
+        "music",
+        "socials",
+        "videos",
+        "other"
+      ]
+    },
+    "iframe": {
+      "type": "boolean",
+      "description": "Whether or not the activity should run in iframes."
+    },
+    "readLogs": {
+      "type": "boolean",
+      "description": "Whether or not the extension should be reading logs."
+    },
+    "regExp": {
+      "type": "string",
+      "description": "A regular expression used to match URLs for the activity to inject into."
+    },
+    "iFrameRegExp": {
+      "type": "string",
+      "description": "A regular expression used to match iframes for the activity to inject into."
+    },
+    "allowURLOverrides": {
+      "type": "boolean",
+      "description": "Whether or not the activity should allow the user to override the activity's matching regExps."
+    },
+    "settings": {
+      "type": "array",
+      "description": "An array of settings the user can change in the activity.",
+      "items": {
+        "type": "object",
+        "description": "A setting.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the setting."
+          },
+          "title": {
+            "type": "string",
+            "description": "The title of the setting. Required only if `multiLanguage` is disabled."
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the setting. Only applicable if `multiLanguage` is disabled."
+          },
+          "icon": {
+            "type": "string",
+            "description": "The icon of the setting. Required only if `multiLanguage` is disabled.",
+            "pattern": "^fa([bsdrlt]|([-](brands|solid|duotone|regular|light|thin))) fa-[0-9a-z-]+$"
+          },
+          "if": {
+            "type": "object",
+            "description": "Restrict showing this setting if another setting is the defined value.",
+            "propertyNames": {
+              "type": "string",
+              "description": "The ID of the setting."
+            },
+            "patternProperties": {
+              "": {
+                "type": [
+                  "string",
+                  "number",
+                  "boolean"
+                ],
+                "description": "The value of the setting."
+              }
+            },
+            "additionalProperties": false
+          },
+          "placeholder": {
+            "type": "string",
+            "description": "The placeholder for settings that require input. Shown when the input is empty."
+          },
+          "value": {
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ],
+            "description": "The default value of the setting. Not compatible with `values`."
+          },
+          "values": {
+            "type": "array",
+            "description": "The default values of the setting. Not compatible with `value`.",
+            "items": {
+              "type": [
+                "string",
+                "number",
+                "boolean"
+              ],
+              "description": "The value of the setting."
+            }
+          },
+          "multiLanguage": {
+            "type": "boolean",
+            "description": "When true, strings from the `general.json` file are available for use, plus the <service>.json file. False is not allowed."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "mobile": {
+      "type": "boolean",
+      "description": "Whether or not the activity has support for mobile devices."
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "author",
+    "service",
+    "description",
+    "url",
+    "version",
+    "apiVersion",
+    "logo",
+    "thumbnail",
+    "color",
+    "tags",
+    "category",
+    "regExp"
+  ]
+}

--- a/schemas/metadata/1.17.json
+++ b/schemas/metadata/1.17.json
@@ -1,0 +1,255 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.premid.app/metadata/1.17",
+  "title": "Metadata",
+  "type": "object",
+  "description": "Metadata that describes an activity.",
+  "definitions": {
+    "user": {
+      "type": "object",
+      "description": "User information.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user."
+        },
+        "id": {
+          "type": "string",
+          "description": "The Discord snowflake of the user.",
+          "pattern": "^\\d+$"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "id"
+      ]
+    }
+  },
+  "properties": {
+    "$schema": {
+      "$comment": "This is required otherwise the schema will fail itself when it is applied to a document via $schema. This is optional so that validators that use this schema don't fail if the metadata doesn't have the $schema property.",
+      "type": "string",
+      "description": "The metadata schema URL."
+    },
+    "author": {
+      "$ref": "#/definitions/user",
+      "description": "The author of this activity."
+    },
+    "contributors": {
+      "type": "array",
+      "description": "Any extra contributors to this activity.",
+      "items": {
+        "$ref": "#/definitions/user"
+      }
+    },
+    "service": {
+      "type": "string",
+      "description": "The service this activity is for."
+    },
+    "altnames": {
+      "type": "array",
+      "description": "Alternative names for the service.",
+      "items": {
+        "type": "string",
+        "description": "An alternative name."
+      },
+      "minItems": 1
+    },
+    "description": {
+      "type": "object",
+      "description": "A description of the activity in multiple languages.",
+      "propertyNames": {
+        "type": "string",
+        "description": "The language key in the format: languagecode or languagecode-regioncode.",
+        "pattern": "^[a-z]{2,3}(?:-(?:[a-z]{2}|[0-9]{1,3}))?$"
+      },
+      "patternProperties": {
+        "^[a-z]{2,3}(?:-(?:[a-z]{2}|[0-9]{1,3}))?$": {
+          "type": "string",
+          "description": "The description of the activity in the key's language."
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "en"
+      ]
+    },
+    "url": {
+      "type": [
+        "string",
+        "array"
+      ],
+      "description": "The service's website URL, or an array of URLs. Protocols should not be added. Not used for matching.",
+      "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$",
+      "items": {
+        "type": "string",
+        "description": "One of the service's website URLs.",
+        "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$"
+      },
+      "minItems": 2
+    },
+    "version": {
+      "type": "string",
+      "description": "The SemVer version of the activity in the format: major.minor.patch.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "apiVersion": {
+      "type": "integer",
+      "description": "The Activity System version this activity supports.",
+      "minimum": 1,
+      "maximum": 2
+    },
+    "logo": {
+      "type": "string",
+      "description": "The logo of the service this activity is for.",
+      "pattern": "^https?://.+\\.(png|jpe?g|gif|webp)$"
+    },
+    "thumbnail": {
+      "type": "string",
+      "description": "A thumbnail of the service this activity is for.",
+      "pattern": "^https?://.+\\.(png|jpe?g|gif|webp)$"
+    },
+    "color": {
+      "type": "string",
+      "description": "The theme color of the service this activity is for. Must be either a 6 digit or a 3 digit hex code.",
+      "pattern": "^#([A-Fa-f0-9]{3}){1,2}$"
+    },
+    "tags": {
+      "type": "array",
+      "description": "The tags for the activity.",
+      "items": {
+        "type": "string",
+        "description": "A tag.",
+        "pattern": "^[^A-Z\\s!\"#$%&'()*+,./:;<=>?@\\[\\\\\\]^_`{|}~]+$"
+      },
+      "minItems": 1
+    },
+    "category": {
+      "type": "string",
+      "description": "The category the activity falls under.",
+      "enum": [
+        "anime",
+        "games",
+        "music",
+        "socials",
+        "videos",
+        "other"
+      ]
+    },
+    "iframe": {
+      "type": "boolean",
+      "description": "Whether or not the activity should run in iframes."
+    },
+    "readLogs": {
+      "type": "boolean",
+      "description": "Whether or not the extension should be reading logs."
+    },
+    "regExp": {
+      "type": "string",
+      "description": "A regular expression used to match URLs for the activity to inject into."
+    },
+    "iFrameRegExp": {
+      "type": "string",
+      "description": "A regular expression used to match iframes for the activity to inject into."
+    },
+    "allowURLOverrides": {
+      "type": "boolean",
+      "description": "Whether or not the activity should allow the user to override the activity's matching regExps."
+    },
+    "settings": {
+      "type": "array",
+      "description": "An array of settings the user can change in the activity.",
+      "items": {
+        "type": "object",
+        "description": "A setting.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the setting."
+          },
+          "title": {
+            "type": "string",
+            "description": "The title of the setting. Required only if `multiLanguage` is disabled."
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the setting. Only applicable if `multiLanguage` is disabled."
+          },
+          "icon": {
+            "type": "string",
+            "description": "The icon of the setting. Required only if `multiLanguage` is disabled.",
+            "pattern": "^fa([bsd]|([-](brands|solid|duotone))) fa-[0-9a-z-]+$"
+          },
+          "if": {
+            "type": "object",
+            "description": "Restrict showing this setting if another setting is the defined value.",
+            "propertyNames": {
+              "type": "string",
+              "description": "The ID of the setting."
+            },
+            "patternProperties": {
+              "": {
+                "type": [
+                  "string",
+                  "number",
+                  "boolean"
+                ],
+                "description": "The value of the setting."
+              }
+            },
+            "additionalProperties": false
+          },
+          "placeholder": {
+            "type": "string",
+            "description": "The placeholder for settings that require input. Shown when the input is empty."
+          },
+          "value": {
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ],
+            "description": "The default value of the setting. Not compatible with `values`."
+          },
+          "values": {
+            "type": "array",
+            "description": "The default values of the setting. Not compatible with `value`.",
+            "items": {
+              "type": [
+                "string",
+                "number",
+                "boolean"
+              ],
+              "description": "The value of the setting."
+            }
+          },
+          "multiLanguage": {
+            "type": "boolean",
+            "description": "When true, strings from the `general.json` file are available for use, plus the <service>.json file. False is not allowed."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "mobile": {
+      "type": "boolean",
+      "description": "Whether or not the activity has support for mobile devices."
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "author",
+    "service",
+    "description",
+    "url",
+    "version",
+    "apiVersion",
+    "logo",
+    "thumbnail",
+    "color",
+    "tags",
+    "category",
+    "regExp"
+  ]
+}

--- a/schemas/metadata/1.2.json
+++ b/schemas/metadata/1.2.json
@@ -1,0 +1,257 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.premid.app/metadata/1.0",
+
+  "title": "Metadata",
+  "type": "object",
+  "description": "Metadata that describes a presence.",
+
+  "definitions": {
+    "user": {
+      "type": "object",
+      "description": "User information.",
+
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user."
+        },
+
+        "id": {
+          "type": "string",
+          "description": "The Discord snowflake of the user.",
+          "pattern": "^\\d+$"
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["name", "id"]
+    }
+  },
+
+  "properties": {
+    "$schema": {
+      "$comment": "This is required otherwise the schema will fail itself when it is applied to a document via $schema. This is optional so that validators that use this schema don't fail if the metadata doesn't have the $schema property.",
+
+      "type": "string",
+      "description": "The metadata schema URL."
+    },
+
+    "author": {
+      "$ref": "#/definitions/user",
+      "description": "The author of this presence."
+    },
+
+    "contributors": {
+      "type": "array",
+      "description": "Any extra contributors to this presence.",
+
+      "items": {
+        "$ref": "#/definitions/user"
+      }
+    },
+
+    "service": {
+      "type": "string",
+      "description": "The service this presence is for."
+    },
+
+    "altnames": {
+      "type": "array",
+      "description": "Alternative names for the service.",
+
+      "items": {
+        "type": "string",
+        "description": "An alternative name."
+      },
+      "minItems": 1
+    },
+
+    "description": {
+      "type": "object",
+      "description": "A description of the presence in multiple languages.",
+
+      "propertyNames": {
+        "type": "string",
+        "description": "The language key. The key must be languagecode(_REGIONCODE).",
+        "pattern": "^[a-z]{2}(_[A-Z]{2})?$"
+      },
+      "patternProperties": {
+        "^[a-z]{2}(_[A-Z]{2})?$": {
+          "type": "string",
+          "description": "The description of the presence in the key's language."
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["en"]
+    },
+
+    "url": {
+      "type": ["string", "array"],
+      "description": "The service's website URL, or an array of URLs. Protocols should not be added.",
+      "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$",
+
+      "items": {
+        "type": "string",
+        "description": "One of the service's website URLs.",
+        "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$"
+      },
+      "minItems": 2
+    },
+
+    "version": {
+      "type": "string",
+      "description": "The SemVer version of the presence. Must just be major.minor.patch.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+
+    "logo": {
+      "type": "string",
+      "description": "The logo of the service this presence is for.",
+      "pattern": "^https?:\\/\\/?(?:[a-z0-9-]+\\.)*[0-9a-z_-]+(?:\\.[a-z]+)+\\/.*$"
+    },
+
+    "thumbnail": {
+      "type": "string",
+      "description": "A thumbnail of the service this presence is for.",
+      "pattern": "^https?:\\/\\/?([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+\\/.*$"
+    },
+
+    "color": {
+      "type": "string",
+      "description": "The theme color of the service this presence is for. Must be either a 6 digit or a 3 digit hex code.",
+      "pattern": "^#([A-Fa-f0-9]{3}){1,2}$"
+    },
+
+    "tags": {
+      "type": ["array"],
+      "description": "The tags for the presence.",
+
+      "items": {
+        "type": "string",
+        "description": "A tag.",
+        "pattern": "^[^A-Z\\s!\"#$%&'()*+,./:;<=>?@\\[\\\\\\]^_`{|}~]+$"
+      },
+      "minItems": 1
+    },
+
+    "category": {
+      "type": "string",
+      "description": "The category the presence falls under.",
+      "enum": ["anime", "games", "music", "socials", "videos", "other"]
+    },
+
+    "iframe": {
+      "type": "boolean",
+      "description": "Whether or not the presence should run in IFrames."
+    },
+
+    "readLogs": {
+      "type": "boolean",
+      "description": "Whether or not the extension should be reading logs."
+    },
+
+    "regExp": {
+      "type": "string",
+      "description": "A regular expression used to match URLs for the presence to inject into."
+    },
+
+    "iFrameRegExp": {
+      "type": "string",
+      "description": "A regular expression used to match IFrames for the presence to inject into."
+    },
+
+    "button": {
+      "type": "boolean",
+      "description": "Controls whether the presence is automatically added when the extension is installed. For partner presences only."
+    },
+
+    "warning": {
+      "type": "boolean",
+      "description": "Shows a warning saying that it requires additional steps for the presence to function correctly."
+    },
+
+    "settings": {
+      "type": "array",
+      "description": "An array of settings the user can change in the presence.",
+
+      "items": {
+        "type": "object",
+        "description": "A setting.",
+
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the setting."
+          },
+
+          "title": {
+            "type": "string",
+            "description": "The title of the setting. Required only if `multiLanguage` is disabled."
+          },
+
+          "icon": {
+            "type": "string",
+            "description": "The icon of the setting. Required only if `multiLanguage` is disabled.",
+            "pattern": "^fa[bs] fa-[0-9a-z-]+$"
+          },
+
+          "if": {
+            "type": "object",
+            "description": "Restrict showing this setting if another setting is the defined value.",
+
+            "propertyNames": {
+              "type": "string",
+              "description": "The ID of the setting."
+            },
+
+            "patternProperties": {
+              "": {
+                "type": ["string", "number", "boolean"],
+                "description": "The value of the setting."
+              }
+            },
+
+            "additionalProperties": false
+          },
+
+          "placeholder": {
+            "type": "string",
+            "description": "The placeholder for settings that require input. Shown when the input is empty."
+          },
+
+          "value": {
+            "type": ["string", "number", "boolean"],
+            "description": "The default value of the setting. Not compatible with `values`."
+          },
+
+          "values": {
+            "type": "array",
+            "description": "The default values of the setting. Not compatible with `value`.",
+
+            "items": {
+              "type": ["string", "number", "boolean"],
+              "description": "The value of the setting."
+            }
+          },
+
+          "multiLanguage": {
+            "type": ["string", "boolean", "array"],
+            "description": "When false, multi-localization is disabled. When true, strings from the `general.json` file are available for use. When a string, it is the name of a file (excluding .json) of a used language from the localization GitHub repo. When an array of strings, it is all of the file names (excluding .json) of used languages from the localization GitHub repo.",
+
+            "items": {
+              "type": "string",
+              "description": "The name of a file from the localization GitHub repository."
+            }
+          }
+        },
+
+        "additionalProperties": false
+      }
+    }
+  },
+
+  "additionalProperties": false,
+  "required": ["author", "service", "description", "url", "version", "logo", "thumbnail", "color", "tags", "category"]
+}

--- a/schemas/metadata/1.3.json
+++ b/schemas/metadata/1.3.json
@@ -1,0 +1,257 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.premid.app/metadata/1.3",
+
+  "title": "Metadata",
+  "type": "object",
+  "description": "Metadata that describes a presence.",
+
+  "definitions": {
+    "user": {
+      "type": "object",
+      "description": "User information.",
+
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user."
+        },
+
+        "id": {
+          "type": "string",
+          "description": "The Discord snowflake of the user.",
+          "pattern": "^\\d+$"
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["name", "id"]
+    }
+  },
+
+  "properties": {
+    "$schema": {
+      "$comment": "This is required otherwise the schema will fail itself when it is applied to a document via $schema. This is optional so that validators that use this schema don't fail if the metadata doesn't have the $schema property.",
+
+      "type": "string",
+      "description": "The metadata schema URL."
+    },
+
+    "author": {
+      "$ref": "#/definitions/user",
+      "description": "The author of this presence."
+    },
+
+    "contributors": {
+      "type": "array",
+      "description": "Any extra contributors to this presence.",
+
+      "items": {
+        "$ref": "#/definitions/user"
+      }
+    },
+
+    "service": {
+      "type": "string",
+      "description": "The service this presence is for."
+    },
+
+    "altnames": {
+      "type": "array",
+      "description": "Alternative names for the service.",
+
+      "items": {
+        "type": "string",
+        "description": "An alternative name."
+      },
+      "minItems": 1
+    },
+
+    "description": {
+      "type": "object",
+      "description": "A description of the presence in multiple languages.",
+
+      "propertyNames": {
+        "type": "string",
+        "description": "The language key. The key must be languagecode(_REGIONCODE).",
+        "pattern": "^[a-z]{2}(_[A-Z]{2})?$"
+      },
+      "patternProperties": {
+        "^[a-z]{2}(_[A-Z]{2})?$": {
+          "type": "string",
+          "description": "The description of the presence in the key's language."
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["en"]
+    },
+
+    "url": {
+      "type": ["string", "array"],
+      "description": "The service's website URL, or an array of URLs. Protocols should not be added.",
+      "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$",
+
+      "items": {
+        "type": "string",
+        "description": "One of the service's website URLs.",
+        "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$"
+      },
+      "minItems": 2
+    },
+
+    "version": {
+      "type": "string",
+      "description": "The SemVer version of the presence. Must just be major.minor.patch.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+
+    "logo": {
+      "type": "string",
+      "description": "The logo of the service this presence is for.",
+      "pattern": "^https?:\\/\\/?(?:[a-z0-9-]+\\.)*[0-9a-z_-]+(?:\\.[a-z]+)+\\/.*$"
+    },
+
+    "thumbnail": {
+      "type": "string",
+      "description": "A thumbnail of the service this presence is for.",
+      "pattern": "^https?:\\/\\/?([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+\\/.*$"
+    },
+
+    "color": {
+      "type": "string",
+      "description": "The theme color of the service this presence is for. Must be either a 6 digit or a 3 digit hex code.",
+      "pattern": "^#([A-Fa-f0-9]{3}){1,2}$"
+    },
+
+    "tags": {
+      "type": ["array"],
+      "description": "The tags for the presence.",
+
+      "items": {
+        "type": "string",
+        "description": "A tag.",
+        "pattern": "^[^A-Z\\s!\"#$%&'()*+,./:;<=>?@\\[\\\\\\]^_`{|}~]+$"
+      },
+      "minItems": 1
+    },
+
+    "category": {
+      "type": "string",
+      "description": "The category the presence falls under.",
+      "enum": ["anime", "games", "music", "socials", "videos", "other"]
+    },
+
+    "iframe": {
+      "type": "boolean",
+      "description": "Whether or not the presence should run in IFrames."
+    },
+
+    "readLogs": {
+      "type": "boolean",
+      "description": "Whether or not the extension should be reading logs."
+    },
+
+    "regExp": {
+      "type": "string",
+      "description": "A regular expression used to match URLs for the presence to inject into."
+    },
+
+    "iFrameRegExp": {
+      "type": "string",
+      "description": "A regular expression used to match IFrames for the presence to inject into."
+    },
+
+    "button": {
+      "type": "boolean",
+      "description": "Controls whether the presence is automatically added when the extension is installed. For partner presences only."
+    },
+
+    "warning": {
+      "type": "boolean",
+      "description": "Shows a warning saying that it requires additional steps for the presence to function correctly."
+    },
+
+    "settings": {
+      "type": "array",
+      "description": "An array of settings the user can change in the presence.",
+
+      "items": {
+        "type": "object",
+        "description": "A setting.",
+
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the setting."
+          },
+
+          "title": {
+            "type": "string",
+            "description": "The title of the setting. Required only if `multiLanguage` is disabled."
+          },
+
+          "icon": {
+            "type": "string",
+            "description": "The icon of the setting. Required only if `multiLanguage` is disabled.",
+            "pattern": "^fa[bsd] fa-[0-9a-z-]+$"
+          },
+
+          "if": {
+            "type": "object",
+            "description": "Restrict showing this setting if another setting is the defined value.",
+
+            "propertyNames": {
+              "type": "string",
+              "description": "The ID of the setting."
+            },
+
+            "patternProperties": {
+              "": {
+                "type": ["string", "number", "boolean"],
+                "description": "The value of the setting."
+              }
+            },
+
+            "additionalProperties": false
+          },
+
+          "placeholder": {
+            "type": "string",
+            "description": "The placeholder for settings that require input. Shown when the input is empty."
+          },
+
+          "value": {
+            "type": ["string", "number", "boolean"],
+            "description": "The default value of the setting. Not compatible with `values`."
+          },
+
+          "values": {
+            "type": "array",
+            "description": "The default values of the setting. Not compatible with `value`.",
+
+            "items": {
+              "type": ["string", "number", "boolean"],
+              "description": "The value of the setting."
+            }
+          },
+
+          "multiLanguage": {
+            "type": ["string", "boolean", "array"],
+            "description": "When false, multi-localization is disabled. When true, strings from the `general.json` file are available for use. When a string, it is the name of a file (excluding .json) of a used language from the localization GitHub repo. When an array of strings, it is all of the file names (excluding .json) of used languages from the localization GitHub repo.",
+
+            "items": {
+              "type": "string",
+              "description": "The name of a file from the localization GitHub repository."
+            }
+          }
+        },
+
+        "additionalProperties": false
+      }
+    }
+  },
+
+  "additionalProperties": false,
+  "required": ["author", "service", "description", "url", "version", "logo", "thumbnail", "color", "tags", "category"]
+}

--- a/schemas/metadata/1.4.json
+++ b/schemas/metadata/1.4.json
@@ -1,0 +1,257 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.premid.app/metadata/1.4",
+
+  "title": "Metadata",
+  "type": "object",
+  "description": "Metadata that describes a presence.",
+
+  "definitions": {
+    "user": {
+      "type": "object",
+      "description": "User information.",
+
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user."
+        },
+
+        "id": {
+          "type": "string",
+          "description": "The Discord snowflake of the user.",
+          "pattern": "^\\d+$"
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["name", "id"]
+    }
+  },
+
+  "properties": {
+    "$schema": {
+      "$comment": "This is required otherwise the schema will fail itself when it is applied to a document via $schema. This is optional so that validators that use this schema don't fail if the metadata doesn't have the $schema property.",
+
+      "type": "string",
+      "description": "The metadata schema URL."
+    },
+
+    "author": {
+      "$ref": "#/definitions/user",
+      "description": "The author of this presence."
+    },
+
+    "contributors": {
+      "type": "array",
+      "description": "Any extra contributors to this presence.",
+
+      "items": {
+        "$ref": "#/definitions/user"
+      }
+    },
+
+    "service": {
+      "type": "string",
+      "description": "The service this presence is for."
+    },
+
+    "altnames": {
+      "type": "array",
+      "description": "Alternative names for the service.",
+
+      "items": {
+        "type": "string",
+        "description": "An alternative name."
+      },
+      "minItems": 1
+    },
+
+    "description": {
+      "type": "object",
+      "description": "A description of the presence in multiple languages.",
+
+      "propertyNames": {
+        "type": "string",
+        "description": "The language key. The key must be languagecode(_REGIONCODE).",
+        "pattern": "^[a-z]{2}(_[A-Z]{2})?$"
+      },
+      "patternProperties": {
+        "^[a-z]{2}(_[A-Z]{2})?$": {
+          "type": "string",
+          "description": "The description of the presence in the key's language."
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["en"]
+    },
+
+    "url": {
+      "type": ["string", "array"],
+      "description": "The service's website URL, or an array of URLs. Protocols should not be added.",
+      "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$",
+
+      "items": {
+        "type": "string",
+        "description": "One of the service's website URLs.",
+        "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$"
+      },
+      "minItems": 2
+    },
+
+    "version": {
+      "type": "string",
+      "description": "The SemVer version of the presence. Must just be major.minor.patch.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+
+    "logo": {
+      "type": "string",
+      "description": "The logo of the service this presence is for.",
+      "pattern": "^https?://(i).(imgur).(com)/(.*?).(png|jpg)$"
+    },
+
+    "thumbnail": {
+      "type": "string",
+      "description": "A thumbnail of the service this presence is for.",
+      "pattern": "^https?://(i).(imgur).(com)/(.*?).(png|jpg)$"
+    },
+
+    "color": {
+      "type": "string",
+      "description": "The theme color of the service this presence is for. Must be either a 6 digit or a 3 digit hex code.",
+      "pattern": "^#([A-Fa-f0-9]{3}){1,2}$"
+    },
+
+    "tags": {
+      "type": ["array"],
+      "description": "The tags for the presence.",
+
+      "items": {
+        "type": "string",
+        "description": "A tag.",
+        "pattern": "^[^A-Z\\s!\"#$%&'()*+,./:;<=>?@\\[\\\\\\]^_`{|}~]+$"
+      },
+      "minItems": 1
+    },
+
+    "category": {
+      "type": "string",
+      "description": "The category the presence falls under.",
+      "enum": ["anime", "games", "music", "socials", "videos", "other"]
+    },
+
+    "iframe": {
+      "type": "boolean",
+      "description": "Whether or not the presence should run in IFrames."
+    },
+
+    "readLogs": {
+      "type": "boolean",
+      "description": "Whether or not the extension should be reading logs."
+    },
+
+    "regExp": {
+      "type": "string",
+      "description": "A regular expression used to match URLs for the presence to inject into."
+    },
+
+    "iFrameRegExp": {
+      "type": "string",
+      "description": "A regular expression used to match IFrames for the presence to inject into."
+    },
+
+    "button": {
+      "type": "boolean",
+      "description": "Controls whether the presence is automatically added when the extension is installed. For partner presences only."
+    },
+
+    "warning": {
+      "type": "boolean",
+      "description": "Shows a warning saying that it requires additional steps for the presence to function correctly."
+    },
+
+    "settings": {
+      "type": "array",
+      "description": "An array of settings the user can change in the presence.",
+
+      "items": {
+        "type": "object",
+        "description": "A setting.",
+
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the setting."
+          },
+
+          "title": {
+            "type": "string",
+            "description": "The title of the setting. Required only if `multiLanguage` is disabled."
+          },
+
+          "icon": {
+            "type": "string",
+            "description": "The icon of the setting. Required only if `multiLanguage` is disabled.",
+            "pattern": "^fa[bsd] fa-[0-9a-z-]+$"
+          },
+
+          "if": {
+            "type": "object",
+            "description": "Restrict showing this setting if another setting is the defined value.",
+
+            "propertyNames": {
+              "type": "string",
+              "description": "The ID of the setting."
+            },
+
+            "patternProperties": {
+              "": {
+                "type": ["string", "number", "boolean"],
+                "description": "The value of the setting."
+              }
+            },
+
+            "additionalProperties": false
+          },
+
+          "placeholder": {
+            "type": "string",
+            "description": "The placeholder for settings that require input. Shown when the input is empty."
+          },
+
+          "value": {
+            "type": ["string", "number", "boolean"],
+            "description": "The default value of the setting. Not compatible with `values`."
+          },
+
+          "values": {
+            "type": "array",
+            "description": "The default values of the setting. Not compatible with `value`.",
+
+            "items": {
+              "type": ["string", "number", "boolean"],
+              "description": "The value of the setting."
+            }
+          },
+
+          "multiLanguage": {
+            "type": ["string", "boolean", "array"],
+            "description": "When false, multi-localization is disabled. When true, strings from the `general.json` file are available for use. When a string, it is the name of a file (excluding .json) of a used language from the localization GitHub repo. When an array of strings, it is all of the file names (excluding .json) of used languages from the localization GitHub repo.",
+
+            "items": {
+              "type": "string",
+              "description": "The name of a file from the localization GitHub repository."
+            }
+          }
+        },
+
+        "additionalProperties": false
+      }
+    }
+  },
+
+  "additionalProperties": false,
+  "required": ["author", "service", "description", "url", "version", "logo", "thumbnail", "color", "tags", "category"]
+}

--- a/schemas/metadata/1.5.json
+++ b/schemas/metadata/1.5.json
@@ -1,0 +1,257 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.premid.app/metadata/1.5",
+
+  "title": "Metadata",
+  "type": "object",
+  "description": "Metadata that describes a presence.",
+
+  "definitions": {
+    "user": {
+      "type": "object",
+      "description": "User information.",
+
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user."
+        },
+
+        "id": {
+          "type": "string",
+          "description": "The Discord snowflake of the user.",
+          "pattern": "^\\d+$"
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["name", "id"]
+    }
+  },
+
+  "properties": {
+    "$schema": {
+      "$comment": "This is required otherwise the schema will fail itself when it is applied to a document via $schema. This is optional so that validators that use this schema don't fail if the metadata doesn't have the $schema property.",
+
+      "type": "string",
+      "description": "The metadata schema URL."
+    },
+
+    "author": {
+      "$ref": "#/definitions/user",
+      "description": "The author of this presence."
+    },
+
+    "contributors": {
+      "type": "array",
+      "description": "Any extra contributors to this presence.",
+
+      "items": {
+        "$ref": "#/definitions/user"
+      }
+    },
+
+    "service": {
+      "type": "string",
+      "description": "The service this presence is for."
+    },
+
+    "altnames": {
+      "type": "array",
+      "description": "Alternative names for the service.",
+
+      "items": {
+        "type": "string",
+        "description": "An alternative name."
+      },
+      "minItems": 1
+    },
+
+    "description": {
+      "type": "object",
+      "description": "A description of the presence in multiple languages.",
+
+      "propertyNames": {
+        "type": "string",
+        "description": "The language key. The key must be languagecode(_REGIONCODE).",
+        "pattern": "^[a-z]{2}(_[A-Z]{2})?$"
+      },
+      "patternProperties": {
+        "^[a-z]{2}(_[A-Z]{2})?$": {
+          "type": "string",
+          "description": "The description of the presence in the key's language."
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["en"]
+    },
+
+    "url": {
+      "type": ["string", "array"],
+      "description": "The service's website URL, or an array of URLs. Protocols should not be added.",
+      "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$",
+
+      "items": {
+        "type": "string",
+        "description": "One of the service's website URLs.",
+        "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$"
+      },
+      "minItems": 2
+    },
+
+    "version": {
+      "type": "string",
+      "description": "The SemVer version of the presence. Must just be major.minor.patch.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+
+    "logo": {
+      "type": "string",
+      "description": "The logo of the service this presence is for.",
+      "pattern": "^https?://(i).(imgur).(com)/(.*?).(png|jpe?g|gif)$"
+    },
+
+    "thumbnail": {
+      "type": "string",
+      "description": "A thumbnail of the service this presence is for.",
+      "pattern": "^https?://(i).(imgur).(com)/(.*?).(png|jpe?g)$"
+    },
+
+    "color": {
+      "type": "string",
+      "description": "The theme color of the service this presence is for. Must be either a 6 digit or a 3 digit hex code.",
+      "pattern": "^#([A-Fa-f0-9]{3}){1,2}$"
+    },
+
+    "tags": {
+      "type": ["array"],
+      "description": "The tags for the presence.",
+
+      "items": {
+        "type": "string",
+        "description": "A tag.",
+        "pattern": "^[^A-Z\\s!\"#$%&'()*+,./:;<=>?@\\[\\\\\\]^_`{|}~]+$"
+      },
+      "minItems": 1
+    },
+
+    "category": {
+      "type": "string",
+      "description": "The category the presence falls under.",
+      "enum": ["anime", "games", "music", "socials", "videos", "other"]
+    },
+
+    "iframe": {
+      "type": "boolean",
+      "description": "Whether or not the presence should run in IFrames."
+    },
+
+    "readLogs": {
+      "type": "boolean",
+      "description": "Whether or not the extension should be reading logs."
+    },
+
+    "regExp": {
+      "type": "string",
+      "description": "A regular expression used to match URLs for the presence to inject into."
+    },
+
+    "iFrameRegExp": {
+      "type": "string",
+      "description": "A regular expression used to match IFrames for the presence to inject into."
+    },
+
+    "button": {
+      "type": "boolean",
+      "description": "Controls whether the presence is automatically added when the extension is installed. For partner presences only."
+    },
+
+    "warning": {
+      "type": "boolean",
+      "description": "Shows a warning saying that it requires additional steps for the presence to function correctly."
+    },
+
+    "settings": {
+      "type": "array",
+      "description": "An array of settings the user can change in the presence.",
+
+      "items": {
+        "type": "object",
+        "description": "A setting.",
+
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the setting."
+          },
+
+          "title": {
+            "type": "string",
+            "description": "The title of the setting. Required only if `multiLanguage` is disabled."
+          },
+
+          "icon": {
+            "type": "string",
+            "description": "The icon of the setting. Required only if `multiLanguage` is disabled.",
+            "pattern": "^fa[bsd] fa-[0-9a-z-]+$"
+          },
+
+          "if": {
+            "type": "object",
+            "description": "Restrict showing this setting if another setting is the defined value.",
+
+            "propertyNames": {
+              "type": "string",
+              "description": "The ID of the setting."
+            },
+
+            "patternProperties": {
+              "": {
+                "type": ["string", "number", "boolean"],
+                "description": "The value of the setting."
+              }
+            },
+
+            "additionalProperties": false
+          },
+
+          "placeholder": {
+            "type": "string",
+            "description": "The placeholder for settings that require input. Shown when the input is empty."
+          },
+
+          "value": {
+            "type": ["string", "number", "boolean"],
+            "description": "The default value of the setting. Not compatible with `values`."
+          },
+
+          "values": {
+            "type": "array",
+            "description": "The default values of the setting. Not compatible with `value`.",
+
+            "items": {
+              "type": ["string", "number", "boolean"],
+              "description": "The value of the setting."
+            }
+          },
+
+          "multiLanguage": {
+            "type": ["string", "boolean", "array"],
+            "description": "When false, multi-localization is disabled. When true, strings from the `general.json` file are available for use. When a string, it is the name of a file (excluding .json) of a used language from the localization GitHub repo. When an array of strings, it is all of the file names (excluding .json) of used languages from the localization GitHub repo.",
+
+            "items": {
+              "type": "string",
+              "description": "The name of a file from the localization GitHub repository."
+            }
+          }
+        },
+
+        "additionalProperties": false
+      }
+    }
+  },
+
+  "additionalProperties": false,
+  "required": ["author", "service", "description", "url", "version", "logo", "thumbnail", "color", "tags", "category"]
+}

--- a/schemas/metadata/1.6.json
+++ b/schemas/metadata/1.6.json
@@ -1,0 +1,257 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.premid.app/metadata/1.6",
+
+  "title": "Metadata",
+  "type": "object",
+  "description": "Metadata that describes a presence.",
+
+  "definitions": {
+    "user": {
+      "type": "object",
+      "description": "User information.",
+
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user."
+        },
+
+        "id": {
+          "type": "string",
+          "description": "The Discord snowflake of the user.",
+          "pattern": "^\\d+$"
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["name", "id"]
+    }
+  },
+
+  "properties": {
+    "$schema": {
+      "$comment": "This is required otherwise the schema will fail itself when it is applied to a document via $schema. This is optional so that validators that use this schema don't fail if the metadata doesn't have the $schema property.",
+
+      "type": "string",
+      "description": "The metadata schema URL."
+    },
+
+    "author": {
+      "$ref": "#/definitions/user",
+      "description": "The author of this presence."
+    },
+
+    "contributors": {
+      "type": "array",
+      "description": "Any extra contributors to this presence.",
+
+      "items": {
+        "$ref": "#/definitions/user"
+      }
+    },
+
+    "service": {
+      "type": "string",
+      "description": "The service this presence is for."
+    },
+
+    "altnames": {
+      "type": "array",
+      "description": "Alternative names for the service.",
+
+      "items": {
+        "type": "string",
+        "description": "An alternative name."
+      },
+      "minItems": 1
+    },
+
+    "description": {
+      "type": "object",
+      "description": "A description of the presence in multiple languages.",
+
+      "propertyNames": {
+        "type": "string",
+        "description": "The language key. The key must be languagecode(_REGIONCODE).",
+        "pattern": "^[a-z]{2}(?:_(?:[A-Z]{2}|[0-9]{1,3}))?$"
+      },
+      "patternProperties": {
+        "^[a-z]{2}(?:_(?:[A-Z]{2}|[0-9]{1,3}))?$": {
+          "type": "string",
+          "description": "The description of the presence in the key's language."
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["en"]
+    },
+
+    "url": {
+      "type": ["string", "array"],
+      "description": "The service's website URL, or an array of URLs. Protocols should not be added.",
+      "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$",
+
+      "items": {
+        "type": "string",
+        "description": "One of the service's website URLs.",
+        "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$"
+      },
+      "minItems": 2
+    },
+
+    "version": {
+      "type": "string",
+      "description": "The SemVer version of the presence. Must just be major.minor.patch.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+
+    "logo": {
+      "type": "string",
+      "description": "The logo of the service this presence is for.",
+      "pattern": "^https?://(i).(imgur).(com)/(.*?).(png|jpe?g|gif)$"
+    },
+
+    "thumbnail": {
+      "type": "string",
+      "description": "A thumbnail of the service this presence is for.",
+      "pattern": "^https?://(i).(imgur).(com)/(.*?).(png|jpe?g)$"
+    },
+
+    "color": {
+      "type": "string",
+      "description": "The theme color of the service this presence is for. Must be either a 6 digit or a 3 digit hex code.",
+      "pattern": "^#([A-Fa-f0-9]{3}){1,2}$"
+    },
+
+    "tags": {
+      "type": ["array"],
+      "description": "The tags for the presence.",
+
+      "items": {
+        "type": "string",
+        "description": "A tag.",
+        "pattern": "^[^A-Z\\s!\"#$%&'()*+,./:;<=>?@\\[\\\\\\]^_`{|}~]+$"
+      },
+      "minItems": 1
+    },
+
+    "category": {
+      "type": "string",
+      "description": "The category the presence falls under.",
+      "enum": ["anime", "games", "music", "socials", "videos", "other"]
+    },
+
+    "iframe": {
+      "type": "boolean",
+      "description": "Whether or not the presence should run in IFrames."
+    },
+
+    "readLogs": {
+      "type": "boolean",
+      "description": "Whether or not the extension should be reading logs."
+    },
+
+    "regExp": {
+      "type": "string",
+      "description": "A regular expression used to match URLs for the presence to inject into."
+    },
+
+    "iFrameRegExp": {
+      "type": "string",
+      "description": "A regular expression used to match IFrames for the presence to inject into."
+    },
+
+    "button": {
+      "type": "boolean",
+      "description": "Controls whether the presence is automatically added when the extension is installed. For partner presences only."
+    },
+
+    "warning": {
+      "type": "boolean",
+      "description": "Shows a warning saying that it requires additional steps for the presence to function correctly."
+    },
+
+    "settings": {
+      "type": "array",
+      "description": "An array of settings the user can change in the presence.",
+
+      "items": {
+        "type": "object",
+        "description": "A setting.",
+
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the setting."
+          },
+
+          "title": {
+            "type": "string",
+            "description": "The title of the setting. Required only if `multiLanguage` is disabled."
+          },
+
+          "icon": {
+            "type": "string",
+            "description": "The icon of the setting. Required only if `multiLanguage` is disabled.",
+            "pattern": "^fa[bsd] fa-[0-9a-z-]+$"
+          },
+
+          "if": {
+            "type": "object",
+            "description": "Restrict showing this setting if another setting is the defined value.",
+
+            "propertyNames": {
+              "type": "string",
+              "description": "The ID of the setting."
+            },
+
+            "patternProperties": {
+              "": {
+                "type": ["string", "number", "boolean"],
+                "description": "The value of the setting."
+              }
+            },
+
+            "additionalProperties": false
+          },
+
+          "placeholder": {
+            "type": "string",
+            "description": "The placeholder for settings that require input. Shown when the input is empty."
+          },
+
+          "value": {
+            "type": ["string", "number", "boolean"],
+            "description": "The default value of the setting. Not compatible with `values`."
+          },
+
+          "values": {
+            "type": "array",
+            "description": "The default values of the setting. Not compatible with `value`.",
+
+            "items": {
+              "type": ["string", "number", "boolean"],
+              "description": "The value of the setting."
+            }
+          },
+
+          "multiLanguage": {
+            "type": ["string", "boolean", "array"],
+            "description": "When false, multi-localization is disabled. When true, strings from the `general.json` file are available for use. When a string, it is the name of a file (excluding .json) of a used language from the localization GitHub repo. When an array of strings, it is all of the file names (excluding .json) of used languages from the localization GitHub repo.",
+
+            "items": {
+              "type": "string",
+              "description": "The name of a file from the localization GitHub repository."
+            }
+          }
+        },
+
+        "additionalProperties": false
+      }
+    }
+  },
+
+  "additionalProperties": false,
+  "required": ["author", "service", "description", "url", "version", "logo", "thumbnail", "color", "tags", "category"]
+}

--- a/schemas/metadata/1.7.json
+++ b/schemas/metadata/1.7.json
@@ -1,0 +1,257 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.premid.app/metadata/1.7",
+
+  "title": "Metadata",
+  "type": "object",
+  "description": "Metadata that describes a presence.",
+
+  "definitions": {
+    "user": {
+      "type": "object",
+      "description": "User information.",
+
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user."
+        },
+
+        "id": {
+          "type": "string",
+          "description": "The Discord snowflake of the user.",
+          "pattern": "^\\d+$"
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["name", "id"]
+    }
+  },
+
+  "properties": {
+    "$schema": {
+      "$comment": "This is required otherwise the schema will fail itself when it is applied to a document via $schema. This is optional so that validators that use this schema don't fail if the metadata doesn't have the $schema property.",
+
+      "type": "string",
+      "description": "The metadata schema URL."
+    },
+
+    "author": {
+      "$ref": "#/definitions/user",
+      "description": "The author of this presence."
+    },
+
+    "contributors": {
+      "type": "array",
+      "description": "Any extra contributors to this presence.",
+
+      "items": {
+        "$ref": "#/definitions/user"
+      }
+    },
+
+    "service": {
+      "type": "string",
+      "description": "The service this presence is for."
+    },
+
+    "altnames": {
+      "type": "array",
+      "description": "Alternative names for the service.",
+
+      "items": {
+        "type": "string",
+        "description": "An alternative name."
+      },
+      "minItems": 1
+    },
+
+    "description": {
+      "type": "object",
+      "description": "A description of the presence in multiple languages.",
+
+      "propertyNames": {
+        "type": "string",
+        "description": "The language key. The key must be languagecode(_REGIONCODE).",
+        "pattern": "^[a-z]{2}(?:_(?:[A-Z]{2}|[0-9]{1,3}))?$"
+      },
+      "patternProperties": {
+        "^[a-z]{2}(?:_(?:[A-Z]{2}|[0-9]{1,3}))?$": {
+          "type": "string",
+          "description": "The description of the presence in the key's language."
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["en"]
+    },
+
+    "url": {
+      "type": ["string", "array"],
+      "description": "The service's website URL, or an array of URLs. Protocols should not be added.",
+      "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$",
+
+      "items": {
+        "type": "string",
+        "description": "One of the service's website URLs.",
+        "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$"
+      },
+      "minItems": 2
+    },
+
+    "version": {
+      "type": "string",
+      "description": "The SemVer version of the presence. Must just be major.minor.patch.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+
+    "logo": {
+      "type": "string",
+      "description": "The logo of the service this presence is for.",
+      "pattern": "^https?://(i).(imgur).(com)/(.*?).(png|jpe?g|gif)$"
+    },
+
+    "thumbnail": {
+      "type": "string",
+      "description": "A thumbnail of the service this presence is for.",
+      "pattern": "^https?://(i).(imgur).(com)/(.*?).(png|jpe?g)$"
+    },
+
+    "color": {
+      "type": "string",
+      "description": "The theme color of the service this presence is for. Must be either a 6 digit or a 3 digit hex code.",
+      "pattern": "^#([A-Fa-f0-9]{3}){1,2}$"
+    },
+
+    "tags": {
+      "type": ["array"],
+      "description": "The tags for the presence.",
+
+      "items": {
+        "type": "string",
+        "description": "A tag.",
+        "pattern": "^[^A-Z\\s!\"#$%&'()*+,./:;<=>?@\\[\\\\\\]^_`{|}~]+$"
+      },
+      "minItems": 1
+    },
+
+    "category": {
+      "type": "string",
+      "description": "The category the presence falls under.",
+      "enum": ["anime", "games", "music", "socials", "videos", "other"]
+    },
+
+    "iframe": {
+      "type": "boolean",
+      "description": "Whether or not the presence should run in IFrames."
+    },
+
+    "readLogs": {
+      "type": "boolean",
+      "description": "Whether or not the extension should be reading logs."
+    },
+
+    "regExp": {
+      "type": "string",
+      "description": "A regular expression used to match URLs for the presence to inject into."
+    },
+
+    "iFrameRegExp": {
+      "type": "string",
+      "description": "A regular expression used to match IFrames for the presence to inject into."
+    },
+
+    "button": {
+      "type": "boolean",
+      "description": "Controls whether the presence is automatically added when the extension is installed. For partner presences only."
+    },
+
+    "warning": {
+      "type": "boolean",
+      "description": "Shows a warning saying that it requires additional steps for the presence to function correctly."
+    },
+
+    "settings": {
+      "type": "array",
+      "description": "An array of settings the user can change in the presence.",
+
+      "items": {
+        "type": "object",
+        "description": "A setting.",
+
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the setting."
+          },
+
+          "title": {
+            "type": "string",
+            "description": "The title of the setting. Required only if `multiLanguage` is disabled."
+          },
+
+          "icon": {
+            "type": "string",
+            "description": "The icon of the setting. Required only if `multiLanguage` is disabled.",
+            "pattern": "^fa([bsdrlt]|([-](brands|solid|duotone|regular|light|thin))) fa-[0-9a-z-]+$"
+          },
+
+          "if": {
+            "type": "object",
+            "description": "Restrict showing this setting if another setting is the defined value.",
+
+            "propertyNames": {
+              "type": "string",
+              "description": "The ID of the setting."
+            },
+
+            "patternProperties": {
+              "": {
+                "type": ["string", "number", "boolean"],
+                "description": "The value of the setting."
+              }
+            },
+
+            "additionalProperties": false
+          },
+
+          "placeholder": {
+            "type": "string",
+            "description": "The placeholder for settings that require input. Shown when the input is empty."
+          },
+
+          "value": {
+            "type": ["string", "number", "boolean"],
+            "description": "The default value of the setting. Not compatible with `values`."
+          },
+
+          "values": {
+            "type": "array",
+            "description": "The default values of the setting. Not compatible with `value`.",
+
+            "items": {
+              "type": ["string", "number", "boolean"],
+              "description": "The value of the setting."
+            }
+          },
+
+          "multiLanguage": {
+            "type": ["string", "boolean", "array"],
+            "description": "When false, multi-localization is disabled. When true, strings from the `general.json` file are available for use. When a string, it is the name of a file (excluding .json) of a used language from the localization GitHub repo. When an array of strings, it is all of the file names (excluding .json) of used languages from the localization GitHub repo.",
+
+            "items": {
+              "type": "string",
+              "description": "The name of a file from the localization GitHub repository."
+            }
+          }
+        },
+
+        "additionalProperties": false
+      }
+    }
+  },
+
+  "additionalProperties": false,
+  "required": ["author", "service", "description", "url", "version", "logo", "thumbnail", "color", "tags", "category"]
+}

--- a/schemas/metadata/1.8.json
+++ b/schemas/metadata/1.8.json
@@ -1,0 +1,257 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.premid.app/metadata/1.8",
+
+  "title": "Metadata",
+  "type": "object",
+  "description": "Metadata that describes a presence.",
+
+  "definitions": {
+    "user": {
+      "type": "object",
+      "description": "User information.",
+
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user."
+        },
+
+        "id": {
+          "type": "string",
+          "description": "The Discord snowflake of the user.",
+          "pattern": "^\\d+$"
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["name", "id"]
+    }
+  },
+
+  "properties": {
+    "$schema": {
+      "$comment": "This is required otherwise the schema will fail itself when it is applied to a document via $schema. This is optional so that validators that use this schema don't fail if the metadata doesn't have the $schema property.",
+
+      "type": "string",
+      "description": "The metadata schema URL."
+    },
+
+    "author": {
+      "$ref": "#/definitions/user",
+      "description": "The author of this presence."
+    },
+
+    "contributors": {
+      "type": "array",
+      "description": "Any extra contributors to this presence.",
+
+      "items": {
+        "$ref": "#/definitions/user"
+      }
+    },
+
+    "service": {
+      "type": "string",
+      "description": "The service this presence is for."
+    },
+
+    "altnames": {
+      "type": "array",
+      "description": "Alternative names for the service.",
+
+      "items": {
+        "type": "string",
+        "description": "An alternative name."
+      },
+      "minItems": 1
+    },
+
+    "description": {
+      "type": "object",
+      "description": "A description of the presence in multiple languages.",
+
+      "propertyNames": {
+        "type": "string",
+        "description": "The language key. The key must be languagecode(_REGIONCODE).",
+        "pattern": "^[a-z]{2}(?:_(?:[A-Z]{2}|[0-9]{1,3}))?$"
+      },
+      "patternProperties": {
+        "^[a-z]{2}(?:_(?:[A-Z]{2}|[0-9]{1,3}))?$": {
+          "type": "string",
+          "description": "The description of the presence in the key's language."
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["en"]
+    },
+
+    "url": {
+      "type": ["string", "array"],
+      "description": "The service's website URL, or an array of URLs. Protocols should not be added.",
+      "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$",
+
+      "items": {
+        "type": "string",
+        "description": "One of the service's website URLs.",
+        "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$"
+      },
+      "minItems": 2
+    },
+
+    "version": {
+      "type": "string",
+      "description": "The SemVer version of the presence. Must just be major.minor.patch.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+
+    "logo": {
+      "type": "string",
+      "description": "The logo of the service this presence is for.",
+      "pattern": "^https?://(cdn[.]rcd[.]gg|i[.]imgur[.]com)/(.*?)[.](png|jpe?g|gif|webp)$"
+    },
+
+    "thumbnail": {
+      "type": "string",
+      "description": "A thumbnail of the service this presence is for.",
+      "pattern": "^https?://(cdn[.]rcd[.]gg|i[.]imgur[.]com)/(.*?)[.](png|jpe?g|gif|webp)$"
+    },
+
+    "color": {
+      "type": "string",
+      "description": "The theme color of the service this presence is for. Must be either a 6 digit or a 3 digit hex code.",
+      "pattern": "^#([A-Fa-f0-9]{3}){1,2}$"
+    },
+
+    "tags": {
+      "type": ["array"],
+      "description": "The tags for the presence.",
+
+      "items": {
+        "type": "string",
+        "description": "A tag.",
+        "pattern": "^[^A-Z\\s!\"#$%&'()*+,./:;<=>?@\\[\\\\\\]^_`{|}~]+$"
+      },
+      "minItems": 1
+    },
+
+    "category": {
+      "type": "string",
+      "description": "The category the presence falls under.",
+      "enum": ["anime", "games", "music", "socials", "videos", "other"]
+    },
+
+    "iframe": {
+      "type": "boolean",
+      "description": "Whether or not the presence should run in IFrames."
+    },
+
+    "readLogs": {
+      "type": "boolean",
+      "description": "Whether or not the extension should be reading logs."
+    },
+
+    "regExp": {
+      "type": "string",
+      "description": "A regular expression used to match URLs for the presence to inject into."
+    },
+
+    "iFrameRegExp": {
+      "type": "string",
+      "description": "A regular expression used to match IFrames for the presence to inject into."
+    },
+
+    "button": {
+      "type": "boolean",
+      "description": "Controls whether the presence is automatically added when the extension is installed. For partner presences only."
+    },
+
+    "warning": {
+      "type": "boolean",
+      "description": "Shows a warning saying that it requires additional steps for the presence to function correctly."
+    },
+
+    "settings": {
+      "type": "array",
+      "description": "An array of settings the user can change in the presence.",
+
+      "items": {
+        "type": "object",
+        "description": "A setting.",
+
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the setting."
+          },
+
+          "title": {
+            "type": "string",
+            "description": "The title of the setting. Required only if `multiLanguage` is disabled."
+          },
+
+          "icon": {
+            "type": "string",
+            "description": "The icon of the setting. Required only if `multiLanguage` is disabled.",
+            "pattern": "^fa([bsdrlt]|([-](brands|solid|duotone|regular|light|thin))) fa-[0-9a-z-]+$"
+          },
+
+          "if": {
+            "type": "object",
+            "description": "Restrict showing this setting if another setting is the defined value.",
+
+            "propertyNames": {
+              "type": "string",
+              "description": "The ID of the setting."
+            },
+
+            "patternProperties": {
+              "": {
+                "type": ["string", "number", "boolean"],
+                "description": "The value of the setting."
+              }
+            },
+
+            "additionalProperties": false
+          },
+
+          "placeholder": {
+            "type": "string",
+            "description": "The placeholder for settings that require input. Shown when the input is empty."
+          },
+
+          "value": {
+            "type": ["string", "number", "boolean"],
+            "description": "The default value of the setting. Not compatible with `values`."
+          },
+
+          "values": {
+            "type": "array",
+            "description": "The default values of the setting. Not compatible with `value`.",
+
+            "items": {
+              "type": ["string", "number", "boolean"],
+              "description": "The value of the setting."
+            }
+          },
+
+          "multiLanguage": {
+            "type": ["string", "boolean", "array"],
+            "description": "When false, multi-localization is disabled. When true, strings from the `general.json` file are available for use. When a string, it is the name of a file (excluding .json) of a used language from the localization GitHub repo. When an array of strings, it is all of the file names (excluding .json) of used languages from the localization GitHub repo.",
+
+            "items": {
+              "type": "string",
+              "description": "The name of a file from the localization GitHub repository."
+            }
+          }
+        },
+
+        "additionalProperties": false
+      }
+    }
+  },
+
+  "additionalProperties": false,
+  "required": ["author", "service", "description", "url", "version", "logo", "thumbnail", "color", "tags", "category"]
+}

--- a/schemas/metadata/1.9.json
+++ b/schemas/metadata/1.9.json
@@ -1,0 +1,257 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schemas.premid.app/metadata/1.9",
+
+  "title": "Metadata",
+  "type": "object",
+  "description": "Metadata that describes a presence.",
+
+  "definitions": {
+    "user": {
+      "type": "object",
+      "description": "User information.",
+
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user."
+        },
+
+        "id": {
+          "type": "string",
+          "description": "The Discord snowflake of the user.",
+          "pattern": "^\\d+$"
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["name", "id"]
+    }
+  },
+
+  "properties": {
+    "$schema": {
+      "$comment": "This is required otherwise the schema will fail itself when it is applied to a document via $schema. This is optional so that validators that use this schema don't fail if the metadata doesn't have the $schema property.",
+
+      "type": "string",
+      "description": "The metadata schema URL."
+    },
+
+    "author": {
+      "$ref": "#/definitions/user",
+      "description": "The author of this presence."
+    },
+
+    "contributors": {
+      "type": "array",
+      "description": "Any extra contributors to this presence.",
+
+      "items": {
+        "$ref": "#/definitions/user"
+      }
+    },
+
+    "service": {
+      "type": "string",
+      "description": "The service this presence is for."
+    },
+
+    "altnames": {
+      "type": "array",
+      "description": "Alternative names for the service.",
+
+      "items": {
+        "type": "string",
+        "description": "An alternative name."
+      },
+      "minItems": 1
+    },
+
+    "description": {
+      "type": "object",
+      "description": "A description of the presence in multiple languages.",
+
+      "propertyNames": {
+        "type": "string",
+        "description": "The language key. The key must be languagecode(_REGIONCODE).",
+        "pattern": "^[a-z]{2}(?:_(?:[A-Z]{2}|[0-9]{1,3}))?$"
+      },
+      "patternProperties": {
+        "^[a-z]{2}(?:_(?:[A-Z]{2}|[0-9]{1,3}))?$": {
+          "type": "string",
+          "description": "The description of the presence in the key's language."
+        }
+      },
+
+      "additionalProperties": false,
+      "required": ["en"]
+    },
+
+    "url": {
+      "type": ["string", "array"],
+      "description": "The service's website URL, or an array of URLs. Protocols should not be added.",
+      "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$",
+
+      "items": {
+        "type": "string",
+        "description": "One of the service's website URLs.",
+        "pattern": "^(([a-z0-9-]+\\.)*[0-9a-z_-]+(\\.[a-z]+)+|(\\d{1,3}\\.){3}\\d{1,3}|localhost)$"
+      },
+      "minItems": 2
+    },
+
+    "version": {
+      "type": "string",
+      "description": "The SemVer version of the presence. Must just be major.minor.patch.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+
+    "logo": {
+      "type": "string",
+      "description": "The logo of the service this presence is for.",
+      "pattern": "^https?://.+\\.(png|jpe?g|gif|webp)$"
+    },
+
+    "thumbnail": {
+      "type": "string",
+      "description": "A thumbnail of the service this presence is for.",
+      "pattern": "^https?://.+\\.(png|jpe?g|gif|webp)$"
+    },
+
+    "color": {
+      "type": "string",
+      "description": "The theme color of the service this presence is for. Must be either a 6 digit or a 3 digit hex code.",
+      "pattern": "^#([A-Fa-f0-9]{3}){1,2}$"
+    },
+
+    "tags": {
+      "type": ["array"],
+      "description": "The tags for the presence.",
+
+      "items": {
+        "type": "string",
+        "description": "A tag.",
+        "pattern": "^[^A-Z\\s!\"#$%&'()*+,./:;<=>?@\\[\\\\\\]^_`{|}~]+$"
+      },
+      "minItems": 1
+    },
+
+    "category": {
+      "type": "string",
+      "description": "The category the presence falls under.",
+      "enum": ["anime", "games", "music", "socials", "videos", "other"]
+    },
+
+    "iframe": {
+      "type": "boolean",
+      "description": "Whether or not the presence should run in IFrames."
+    },
+
+    "readLogs": {
+      "type": "boolean",
+      "description": "Whether or not the extension should be reading logs."
+    },
+
+    "regExp": {
+      "type": "string",
+      "description": "A regular expression used to match URLs for the presence to inject into."
+    },
+
+    "iFrameRegExp": {
+      "type": "string",
+      "description": "A regular expression used to match IFrames for the presence to inject into."
+    },
+
+    "button": {
+      "type": "boolean",
+      "description": "Controls whether the presence is automatically added when the extension is installed. For partner presences only."
+    },
+
+    "warning": {
+      "type": "boolean",
+      "description": "Shows a warning saying that it requires additional steps for the presence to function correctly."
+    },
+
+    "settings": {
+      "type": "array",
+      "description": "An array of settings the user can change in the presence.",
+
+      "items": {
+        "type": "object",
+        "description": "A setting.",
+
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the setting."
+          },
+
+          "title": {
+            "type": "string",
+            "description": "The title of the setting. Required only if `multiLanguage` is disabled."
+          },
+
+          "icon": {
+            "type": "string",
+            "description": "The icon of the setting. Required only if `multiLanguage` is disabled.",
+            "pattern": "^fa([bsdrlt]|([-](brands|solid|duotone|regular|light|thin))) fa-[0-9a-z-]+$"
+          },
+
+          "if": {
+            "type": "object",
+            "description": "Restrict showing this setting if another setting is the defined value.",
+
+            "propertyNames": {
+              "type": "string",
+              "description": "The ID of the setting."
+            },
+
+            "patternProperties": {
+              "": {
+                "type": ["string", "number", "boolean"],
+                "description": "The value of the setting."
+              }
+            },
+
+            "additionalProperties": false
+          },
+
+          "placeholder": {
+            "type": "string",
+            "description": "The placeholder for settings that require input. Shown when the input is empty."
+          },
+
+          "value": {
+            "type": ["string", "number", "boolean"],
+            "description": "The default value of the setting. Not compatible with `values`."
+          },
+
+          "values": {
+            "type": "array",
+            "description": "The default values of the setting. Not compatible with `value`.",
+
+            "items": {
+              "type": ["string", "number", "boolean"],
+              "description": "The value of the setting."
+            }
+          },
+
+          "multiLanguage": {
+            "type": ["string", "boolean", "array"],
+            "description": "When false, multi-localization is disabled. When true, strings from the `general.json` file are available for use. When a string, it is the name of a file (excluding .json) of a used language from the localization GitHub repo. When an array of strings, it is all of the file names (excluding .json) of used languages from the localization GitHub repo.",
+
+            "items": {
+              "type": "string",
+              "description": "The name of a file from the localization GitHub repository."
+            }
+          }
+        },
+
+        "additionalProperties": false
+      }
+    }
+  },
+
+  "additionalProperties": false,
+  "required": ["author", "service", "description", "url", "version", "logo", "thumbnail", "color", "tags", "category"]
+}

--- a/schemas/metadata/README.md
+++ b/schemas/metadata/README.md
@@ -1,0 +1,39 @@
+# Metadata Schema
+
+This schema is used to validate the `metadata.json` files in [PreMiD/Activities](https://github.com/PreMiD/Activities).
+
+## 1.17
+
+- Restricts setting `icon` to the FontAwesome families the extension ships (brands, solid, duotone); regular, light and thin are no longer allowed
+
+## 1.7
+
+- Updates `icon` regex for compability with FontAwesome v6 icon labelling
+
+## 1.6
+
+- Adds support for language locales that end in numbers (e.g. es_419)
+
+## 1.5
+
+- Allows `.gif` extensions for service logos and `.jpeg` extensions for service logos and thumbnails.
+
+## 1.4
+
+- Adds regex for only allowing imgur links for `logo` & `thumbnail`.
+
+## 1.3
+
+- Fixes validation for icons.
+
+## 1.2
+
+- Adds "readLogs".
+
+## 1.1
+
+- Adds "altnames" and "multiLanguage".
+
+## 1.0
+
+- First iteration of the metadata file format.


### PR DESCRIPTION
## What

Moves the metadata JSON schemas (1.0–1.17 + README) into this repo under `schemas/metadata/`, making PreMiD/Activities the source of truth for them. They currently live in the PreMiD/PreMiD monorepo (`apps/schema-server/schemas/metadata/`).

## Why

The new `schema-server` service in PreMiD/Go (PreMiD/Go#177) fetches schemas from this repo's raw content at runtime and caches them. With that in place, **adding a new schema version is just a commit here** — no container rebuild/redeploy of a schema server.

The `$id` of each schema still points at `https://schemas.premid.app/metadata/{version}`, so the public contract is unchanged: activities, the CLI, and the Go validator keep working exactly as before.

## Cutover (owned by maintainers)

1. Merge PreMiD/Go#177 and deploy the new `schema-server` service.
2. Point `schemas.premid.app` at it.
3. Retire `apps/schema-server` in PreMiD/PreMiD.

Until then nothing breaks — this PR only adds files.