### PR TITLE
feat(types): execInPage, onRequest & party APIs + supports() capability helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 !cli/bin/**/*.*js
 !*.config.*js
 !.github/scripts/**/*.mjs
+!eslint-rules/**/*.mjs
 websites/**/dist
 websites/**/tsconfig.json
 node_modules

--- a/@types/premid/index.d.ts
+++ b/@types/premid/index.d.ts
@@ -749,9 +749,9 @@ declare global {
      * ```
      * @since 2.14
      */
-    execInPage<T = unknown>(
-      fn: (...args: any[]) => T | Promise<T>,
-      ...args: unknown[]
+    execInPage<T = unknown, A extends unknown[] = unknown[]>(
+      fn: (...args: A) => T | Promise<T>,
+      ...args: A
     ): Promise<T>
     /**
      * Declarative, CSP-immune variant of `execInPage`. Reads a value (`get`) or
@@ -928,9 +928,9 @@ declare global {
      * extensions don't throw.
      * @since 2.14
      */
-    execInPage<T = unknown>(
-      fn: (...args: any[]) => T | Promise<T>,
-      ...args: unknown[]
+    execInPage<T = unknown, A extends unknown[] = unknown[]>(
+      fn: (...args: A) => T | Promise<T>,
+      ...args: A
     ): Promise<T>
     execInPage<T = unknown>(spec: ExecInPageSpec): Promise<T>
     /**

--- a/@types/premid/index.d.ts
+++ b/@types/premid/index.d.ts
@@ -454,9 +454,9 @@ declare global {
     call?: string
     /** Arguments passed to the `call` function (must be serializable). */
     args?: unknown[]
-    /** Only keep these top-level keys of the result. */
+    /** Keep only these keys of the result. Dot-paths allowed, e.g. `'track.name'`. */
     pick?: string[]
-    /** Drop these top-level keys from the result. */
+    /** Drop these keys from the result. Dot-paths allowed, e.g. `'track.art'`. */
     omit?: string[]
   }
 

--- a/@types/premid/index.d.ts
+++ b/@types/premid/index.d.ts
@@ -726,6 +726,14 @@ declare global {
      *   const s = window.spotifyPlayer.getCurrentState()
      *   return { id, title: s.track.name, paused: s.paused }
      * }, userId)
+     * @remarks
+     * Added in extension 2.14. Older versions lack this method, so feature-detect
+     * before calling to avoid throwing on outdated extensions:
+     * ```ts
+     * if (typeof presence.execInPage === 'function') {
+     *   const data = await presence.execInPage(() => window.appState)
+     * }
+     * ```
      * @since 2.14
      */
     execInPage<T = unknown>(
@@ -756,6 +764,14 @@ declare global {
      * presence.onRequest({ url: '/api/now-playing', method: 'GET' }, (req) => {
      *   const data = JSON.parse(req.responseBody ?? '{}')
      * })
+     * @remarks
+     * Added in extension 2.14. Older versions lack this method, so feature-detect
+     * before calling to avoid throwing on outdated extensions:
+     * ```ts
+     * if (typeof presence.onRequest === 'function') {
+     *   presence.onRequest({ url: '/api/now-playing' }, (req) => { ... })
+     * }
+     * ```
      * @since 2.14
      */
     onRequest(
@@ -892,6 +908,10 @@ declare global {
     /**
      * Run code in the iframe page's own realm and get its (serializable) return
      * value. See `Presence#execInPage` for the full contract.
+     * @remarks
+     * Added in extension 2.14 — feature-detect with
+     * `typeof iframe.execInPage === 'function'` before calling so older
+     * extensions don't throw.
      * @since 2.14
      */
     execInPage<T = unknown>(

--- a/@types/premid/index.d.ts
+++ b/@types/premid/index.d.ts
@@ -728,9 +728,10 @@ declare global {
      * }, userId)
      * @remarks
      * Added in extension 2.14. Older versions lack this method, so feature-detect
-     * before calling to avoid throwing on outdated extensions:
+     * with the bundled `supports` helper before calling:
      * ```ts
-     * if (typeof presence.execInPage === 'function') {
+     * import { supports } from 'premid'
+     * if (supports(presence, 'execInPage')) {
      *   const data = await presence.execInPage(() => window.appState)
      * }
      * ```
@@ -766,9 +767,10 @@ declare global {
      * })
      * @remarks
      * Added in extension 2.14. Older versions lack this method, so feature-detect
-     * before calling to avoid throwing on outdated extensions:
+     * with the bundled `supports` helper before calling:
      * ```ts
-     * if (typeof presence.onRequest === 'function') {
+     * import { supports } from 'premid'
+     * if (supports(presence, 'onRequest')) {
      *   presence.onRequest({ url: '/api/now-playing' }, (req) => { ... })
      * }
      * ```
