### PR TITLE
feat(Platform Engineering University): add presence

### DIFF
--- a/websites/P/Platform Engineering University/metadata.json
+++ b/websites/P/Platform Engineering University/metadata.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.17",
+  "apiVersion": 1,
+  "author": {
+    "id": "263735224221827072",
+    "name": "AlperShal"
+  },
+  "service": "Platform Engineering University",
+  "description": {
+    "en": "The home for platform engineering learning and certifications."
+  },
+  "url": "university.platformengineering.org",
+  "regExp": "^https?[:][/][/]university[.]platformengineering[.]org[/]",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/iNgO4NQ.png",
+  "thumbnail": "https://i.imgur.com/c6wvuf2.png",
+  "color": "#000000",
+  "category": "videos",
+  "tags": [
+    "education",
+    "course",
+    "learning",
+    "engineering",
+    "tutorial",
+    "devops",
+    "platform"
+  ]
+}

--- a/websites/P/Platform Engineering University/presence.ts
+++ b/websites/P/Platform Engineering University/presence.ts
@@ -8,32 +8,28 @@ enum ActivityAssets {
   Logo = 'https://i.imgur.com/iNgO4NQ.png',
 }
 
-
 const browsingTimestamp = Math.floor(Date.now() / 1000)
 
 presence.on('UpdateData', async () => {
   const presenceData: PresenceData = {
     largeImageKey: ActivityAssets.Logo,
-    startTimestamp: browsingTimestamp
+    startTimestamp: browsingTimestamp,
   }
-
-  // Information needed to determine what user is doing
-  const { pathname } = document.location
 
   if (document.querySelector('div.lesson-page')) {
     presenceData.details = `Studying: ${document.querySelector('h1.course-title')?.textContent.trim()}`
     presenceData.state = `Lesson: ${document.querySelector('div.lesson-top > h2')?.innerHTML}`
     presenceData.buttons = [{ label: 'Learn Yourself', url: document.location.href }]
-  
 
-    if (document.querySelector('div.jw-icon-playback')?.ariaLabel == "Play") {
+    if (document.querySelector('div.jw-icon-playback')?.ariaLabel === 'Play') {
       presenceData.smallImageKey = Assets.Play
-    } else if (document.querySelector('div.jw-icon-playback')?.ariaLabel == "Pause") {
+    }
+    else if (document.querySelector('div.jw-icon-playback')?.ariaLabel === 'Pause') {
       presenceData.smallImageKey = Assets.Pause
     }
   }
   else {
-    presenceData.details = "Browsing..."
+    presenceData.details = 'Browsing...'
   }
 
   presence.setActivity(presenceData)

--- a/websites/P/Platform Engineering University/presence.ts
+++ b/websites/P/Platform Engineering University/presence.ts
@@ -1,0 +1,40 @@
+import { Assets } from 'premid'
+
+const presence = new Presence({
+  clientId: '1519641524185337916',
+})
+
+enum ActivityAssets {
+  Logo = 'https://i.imgur.com/iNgO4NQ.png',
+}
+
+
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+presence.on('UpdateData', async () => {
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp
+  }
+
+  // Information needed to determine what user is doing
+  const { pathname } = document.location
+
+  if (document.querySelector('div.lesson-page')) {
+    presenceData.details = `Studying: ${document.querySelector('h1.course-title')?.textContent.trim()}`
+    presenceData.state = `Lesson: ${document.querySelector('div.lesson-top > h2')?.innerHTML}`
+    presenceData.buttons = [{ label: 'Learn Yourself', url: document.location.href }]
+  
+
+    if (document.querySelector('div.jw-icon-playback')?.ariaLabel == "Play") {
+      presenceData.smallImageKey = Assets.Play
+    } else if (document.querySelector('div.jw-icon-playback')?.ariaLabel == "Pause") {
+      presenceData.smallImageKey = Assets.Pause
+    }
+  }
+  else {
+    presenceData.details = "Browsing..."
+  }
+
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description
I added support for university.platformengineering.com, a website for learning about Platform Engineering.

NOTE: Documentation mentions that:
```
- Activities with support for only a single subdomain will not be permitted, as they may seem broken for other pages (like the homepage)
- Exceptions can be made for policy and contact pages (content that isn't used often) or sites where the other content is unrelated (e.g., wikia pages)
```
The university and the main website are not really the same. University is a platform specified on course materials and website is just blogs and announcements etc.. Even their logos differ a bit. So I think it does make sense to create an extension only for the subdomain. Tho not sure. It's like music.youtube.com and youtube.com.

## Acknowledgements
- [X] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `npm run lint`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img width="2560" height="1306" alt="image" src="https://github.com/user-attachments/assets/36002eec-7415-4981-a887-2c8bfc4be560" />

<img width="2560" height="1305" alt="image" src="https://github.com/user-attachments/assets/c6b477f2-1c85-47fc-84b6-2db626c71c6c" />

</details>
