### PR TITLE
fix(Cineby): restore TMDB API and fix movie details display

### DIFF
--- a/websites/C/Cineby/api.ts
+++ b/websites/C/Cineby/api.ts
@@ -36,7 +36,8 @@ export interface AnimeDetails {
 const cache: Map<string, unknown> = new Map()
 
 export class CinebyApi {
-  private static readonly BASE_URL = 'https://jumpfreedom.com/3'
+  private static readonly BASE_URL = 'https://api.themoviedb.org/3'
+  private static readonly API_KEY = '269890f657dddf4635473cf4cf456576'
   private static readonly ANIME_URL = 'https://api.videasy.net/hianime'
 
   public static async getCurrent<T>(pathname: string): Promise<T> {
@@ -45,8 +46,10 @@ export class CinebyApi {
 
     const [type, id] = pathname.split('/').slice(1)
     const response = await fetch(
-      `${this.BASE_URL}/${type}/${id}?language=en`,
+      `${this.BASE_URL}/${type}/${id}?language=en&api_key=${this.API_KEY}`,
     )
+    if (!response.ok)
+      throw new Error(`API error: ${response.status}`)
 
     if (type === 'tv') {
       const json = await response.json()
@@ -75,8 +78,10 @@ export class CinebyApi {
     const response = await fetch(
       `${this.BASE_URL}/tv/${id}/season/${season ?? 1}/episode/${
         episode ?? 1
-      }?language=en`,
+      }?language=en&api_key=${this.API_KEY}`,
     )
+    if (!response.ok)
+      throw new Error(`API error: ${response.status}`)
 
     return response.json()
   }

--- a/websites/C/Cineby/metadata.json
+++ b/websites/C/Cineby/metadata.json
@@ -17,7 +17,7 @@
   },
   "url": "www.cineby.at",
   "regExp": "^https?[:][/][/](www[.])?cineby[.]at[/]",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/C/Cineby/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/C/Cineby/assets/thumbnail.png",
   "color": "#fb0013",

--- a/websites/C/Cineby/presence.ts
+++ b/websites/C/Cineby/presence.ts
@@ -51,10 +51,9 @@ presence.on('UpdateData', async () => {
       const year = data.release_date?.split('-').shift()
       const runtime = data.runtime
 
-      if (useActivityName) {
+      if (useActivityName)
         presenceData.name = title
-        presenceData.details = title
-      }
+      presenceData.details = title
       const stateStr = [year, runtime != null ? `${runtime} min` : null]
         .filter(Boolean)
         .join(' • ')
@@ -66,7 +65,7 @@ presence.on('UpdateData', async () => {
       }
     }
     catch {
-      presenceData.details = 'Browsing'
+      presenceData.details = 'Watching a Movie'
     }
   }
   else if (type === 'tv' && contentId) {
@@ -95,7 +94,9 @@ presence.on('UpdateData', async () => {
       }
     }
     catch {
-      presenceData.details = 'Browsing'
+      presenceData.details = 'Watching a TV Show'
+      if (seasonNum && episodeNum)
+        presenceData.state = `S${seasonNum}:E${episodeNum}`
     }
   }
   else if (type === 'anime' && contentId) {
@@ -119,7 +120,9 @@ presence.on('UpdateData', async () => {
       }
     }
     catch {
-      presenceData.details = 'Browsing'
+      presenceData.details = 'Watching Anime'
+      if (episodeNum)
+        presenceData.state = `Episode ${episodeNum}`
     }
   }
   else {


### PR DESCRIPTION
## Description
Fixes #10886 : Cineby showing "Browsing" instead of movie/show title.

The root cause was that the upstream switched to `jumpfreedom.com` as a TMDB proxy, which is rate-limited and unreliable. This restores direct TMDB API usage (same key used in the original activity before the proxy was introduced). The API key is hardcoded but it's necessary because that was the original approach and the proxy is dead.

Also fixes a bug where the movie title wouldn't show in `details` when "Show Title as Activity" was turned off, and also added fallback text (`Watching a Movie` / `Watching a TV Show` / `Watching Anime`) if the API ever fails rather than the fall back of `Browsing`.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

<img width="291" height="194" alt="image" src="https://github.com/user-attachments/assets/500611b8-a3ad-46b4-b87f-191db57b2447" />
<img width="452" height="163" alt="image" src="https://github.com/user-attachments/assets/4d7f3ec3-627e-4156-bd75-475f19217ebf" />
<img width="411" height="448" alt="image" src="https://github.com/user-attachments/assets/ac7d88e1-050d-4a2d-8126-847893413588" />


</details>