### PR TITLE
feat(OpenJam): display dynamic album artwork and small logo badge

### DIFF
--- a/websites/O/OpenJam/metadata.json
+++ b/websites/O/OpenJam/metadata.json
@@ -15,9 +15,9 @@
   },
   "url": "openjam.fun",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*openjam[.]fun[/]",
-  "version": "1.0.0",
-  "logo": "https://files.catbox.moe/oz8aca.png",
-  "thumbnail": "https://files.catbox.moe/yjqyp3.png",
+  "version": "1.0.2",
+  "logo": "https://cdn.rcd.gg/PreMiD/websites/O/OpenJam/assets/logo.png",
+  "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/O/OpenJam/assets/thumbnail.png",
   "color": "#6366f1",
   "category": "music",
   "tags": [

--- a/websites/O/OpenJam/metadata.json
+++ b/websites/O/OpenJam/metadata.json
@@ -15,9 +15,9 @@
   },
   "url": "openjam.fun",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*openjam[.]fun[/]",
-  "version": "1.0.1",
-  "logo": "https://cdn.rcd.gg/PreMiD/websites/O/OpenJam/assets/logo.png",
-  "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/O/OpenJam/assets/thumbnail.png",
+  "version": "1.0.0",
+  "logo": "https://files.catbox.moe/oz8aca.png",
+  "thumbnail": "https://files.catbox.moe/yjqyp3.png",
   "color": "#6366f1",
   "category": "music",
   "tags": [

--- a/websites/O/OpenJam/presence.ts
+++ b/websites/O/OpenJam/presence.ts
@@ -8,7 +8,7 @@ let elapsedSinceChange = 0
 
 presence.on('UpdateData', async () => {
   const presenceData: PresenceData = {
-    largeImageKey: 'https://files.catbox.moe/oz8aca.png',
+    largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/O/OpenJam/assets/logo.png',
   }
 
   const [showButtons, showTimestamps] = await Promise.all([
@@ -48,7 +48,7 @@ presence.on('UpdateData', async () => {
       const artworkUrl = artworkEl?.src || ''
       if (artworkUrl && artworkUrl.startsWith('http') && !artworkUrl.includes('/logo.png')) {
         presenceData.largeImageKey = artworkUrl
-        presenceData.smallImageKey = 'https://files.catbox.moe/oz8aca.png'
+        presenceData.smallImageKey = 'https://cdn.rcd.gg/PreMiD/websites/O/OpenJam/assets/logo.png'
         presenceData.smallImageText = 'OpenJam'
       }
     }

--- a/websites/O/OpenJam/presence.ts
+++ b/websites/O/OpenJam/presence.ts
@@ -8,7 +8,7 @@ let elapsedSinceChange = 0
 
 presence.on('UpdateData', async () => {
   const presenceData: PresenceData = {
-    largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/O/OpenJam/assets/logo.png',
+    largeImageKey: 'https://files.catbox.moe/oz8aca.png',
   }
 
   const [showButtons, showTimestamps] = await Promise.all([
@@ -41,6 +41,15 @@ presence.on('UpdateData', async () => {
 
       if (showTimestamps) {
         presenceData.startTimestamp = Math.floor(elapsedSinceChange / 1000)
+      }
+
+      // Dynamic Album Art
+      const artworkEl = document.querySelector<HTMLImageElement>('.mp-artwork-img, .mini-art')
+      const artworkUrl = artworkEl?.src || ''
+      if (artworkUrl && artworkUrl.startsWith('http') && !artworkUrl.includes('/logo.png')) {
+        presenceData.largeImageKey = artworkUrl
+        presenceData.smallImageKey = 'https://files.catbox.moe/oz8aca.png'
+        presenceData.smallImageText = 'OpenJam'
       }
     }
     else {


### PR DESCRIPTION
This PR adds dynamic album art support to OpenJam presence. When a track is playing in a room, it resolves and displays the album art as the large presence image, while showing the OpenJam headphones logo as a small badge on the bottom right.