### PR TITLE
feat(CRT AUDIO SCULPTURES): add activity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
         "chokidar": "^5.0.0",
         "discord-rpc": "^4.0.1",
         "esbuild": "^0.28.0",
-        "form-data": "^4.0.5",
         "gitdiff-parser": "^0.3.1",
         "globby": "^16.2.0",
         "got": "^15.0.3",
@@ -5888,23 +5887,6 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/format": {
       "version": "0.2.2",

--- a/websites/C/CRT AUDIO SCULPTURES/metadata.json
+++ b/websites/C/CRT AUDIO SCULPTURES/metadata.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.10",
+  "author": {
+    "name": "Mazin",
+    "id": "765119143745290280"
+  },
+  "service": "CRT // AUDIO SCULPTURES",
+  "altnames": [],
+  "description": {
+    "en": "Rich Presence for CRT // AUDIO SCULPTURES, a custom WebGL music player."
+  },
+  "url": "mzn-visuals.github.io/crt-audio-sculptures",
+  "regExp": "^https:\\/\\/mzn-visuals\\.github\\.io\\/crt-audio-sculptures\\/?.*",
+  "version": "1.0.0",
+  "logo": "https://dl.dropboxusercontent.com/scl/fi/1frrc96dnawl5c4w0hzu1/logo-crt.png?rlkey=4ffmgrqbcc84xxdx5x2cdh2ak&st=kkmc2go6",
+  "thumbnail": "https://dl.dropboxusercontent.com/scl/fi/1frrc96dnawl5c4w0hzu1/logo-crt.png?rlkey=4ffmgrqbcc84xxdx5x2cdh2ak&st=kkmc2go6",
+  "color": "#7DF9FF",
+  "tags": ["music", "player"],
+  "category": "music",
+  "iframe": false
+}

--- a/websites/C/CRT AUDIO SCULPTURES/metadata.json
+++ b/websites/C/CRT AUDIO SCULPTURES/metadata.json
@@ -1,21 +1,21 @@
 {
-  "$schema": "https://schemas.premid.app/metadata/1.10",
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
   "author": {
     "name": "Mazin",
     "id": "765119143745290280"
   },
-  "service": "CRT // AUDIO SCULPTURES",
-  "altnames": [],
+  "service": "CRT AUDIO SCULPTURES",
   "description": {
-    "en": "Rich Presence for CRT // AUDIO SCULPTURES, a custom WebGL music player."
+    "en": "Rich Presence for CRT AUDIO SCULPTURES, a custom WebGL music player."
   },
-  "url": "mzn-visuals.github.io/crt-audio-sculptures",
+  "url": "mzn-visuals.github.io",
   "regExp": "^https:\\/\\/mzn-visuals\\.github\\.io\\/crt-audio-sculptures\\/?.*",
   "version": "1.0.0",
-  "logo": "https://dl.dropboxusercontent.com/scl/fi/1frrc96dnawl5c4w0hzu1/logo-crt.png?rlkey=4ffmgrqbcc84xxdx5x2cdh2ak&st=kkmc2go6",
-  "thumbnail": "https://dl.dropboxusercontent.com/scl/fi/1frrc96dnawl5c4w0hzu1/logo-crt.png?rlkey=4ffmgrqbcc84xxdx5x2cdh2ak&st=kkmc2go6",
+  "logo": "https://i.imgur.com/4OUP9S2.png",
+  "thumbnail": "https://i.imgur.com/FelB3YG.png",
   "color": "#7DF9FF",
-  "tags": ["music", "player"],
   "category": "music",
+  "tags": ["music", "player"],
   "iframe": false
 }

--- a/websites/C/CRT AUDIO SCULPTURES/metadata.json
+++ b/websites/C/CRT AUDIO SCULPTURES/metadata.json
@@ -10,7 +10,7 @@
     "en": "Rich Presence for CRT AUDIO SCULPTURES, a custom WebGL music player."
   },
   "url": "mzn-visuals.github.io",
-  "regExp": "^https:\\/\\/mzn-visuals\\.github\\.io\\/crt-audio-sculptures\\/?.*",
+  "regExp": "^https:\\/\\/mzn-visuals\\.github\\.io\\/(crt-audio-sculptures\\/?.*)?$",
   "version": "1.0.0",
   "logo": "https://i.imgur.com/4OUP9S2.png",
   "thumbnail": "https://i.imgur.com/FelB3YG.png",

--- a/websites/C/CRT AUDIO SCULPTURES/presence.ts
+++ b/websites/C/CRT AUDIO SCULPTURES/presence.ts
@@ -1,39 +1,39 @@
-import { ActivityType } from "premid";
+import { ActivityType } from 'premid'
 
 const presence = new Presence({
-  clientId: "1519448916469350601",
-});
+  clientId: '1519448916469350601',
+})
 
 // Your existing favicon/logo, reused as the small corner badge on the card.