@@ -909,8 +911,8 @@ declare global {
      * Run code in the iframe page's own realm and get its (serializable) return
      * value. See `Presence#execInPage` for the full contract.
      * @remarks
-     * Added in extension 2.14 — feature-detect with
-     * `typeof iframe.execInPage === 'function'` before calling so older
+     * Added in extension 2.14 — feature-detect with the bundled `supports`
+     * helper (`supports(iframe, 'execInPage')`) before calling so older
      * extensions don't throw.
      * @since 2.14
      */

--- a/@types/premid/index.d.ts
+++ b/@types/premid/index.d.ts
@@ -150,6 +150,18 @@ declare global {
      * @since 2.8.0
      */
     smallImageUrl?: string
+    /**
+     * Party info shown on Playing activities (e.g. "2 of 5").
+     *
+     * Only honored on `type: ActivityType.Playing`. `partyId` is optional —
+     * when omitted a stable fallback is generated.
+     * @since 2.14.0
+     */
+    party?: {
+      partyId?: string
+      partySize: number
+      maxPartySize: number
+    }
   }
 
   interface MediaPresenceData extends BasePresenceData {

--- a/@types/premid/index.d.ts
+++ b/@types/premid/index.d.ts
@@ -430,6 +430,56 @@ declare global {
   }
 
   /**
+   * Declarative, CSP-immune form of `Presence#execInPage` / `iFrame#execInPage`.
+   * Use instead of a closure when you only need to read a value or call a page
+   * function — it works even on pages whose CSP blocks `eval`.
+   * @since 2.14
+   */
+  interface ExecInPageSpec {
+    /** Dot-path to a value on `window` to read, e.g. `'player.track.name'`. */
+    get?: string
+    /** Dot-path to a page function to invoke, e.g. `'spotifyPlayer.getState'`. */
+    call?: string
+    /** Arguments passed to the `call` function (must be serializable). */
+    args?: unknown[]
+    /** Only keep these top-level keys of the result. */
+    pick?: string[]
+    /** Drop these top-level keys from the result. */
+    omit?: string[]
+  }
+
+  /**
+   * Filter for `Presence#onRequest`.
+   * @since 2.14
+   */
+  interface RequestFilter {
+    /** Match the request URL — substring (string) or pattern (RegExp). */
+    url?: string | RegExp
+    /** Match the HTTP method (case-insensitive). One or many. */
+    method?: string | string[]
+  }
+
+  /**
+   * Read-only snapshot of a captured request/response passed to an
+   * `Presence#onRequest` callback.
+   * @since 2.14
+   */
+  interface InterceptedRequest {
+    url: string
+    method: string
+    requestHeaders: Record<string, string>
+    requestBody: string | null
+    status: number
+    statusText: string
+    ok: boolean
+    responseHeaders: Record<string, string>
+    responseBody: string | null
+    /** URL of the frame the request originated from (page or iframe). */
+    frameUrl: string
+    timestamp: number
+  }
+
+  /**
    * Useful tools for developing presences
    * @link https://docs.premid.app/en/dev/presence/class
    */
@@ -663,6 +713,56 @@ declare global {
       ...variables: string[]
     ): Promise<T>
     /**
+     * Run code in the web page's own realm and get its (serializable) return value.
+     *
+     * Unlike `getPageVariable`, the function executes *inside the page*, so you
+     * can call the page's own functions and reshape the result — stripping
+     * non-serializable parts (streams, DOM nodes, circular refs) — before it is
+     * sent back. The return value must be JSON-serializable.
+     *
+     * The closure cannot reference activity-side variables; pass them as args.
+     * @example
+     * const track = await presence.execInPage((id) => {
+     *   const s = window.spotifyPlayer.getCurrentState()
+     *   return { id, title: s.track.name, paused: s.paused }
+     * }, userId)
+     * @since 2.14
+     */
+    execInPage<T = unknown>(
+      fn: (...args: any[]) => T | Promise<T>,
+      ...args: unknown[]
+    ): Promise<T>
+    /**
+     * Declarative, CSP-immune variant of `execInPage`. Reads a value (`get`) or
+     * calls a page function (`call`) and optionally strips fields — works even
+     * on pages whose CSP blocks `eval`.
+     * @example
+     * const paused = await presence.execInPage({ call: 'spotifyPlayer.isPaused' })
+     * @since 2.14
+     */
+    execInPage<T = unknown>(spec: ExecInPageSpec): Promise<T>
+    /**
+     * Read (never modify) requests the page makes via `fetch` or
+     * `XMLHttpRequest`, including requests made inside the activity's iframes.
+     * The callback receives a read-only snapshot of the request and its response.
+     *
+     * Interception runs from `document_start`; requests that complete before the
+     * activity registers a filter are replayed with request metadata only (no
+     * response body).
+     * @param filter Match by URL (substring or RegExp) and/or HTTP method.
+     * @param callback Invoked with each matching request.
+     * @returns Unsubscribe function.
+     * @example
+     * presence.onRequest({ url: '/api/now-playing', method: 'GET' }, (req) => {
+     *   const data = JSON.parse(req.responseBody ?? '{}')
+     * })
+     * @since 2.14
+     */
+    onRequest(
+      filter: RequestFilter,
+      callback: (request: InterceptedRequest) => void
+    ): () => void
+    /**
      * Sends data back to application
      * @param event Event
      */
@@ -789,6 +889,16 @@ declare global {
      * @since 2.0-BETA3
      */
     getUrl(): Promise<string>
+    /**
+     * Run code in the iframe page's own realm and get its (serializable) return
+     * value. See `Presence#execInPage` for the full contract.
+     * @since 2.14
+     */
+    execInPage<T = unknown>(
+      fn: (...args: any[]) => T | Promise<T>,
+      ...args: unknown[]
+    ): Promise<T>
+    execInPage<T = unknown>(spec: ExecInPageSpec): Promise<T>
     /**
      * Subscribe to events emitted by the extension
      * @param eventName

--- a/docs/v1/api/iframe.md
+++ b/docs/v1/api/iframe.md
@@ -62,6 +62,31 @@ const url = await iframe.getUrl()
 console.log(url) // "https://example.com/embed/video"
 ```
 
+### execInPage
+
+::: tip Requires extension 2.14+
+Added in extension **2.14**. Guard the call with the bundled [`supports`](/v1/api/utility-functions#supports) helper (`supports(iframe, 'execInPage')`) so it degrades gracefully on older extensions.
+:::
+
+<!-- eslint-skip -->
+
+```typescript
+execInPage<T = unknown, A extends unknown[] = unknown[]>(fn: (...args: A) => T | Promise<T>, ...args: A): Promise<T>;
+execInPage<T = unknown>(spec: ExecInPageSpec): Promise<T>;
+```
+
+Runs code in the iframe page's own realm and resolves with its (serializable) return value. Behaves exactly like [`Presence#execInPage`](/v1/api/presence-class#execinpage) — see there for the full contract, the declarative `ExecInPageSpec` form, and examples.
+
+#### Example
+
+```typescript
+import { supports } from 'premid'
+
+if (supports(iframe, 'execInPage')) {
+  const duration = await iframe.execInPage(() => window.player.getDuration())
+}
+```
+
 ### on
 
 <!-- eslint-skip -->

--- a/docs/v1/api/presence-class.md
+++ b/docs/v1/api/presence-class.md
@@ -174,8 +174,8 @@ For pages whose Content-Security-Policy blocks `eval`, pass a declarative spec i
 | `get`    | `string`    | Dot-path to a value on `window` to read (e.g. `'player.track.name'`).    |
 | `call`   | `string`    | Dot-path to a page function to invoke (e.g. `'spotifyPlayer.getState'`). |
 | `args`   | `unknown[]` | Arguments passed to the `call` function (must be serializable).          |
-| `pick`   | `string[]`  | Keep only these top-level keys of the result.                            |
-| `omit`   | `string[]`  | Drop these top-level keys from the result.                               |
+| `pick`   | `string[]`  | Keep only these keys of the result. Dot-paths allowed (e.g. `'track.name'`). |
+| `omit`   | `string[]`  | Drop these keys from the result. Dot-paths allowed (e.g. `'track.art'`).  |
 
 ##### Example
 
@@ -188,6 +188,12 @@ const state = await presence.execInPage({
   call: 'spotifyPlayer.getState',
   pick: ['paused', 'position'],
 })
+
+// Dot-paths pull nested fields out of a call result
+const track = await presence.execInPage({
+  call: 'spotifyPlayer.getState',
+  pick: ['track.name', 'track.artist'],
+}) // → { track: { name, artist } }
 ```
 
 ### onRequest

--- a/docs/v1/api/presence-class.md
+++ b/docs/v1/api/presence-class.md
@@ -169,13 +169,13 @@ if (supports(presence, 'execInPage')) {
 
 For pages whose Content-Security-Policy blocks `eval`, pass a declarative spec instead of a closure. It reads a value or calls a page function by dot-path — no code evaluation, so it works under strict CSP.
 
-| Property | Type        | Description                                                              |
-| -------- | ----------- | ------------------------------------------------------------------------ |
-| `get`    | `string`    | Dot-path to a value on `window` to read (e.g. `'player.track.name'`).    |
-| `call`   | `string`    | Dot-path to a page function to invoke (e.g. `'spotifyPlayer.getState'`). |
-| `args`   | `unknown[]` | Arguments passed to the `call` function (must be serializable).          |
+| Property | Type        | Description                                                                  |
+| -------- | ----------- | ---------------------------------------------------------------------------- |
+| `get`    | `string`    | Dot-path to a value on `window` to read (e.g. `'player.track.name'`).        |
+| `call`   | `string`    | Dot-path to a page function to invoke (e.g. `'spotifyPlayer.getState'`).     |
+| `args`   | `unknown[]` | Arguments passed to the `call` function (must be serializable).              |
 | `pick`   | `string[]`  | Keep only these keys of the result. Dot-paths allowed (e.g. `'track.name'`). |
-| `omit`   | `string[]`  | Drop these keys from the result. Dot-paths allowed (e.g. `'track.art'`).  |
+| `omit`   | `string[]`  | Drop these keys from the result. Dot-paths allowed (e.g. `'track.art'`).     |
 
 ##### Example
 

--- a/docs/v1/api/presence-class.md
+++ b/docs/v1/api/presence-class.md
@@ -124,6 +124,147 @@ const {
 )
 ```
 
+### execInPage
+
+::: tip Requires extension 2.14+
+`execInPage` was added in extension **2.14**. Activities run on every installed version, so guard the call with the bundled [`supports`](/v1/api/utility-functions#supports) helper — on older extensions the method is missing, and feature-detecting lets it degrade gracefully instead of throwing.
+:::
+
+<!-- eslint-skip -->
+
+```typescript
+execInPage<T = unknown, A extends unknown[] = unknown[]>(fn: (...args: A) => T | Promise<T>, ...args: A): Promise<T>;
+execInPage<T = unknown>(spec: ExecInPageSpec): Promise<T>;
+```
+
+Runs code in the **web page's own realm** and resolves with its return value. Unlike [`getPageVariable`](#getpagevariable), which only reads a variable, `execInPage` runs a function _inside the page_ — so you can call the page's own functions and reshape the result before it is sent back to the activity.
+
+The return value must be **JSON-serializable**. Strip non-serializable parts (DOM nodes, streams, circular references) inside the function before returning.
+
+::: warning The closure is isolated
+The function is serialized and re-evaluated in the page, so it **cannot reference activity-side variables** (imports, closures, module scope). Pass any values it needs as trailing arguments — they are forwarded to the function with their types preserved.
+:::
+
+#### Function form
+
+##### Parameters
+
+- `fn`: A function executed in the page. Receives `...args` and returns a serializable value (or a promise of one).
+- `args`: Serializable values forwarded to `fn` as arguments.
+
+##### Example
+
+```typescript
+import { supports } from 'premid'
+
+if (supports(presence, 'execInPage')) {
+  const track = await presence.execInPage((userId) => {
+    const state = window.spotifyPlayer.getCurrentState()
+    return { userId, title: state.track.name, paused: state.paused }
+  }, currentUserId)
+}
+```
+
+#### Declarative form (`ExecInPageSpec`)
+
+For pages whose Content-Security-Policy blocks `eval`, pass a declarative spec instead of a closure. It reads a value or calls a page function by dot-path — no code evaluation, so it works under strict CSP.
+
+| Property | Type        | Description                                                              |
+| -------- | ----------- | ------------------------------------------------------------------------ |
+| `get`    | `string`    | Dot-path to a value on `window` to read (e.g. `'player.track.name'`).    |
+| `call`   | `string`    | Dot-path to a page function to invoke (e.g. `'spotifyPlayer.getState'`). |
+| `args`   | `unknown[]` | Arguments passed to the `call` function (must be serializable).          |
+| `pick`   | `string[]`  | Keep only these top-level keys of the result.                            |
+| `omit`   | `string[]`  | Drop these top-level keys from the result.                               |
+
+##### Example
+
+```typescript
+// Read a nested value
+const title = await presence.execInPage<string>({ get: 'player.track.name' })
+
+// Call a page function and keep only some fields of the result
+const state = await presence.execInPage({
+  call: 'spotifyPlayer.getState',
+  pick: ['paused', 'position'],
+})
+```
+
+### onRequest
+
+::: tip Requires extension 2.14+
+`onRequest` was added in extension **2.14**. Guard the call with the bundled [`supports`](/v1/api/utility-functions#supports) helper so it degrades gracefully on older extensions.
+:::
+
+<!-- eslint-skip -->
+
+```typescript
+onRequest(filter: RequestFilter, callback: (request: InterceptedRequest) => void): () => void;
+```
+
+**Reads** (never modifies) requests the page makes via `fetch` or `XMLHttpRequest`, including requests made inside the activity's iframes. Use it to pull data straight from a site's own API responses instead of scraping the DOM.
+
+Interception runs from `document_start`. Requests that complete **before** your activity registers a filter are replayed to the callback with request metadata only — no `responseBody`.
+
+#### Parameters
+
+- `filter` (`RequestFilter`): Which requests to match. Omitting a field matches everything for that field.
+
+  | Property | Type                 | Description                                                     |
+  | -------- | -------------------- | --------------------------------------------------------------- |
+  | `url`    | `string \| RegExp`   | Match the request URL — substring (string) or pattern (RegExp). |
+  | `method` | `string \| string[]` | Match the HTTP method (case-insensitive). One or many.          |
+
+- `callback`: Invoked with an `InterceptedRequest` for each matching request.
+
+#### Returns
+
+An **unsubscribe** function. Call it to stop receiving requests (e.g. when the relevant page section is gone).
+
+#### InterceptedRequest
+
+A read-only snapshot of the request and its response passed to the callback:
+
+| Property          | Type                     | Description                                               |
+| ----------------- | ------------------------ | --------------------------------------------------------- |
+| `url`             | `string`                 | Request URL                                               |
+| `method`          | `string`                 | HTTP method                                               |
+| `requestHeaders`  | `Record<string, string>` | Request headers                                           |
+| `requestBody`     | `string \| null`         | Request body, if any                                      |
+| `status`          | `number`                 | Response status code                                      |
+| `statusText`      | `string`                 | Response status text                                      |
+| `ok`              | `boolean`                | `true` for 2xx responses                                  |
+| `responseHeaders` | `Record<string, string>` | Response headers                                          |
+| `responseBody`    | `string \| null`         | Response body (`null` for requests replayed at page load) |
+| `frameUrl`        | `string`                 | URL of the frame the request originated from              |
+| `timestamp`       | `number`                 | When the request completed (Unix ms)                      |
+
+#### Example
+
+```typescript
+import { supports } from 'premid'
+
+if (supports(presence, 'onRequest')) {
+  const unsubscribe = presence.onRequest(
+    { url: '/youtubei/v1/player', method: 'POST' },
+    (request) => {
+      if (!request.responseBody)
+        return
+
+      const { videoDetails } = JSON.parse(request.responseBody)
+      // videoDetails.title, videoDetails.author, videoDetails.lengthSeconds, ...
+    },
+  )
+
+  // Later, to stop listening:
+  // unsubscribe()
+}
+```
+
+::: warning Read-only
+`onRequest` can only observe requests — it cannot modify, block, or replay them. It is intended for reading data the page already fetches, not for making your own requests.
+:::
+
 ### getSetting
 
 <!-- eslint-skip -->

--- a/docs/v1/api/presence-data.md
+++ b/docs/v1/api/presence-data.md
@@ -32,6 +32,7 @@ Both extend the `BasePresenceData` interface, which contains the common properti
 | `smallImageUrl`    | `string \| null`                             | URL that is opened when clicking on the small image                                               |
 | `smallImageText`   | `string \| Node \| null`                     | Tooltip for the smallImageKey                                                                     |
 | `buttons`          | `[ButtonData, ButtonData?]`                  | Array of buttons (max 2)                                                                          |
+| `party`            | `PartyData`                                  | Party size shown on the activity, e.g. "2 of 5". Only honored on `ActivityType.Playing`           |
 
 ### Media-Specific Properties (MediaPresenceData)
 
@@ -55,6 +56,27 @@ The `ButtonData` interface defines the structure of buttons that can be added to
 | -------- | ------------------------------------- | ------------------- |
 | `label`  | `string \| Node \| null`              | Text for the button |
 | `url`    | `string \| HTMLAnchorElement \| null` | URL of button link  |
+
+## PartyData Interface
+
+The `party` property displays a party size on the activity, rendered by Discord as e.g. "2 of 5". It is only honored when `type` is `ActivityType.Playing`.
+
+| Property       | Type     | Description                                                             |
+| -------------- | -------- | ----------------------------------------------------------------------- |
+| `partyId`      | `string` | Optional identifier for the party. Generated automatically when omitted |
+| `partySize`    | `number` | Current number of members in the party                                  |
+| `maxPartySize` | `number` | Maximum number of members the party can hold                            |
+
+```typescript
+const presenceData: PresenceData = {
+  type: ActivityType.Playing,
+  details: 'In a match',
+  party: {
+    partySize: 2,
+    maxPartySize: 5
+  }
+}
+```
 
 ## ActivityType Enum
 

--- a/docs/v1/api/utility-functions.md
+++ b/docs/v1/api/utility-functions.md
@@ -108,6 +108,43 @@ const timeString = '01:30:45' // 1 hour, 30 minutes, 45 seconds
 const timeInSeconds = timestampFromFormat(timeString) // 5445
 ```
 
+## supports
+
+<!-- eslint-skip -->
+
+```typescript
+import { supports } from 'premid'
+
+function supports<T extends object, K extends keyof T>(target: T, feature: K): boolean
+```
+
+Checks whether the running PreMiD extension supports a given `Presence` / `iFrame` capability.
+
+Activities run across every extension version, so methods added in newer versions — such as [`execInPage`](/v1/api/presence-class#execinpage) and [`onRequest`](/v1/api/presence-class#onrequest) — may be missing on older installs, where calling them directly would throw. `supports` is bundled into your activity, so it works regardless of the extension version: feature-detect before calling.
+
+### Parameters
+
+- `target`: The `Presence` or `iFrame` instance to check
+- `feature`: Name of the method to check for
+
+### Returns
+
+- `true` when the capability is available on the running extension, otherwise `false`
+
+### Example
+
+<!-- eslint-skip -->
+
+```typescript
+import { supports } from 'premid'
+
+if (supports(presence, 'onRequest')) {
+  presence.onRequest({ url: '/api/now-playing' }, (request) => {
+    // ...
+  })
+}
+```
+
 ## Using Utility Functions in Activities
 
 These utility functions are particularly useful for media-related activities, where you need to calculate timestamps for videos or audio.

--- a/docs/v1/guide/presence-class.md
+++ b/docs/v1/guide/presence-class.md
@@ -69,6 +69,7 @@ The `PresenceData` object can have the following properties:
 | `smallImageUrl`    | `string`            | The URL the user will be redirected to when clicking the small image                                   |
 | `smallImageText`   | `string`            | The text that appears when hovering over the small image                                               |
 | `buttons`          | `ButtonData[]`      | An array of buttons (max 2)                                                                            |
+| `party`            | `PartyData`         | A party size shown on the activity, e.g. "2 of 5". Only honored on `ActivityType.Playing`              |
 
 ## Activity Types
 
@@ -147,6 +148,20 @@ const video = document.querySelector('video')
 [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestampsFromMedia(video)
 ```
 
+## Party Size
+
+For activities with a "Playing" type, you can show a party size — rendered by Discord as e.g. "2 of 5":
+
+```typescript
+presenceData.type = ActivityType.Playing
+presenceData.party = {
+  partySize: 2,
+  maxPartySize: 5
+}
+```
+
+`partySize` and `maxPartySize` are required; `partyId` is optional and generated automatically when omitted. The party is only honored on `ActivityType.Playing` — it is ignored for other activity types.
+
 ## Clearing Activity
 
 If you want to clear the activity, you can use the `clearActivity` method:
@@ -163,6 +178,42 @@ If your activity has settings, you can get their values using the `getSetting` m
 const showButtons = await presence.getSetting<boolean>('showButtons')
 const displayFormat = await presence.getSetting<number>('displayFormat')
 ```
+
+## Reading Page Data and Requests
+
+Some sites don't expose everything you need in the DOM. Two methods let you reach into the page itself:
+
+- [`execInPage`](/v1/api/presence-class#execinpage) — run a function in the page's own realm and get its return value (call the site's own functions, read its globals).
+- [`onRequest`](/v1/api/presence-class#onrequest) — read the data the page fetches from its own API, instead of scraping the DOM.
+
+Both were added in extension **2.14**. Activities run on every installed version, so always guard them with the bundled [`supports`](/v1/api/utility-functions#supports) helper — on older extensions the method is missing, and feature-detecting lets your activity degrade gracefully instead of throwing.
+
+```typescript
+import { supports } from 'premid'
+
+// Run code inside the page and get a serializable result back
+if (supports(presence, 'execInPage')) {
+  const track = await presence.execInPage(() => {
+    const state = window.spotifyPlayer.getCurrentState()
+    return { title: state.track.name, paused: state.paused }
+  })
+}
+
+// Read data straight from the site's own API responses
+if (supports(presence, 'onRequest')) {
+  presence.onRequest({ url: '/api/now-playing', method: 'GET' }, (request) => {
+    if (!request.responseBody)
+      return
+
+    const data = JSON.parse(request.responseBody)
+    // use data...
+  })
+}
+```
+
+::: tip
+The eslint plugin will flag an unguarded `execInPage`/`onRequest` call and can autofix it by wrapping it in a `supports()` check. See the [API reference](/v1/api/presence-class#execinpage) for the full options (declarative `execInPage` specs, request filters, the `InterceptedRequest` shape, and unsubscribing).
+:::
 
 ## Complete Example
 

--- a/eslint-rules/premid-plugin.mjs
+++ b/eslint-rules/premid-plugin.mjs
@@ -1,0 +1,220 @@
+/**
+ * Local ESLint plugin for PreMiD activities.
+ *
+ * `require-support-check`: version-gated Presence/iFrame APIs (added in newer
+ * extension versions) throw on older installs. Flag a call to one of them unless
+ * the enclosing function also feature-detects it — via the bundled
+ * `supports(obj, 'method')` helper, a `typeof obj.method === 'function'` check,
+ * or an `if (obj.method)` truthiness check.
+ *
+ * A call is considered guarded when it sits inside the consequent of a support
+ * check — `if (CHECK) { call }`, `CHECK && call`, or `CHECK ? call : ...` —
+ * where CHECK is `supports(obj, 'method')`, `typeof obj.method === 'function'`,
+ * or a plain `obj.method` truthiness test. This matches the documented pattern;
+ * an early-return guard (`if (!supports(...)) return`) is not recognised, so
+ * wrap the call or disable the line inline for that style. Matches by method
+ * name + object source text.
+ */
+
+const GUARDED_METHODS = new Set(['execInPage', 'onRequest'])
+
+function walk(node, cb) {
+  if (!node || typeof node.type !== 'string')
+    return
+  cb(node)
+  for (const key of Object.keys(node)) {
+    if (key === 'parent')
+      continue
+    const value = node[key]
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        if (child && typeof child.type === 'string')
+          walk(child, cb)
+      }
+    }
+    else if (value && typeof value.type === 'string') {
+      walk(value, cb)
+    }
+  }
+}
+
+const requireSupportCheck = {
+  meta: {
+    type: 'problem',
+    fixable: 'code',
+    docs: {
+      description:
+        'Require a support check before calling version-gated Presence/iFrame APIs (execInPage, onRequest)',
+    },
+    schema: [],
+    messages: {
+      unchecked:
+        'Call to `{{method}}` is not guarded by a support check. Older PreMiD versions lack it and will throw. Wrap it in `if (supports({{obj}}, \'{{method}}\'))` (import { supports } from \'premid\').',
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode()
+
+    /** Does this test subtree reference a support check for obj.method? */
+    function testReferencesSupport(testNode, objText, method) {
+      let found = false
+      walk(testNode, (n) => {
+        if (found)
+          return
+
+        // supports(obj, 'method')
+        if (
+          n.type === 'CallExpression'
+          && n.callee.type === 'Identifier'
+          && n.callee.name === 'supports'
+          && n.arguments.length >= 2
+          && n.arguments[1].type === 'Literal'
+          && n.arguments[1].value === method
+          && sourceCode.getText(n.arguments[0]) === objText
+        ) {
+          found = true
+          return
+        }
+
+        // obj.method outside a call position → typeof / truthiness check
+        if (
+          n.type === 'MemberExpression'
+          && !n.computed
+          && n.property.type === 'Identifier'
+          && n.property.name === method
+          && sourceCode.getText(n.object) === objText
+        ) {
+          const isCalleeOfCall
+            = n.parent?.type === 'CallExpression' && n.parent.callee === n
+          if (!isCalleeOfCall)
+            found = true
+        }
+      })
+      return found
+    }
+
+    function within(node, range) {
+      return range && node.range[0] >= range[0] && node.range[1] <= range[1]
+    }
+
+    /**
+     * Returns the enclosing `ExpressionStatement` if the call is its whole
+     * expression (optionally wrapped in `await`/`void`) — i.e. a fire-and-forget
+     * statement we can safely wrap. Returns null for value-capturing calls.
+     */
+    function fixableStatement(node, ancestors) {
+      const statement = [...ancestors].reverse().find(a => a.type === 'ExpressionStatement')
+      if (!statement)
+        return null
+
+      let expr = statement.expression
+      while (expr && expr !== node) {
+        if (expr.type === 'AwaitExpression' || (expr.type === 'UnaryExpression' && expr.operator === 'void'))
+          expr = expr.argument
+        else if (expr.type === 'ChainExpression')
+          expr = expr.expression
+        else
+          break
+      }
+      return expr === node ? statement : null
+    }
+
+    /** Fix that ensures `supports` is imported from 'premid', or null if already. */
+    function ensureSupportsImport(fixer) {
+      const body = sourceCode.ast.body
+      const premidImport = body.find(
+        s => s.type === 'ImportDeclaration' && s.source.value === 'premid',
+      )
+
+      if (premidImport) {
+        const named = premidImport.specifiers.filter(s => s.type === 'ImportSpecifier')
+        if (named.some(s => s.imported.name === 'supports'))
+          return null
+        if (named.length)
+          return fixer.insertTextAfter(named[named.length - 1], ', supports')
+      }
+
+      return fixer.insertTextBefore(body[0], 'import { supports } from \'premid\'\n')
+    }
+
+    return {
+      CallExpression(node) {
+        const { callee } = node
+        if (callee.type !== 'MemberExpression' || callee.computed)
+          return
+        if (callee.property.type !== 'Identifier')
+          return
+
+        const method = callee.property.name
+        if (!GUARDED_METHODS.has(method))
+          return
+
+        const objText = sourceCode.getText(callee.object)
+
+        const ancestors = sourceCode.getAncestors(node)
+        let guarded = false
+        for (const ancestor of ancestors) {
+          let test
+          let guardedRange
+          if (ancestor.type === 'IfStatement') {
+            test = ancestor.test
+            guardedRange = ancestor.consequent.range
+          }
+          else if (ancestor.type === 'ConditionalExpression') {
+            test = ancestor.test
+            guardedRange = ancestor.consequent.range
+          }
+          else if (ancestor.type === 'LogicalExpression' && ancestor.operator === '&&') {
+            test = ancestor.left
+            guardedRange = ancestor.right.range
+          }
+          else {
+            continue
+          }
+
+          if (within(node, guardedRange) && testReferencesSupport(test, objText, method)) {
+            guarded = true
+            break
+          }
+        }
+
+        if (guarded)
+          return
+
+        context.report({
+          node,
+          messageId: 'unchecked',
+          data: { method, obj: objText },
+          fix(fixer) {
+            const statement = fixableStatement(node, ancestors)
+            if (!statement)
+              return null
+
+            const line = sourceCode.lines[statement.loc.start.line - 1]
+            const indent = line.slice(0, line.length - line.trimStart().length)
+            const statementText = sourceCode.getText(statement)
+
+            const fixes = []
+            const importFix = ensureSupportsImport(fixer)
+            if (importFix)
+              fixes.push(importFix)
+
+            fixes.push(fixer.replaceText(
+              statement,
+              `if (supports(${objText}, '${method}')) {\n${indent}  ${statementText}\n${indent}}`,
+            ))
+
+            return fixes
+          },
+        })
+      },
+    }
+  },
+}
+
+export default {
+  meta: { name: 'premid-local' },
+  rules: {
+    'require-support-check': requireSupportCheck,
+  },
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import antfu from '@antfu/eslint-config'
 import eslintPluginJsonSchemaValidator from 'eslint-plugin-json-schema-validator'
+import premidPlugin from './eslint-rules/premid-plugin.mjs'
 
 export default antfu(
   {
@@ -72,6 +73,9 @@ export default antfu(
   },
   {
     files: ['websites/**/*.ts'],
+    plugins: {
+      premid: premidPlugin,
+    },
     languageOptions: {
       parser: await import('@typescript-eslint/parser'),
       parserOptions: {
@@ -80,6 +84,7 @@ export default antfu(
     },
     rules: {
       'ts/no-deprecated': 'error',
+      'premid/require-support-check': 'error',
     },
   },
 )

--- a/premid/src/functions/supports.ts
+++ b/premid/src/functions/supports.ts
@@ -1,0 +1,25 @@
+/**
+ * Checks whether the running PreMiD extension supports a given `Presence` /
+ * `iFrame` capability.
+ *
+ * Activities run across every extension version, so APIs added in newer
+ * versions (e.g. `execInPage`, `onRequest`) may be missing on older installs,
+ * where calling them directly would throw. This helper is bundled into the
+ * activity, so it works regardless of the extension version — feature-detect
+ * before calling:
+ *
+ * @example
+ * if (supports(presence, 'onRequest')) {
+ *   presence.onRequest({ url: '/api/now-playing' }, handleRequest)
+ * }
+ *
+ * @param target The `Presence` or `iFrame` instance to check
+ * @param feature Name of the method to check for
+ * @returns `true` when the capability is available on this extension version
+ */
+export function supports<T extends object, K extends keyof T>(
+  target: T,
+  feature: K,
+): boolean {
+  return typeof target[feature] === 'function'
+}

--- a/premid/src/index.ts
+++ b/premid/src/index.ts
@@ -1,5 +1,6 @@
 export * from './functions/getTimestamps.js'
 export * from './functions/getTimestampsFromMedia.js'
+export * from './functions/supports.js'
 export * from './functions/timestampFromFormat.js'
 
 /**


### PR DESCRIPTION
## What

Adds the activity-facing types and tooling for three new `Presence`/`iFrame` capabilities, plus a runtime feature-detection helper so activities can adopt them safely today.

- **`execInPage`** — run a function (or a declarative, CSP-immune `get`/`call` spec) in the page's own context and await a returned value.
- **`onRequest`** — read data out of page network requests via a URL/method filter (read-only, no modification).
- **`party`** on `PresenceData` — show a party size on Playing activities (e.g. "2 of 5"); `partyId` optional, only honored on `ActivityType.Playing`.
- **`supports(target, feature)`** — bundled into the activity, returns `true` when the running extension exposes the capability. Lets activities feature-detect instead of crashing on older installs.
- **ESLint rule** — errors on unguarded `execInPage`/`onRequest` usage, with an autofix that wraps the call in a `supports()` check.

## Versioning

These APIs ship with the extension in **2.14.0**. They can be **used as of right now**: because `supports()` is compiled into the activity bundle, it detects the capability at runtime, so an activity guarded with `supports()` works on 2.14.0+ and degrades gracefully (no-op) on older extensions instead of throwing. The lint rule enforces that guard.

```ts
if (supports(presence, 'onRequest')) {
  presence.onRequest({ url: '/api/now-playing', method: 'GET' }, (req) => { /* ... */ })
}
```