-const CRT_LOGO =
-  "https://dl.dropboxusercontent.com/scl/fi/1frrc96dnawl5c4w0hzu1/logo-crt.png?rlkey=4ffmgrqbcc84xxdx5x2cdh2ak&st=kkmc2go6";
+const CRT_LOGO
+  = 'https://dl.dropboxusercontent.com/scl/fi/1frrc96dnawl5c4w0hzu1/logo-crt.png?rlkey=4ffmgrqbcc84xxdx5x2cdh2ak&st=kkmc2go6'
 
 // Fixed start/end timestamps for the CURRENT track, computed once and reused
 // on every tick. Recomputing from Date.now() + currentTime on every tick
 // causes the displayed timer to jitter by ±1s as the two values round
 // independently.
-let cachedTrackKey: string | null = null;
-let cachedStart: number | null = null;
-let cachedEnd: number | null = null;
+let cachedTrackKey: string | null = null
+let cachedStart: number | null = null
+let cachedEnd: number | null = null
 
-presence.on("UpdateData", async () => {
-  const titleEl = document.querySelector<HTMLElement>("#nowPlayingTitle");
-  const artistEl = document.querySelector<HTMLElement>("#nowPlayingArtist");
-  const thumbEl = document.querySelector<HTMLImageElement>("#nowPlayingThumb");
-  const audioEl = document.querySelector<HTMLAudioElement>("audio");
+presence.on('UpdateData', async () => {
+  const titleEl = document.querySelector<HTMLElement>('#nowPlayingTitle')
+  const artistEl = document.querySelector<HTMLElement>('#nowPlayingArtist')
+  const thumbEl = document.querySelector<HTMLImageElement>('#nowPlayingThumb')
+  const audioEl = document.querySelector<HTMLAudioElement>('audio')
 
-  const title = titleEl?.textContent?.trim();
-  const artist = artistEl?.textContent?.trim();
+  const title = titleEl?.textContent?.trim()
+  const artist = artistEl?.textContent?.trim()
 
   // Nothing loaded into the player yet.
-  if (!title || title === "—") {
-    presence.clearActivity();
-    cachedTrackKey = null;
-    return;
+  if (!title || title === '—') {
+    presence.clearActivity()
+    cachedTrackKey = null
+    return
   }
 
-  const isPlaying = audioEl ? !audioEl.paused : false;
-  const thumbnail = thumbEl?.src && thumbEl.src.startsWith("http") ? thumbEl.src : CRT_LOGO;
+  const isPlaying = audioEl ? !audioEl.paused : false
+  const thumbnail = thumbEl?.src && thumbEl.src.startsWith('http') ? thumbEl.src : CRT_LOGO
 
   const presenceData: PresenceData = {
     type: ActivityType.Listening,
@@ -43,41 +43,35 @@ presence.on("UpdateData", async () => {
         ? artist
         : `${artist} · Paused`
       : isPlaying
-        ? "Unknown Artist"
-        : "Unknown Artist · Paused",
+        ? 'Unknown Artist'
+        : 'Unknown Artist · Paused',
     largeImageKey: thumbnail,
-    buttons: [
-      {
-        label: "Open CRT // AUDIO SCULPTURES",
-        url: "https://mzn-visuals.github.io/crt-audio-sculptures/",
-      },
-    ],
-  };
+  }
 
-  const trackKey = `${title}::${artist}`;
+  const trackKey = `${title}::${artist}`
 
   if (audioEl && audioEl.duration && isPlaying) {
     // Recompute the fixed start/end pair only when the track changes,
     // or when we don't have one cached yet (e.g. resuming after a pause).
     if (trackKey !== cachedTrackKey || cachedStart === null) {
-      const nowSeconds = Math.floor(Date.now() / 1000);
-      const elapsed = Math.floor(audioEl.currentTime);
-      const remaining = Math.ceil(audioEl.duration - audioEl.currentTime);
-      cachedStart = nowSeconds - elapsed;
-      cachedEnd = nowSeconds + remaining;
-      cachedTrackKey = trackKey;
+      const nowSeconds = Math.floor(Date.now() / 1000)
+      const elapsed = Math.floor(audioEl.currentTime)
+      const remaining = Math.ceil(audioEl.duration - audioEl.currentTime)
+      cachedStart = nowSeconds - elapsed
+      cachedEnd = nowSeconds + remaining
+      cachedTrackKey = trackKey
     }
-    presenceData.startTimestamp = cachedStart;
-    presenceData.endTimestamp = cachedEnd;
-  } else {
+    presenceData.startTimestamp = cachedStart
+    presenceData.endTimestamp = cachedEnd
+  }
+  else {
     // Paused (or no media yet): clear timestamps so Discord's timer
     // actually stops, and drop the cache so resuming recalculates cleanly.
-    delete presenceData.startTimestamp;
-    delete presenceData.endTimestamp;
-    cachedStart = null;
-    cachedEnd = null;
+    delete presenceData.startTimestamp
+    delete presenceData.endTimestamp
+    cachedStart = null
+    cachedEnd = null
   }
 
-  presence.setActivity(presenceData);
-});
-
+  presence.setActivity(presenceData)
+})

--- a/websites/C/CRT AUDIO SCULPTURES/presence.ts
+++ b/websites/C/CRT AUDIO SCULPTURES/presence.ts
@@ -1,0 +1,83 @@
+import { ActivityType } from "premid";
+
+const presence = new Presence({
+  clientId: "1519448916469350601",
+});
+
+// Your existing favicon/logo, reused as the small corner badge on the card.
+const CRT_LOGO =
+  "https://dl.dropboxusercontent.com/scl/fi/1frrc96dnawl5c4w0hzu1/logo-crt.png?rlkey=4ffmgrqbcc84xxdx5x2cdh2ak&st=kkmc2go6";
+
+// Fixed start/end timestamps for the CURRENT track, computed once and reused
+// on every tick. Recomputing from Date.now() + currentTime on every tick
+// causes the displayed timer to jitter by ±1s as the two values round
+// independently.
+let cachedTrackKey: string | null = null;
+let cachedStart: number | null = null;
+let cachedEnd: number | null = null;
+
+presence.on("UpdateData", async () => {
+  const titleEl = document.querySelector<HTMLElement>("#nowPlayingTitle");
+  const artistEl = document.querySelector<HTMLElement>("#nowPlayingArtist");
+  const thumbEl = document.querySelector<HTMLImageElement>("#nowPlayingThumb");
+  const audioEl = document.querySelector<HTMLAudioElement>("audio");
+
+  const title = titleEl?.textContent?.trim();
+  const artist = artistEl?.textContent?.trim();
+
+  // Nothing loaded into the player yet.
+  if (!title || title === "—") {
+    presence.clearActivity();
+    cachedTrackKey = null;
+    return;
+  }
+
+  const isPlaying = audioEl ? !audioEl.paused : false;
+  const thumbnail = thumbEl?.src && thumbEl.src.startsWith("http") ? thumbEl.src : CRT_LOGO;
+
+  const presenceData: PresenceData = {
+    type: ActivityType.Listening,
+    details: title,
+    state: artist
+      ? isPlaying
+        ? artist
+        : `${artist} · Paused`
+      : isPlaying
+        ? "Unknown Artist"
+        : "Unknown Artist · Paused",
+    largeImageKey: thumbnail,
+    buttons: [
+      {
+        label: "Open CRT // AUDIO SCULPTURES",
+        url: "https://mzn-visuals.github.io/crt-audio-sculptures/",
+      },
+    ],
+  };
+
+  const trackKey = `${title}::${artist}`;
+
+  if (audioEl && audioEl.duration && isPlaying) {
+    // Recompute the fixed start/end pair only when the track changes,
+    // or when we don't have one cached yet (e.g. resuming after a pause).
+    if (trackKey !== cachedTrackKey || cachedStart === null) {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const elapsed = Math.floor(audioEl.currentTime);
+      const remaining = Math.ceil(audioEl.duration - audioEl.currentTime);
+      cachedStart = nowSeconds - elapsed;
+      cachedEnd = nowSeconds + remaining;
+      cachedTrackKey = trackKey;
+    }
+    presenceData.startTimestamp = cachedStart;
+    presenceData.endTimestamp = cachedEnd;
+  } else {
+    // Paused (or no media yet): clear timestamps so Discord's timer
+    // actually stops, and drop the cache so resuming recalculates cleanly.
+    delete presenceData.startTimestamp;
+    delete presenceData.endTimestamp;
+    cachedStart = null;
+    cachedEnd = null;
+  }
+
+  presence.setActivity(presenceData);
+});
+


### PR DESCRIPTION
## Description
Adds a PreMiD Activity for **CRT AUDIO SCULPTURES**, a custom WebGL music player I built that visualizes audio as reactive 3D sculptures with a CRT-style shader overlay.

- Shows the currently playing track title and artist as the Rich Presence details/state
- Reflects play/pause state (shows "Paused" in the state when playback is stopped)
- Uses the track's thumbnail as the large image when available, falling back to the site logo
- Shows accurate elapsed/remaining time using fixed start/end timestamps (avoids timer jitter)

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

(paste your two Discord screenshots here)

<img width="205" height="85" alt="Screenshot 2026-06-25 221052" src="https://github.com/user-attachments/assets/a2928019-b6bc-46fc-a968-65de4c16f5ce" />
<img width="321" height="538" alt="Screenshot 2026-06-25 221106" src="https://github.com/user-attachments/assets/5280bd34-9cc7-4076-9c5c-956776419754" />

</details>