### PR TITLE
fix(BBC): resolve epoch timer on live simulcast episodes

### DIFF
--- a/websites/B/BBC/metadata.json
+++ b/websites/B/BBC/metadata.json
@@ -31,7 +31,7 @@
     "www.bbc.com"
   ],
   "regExp": "^https?[:][/][/](www[.])?bbc[.](com|co[.]uk)[/]",
-  "version": "2.3.2",
+  "version": "2.3.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/B/BBC/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/B/BBC/assets/thumbnail.png",
   "color": "#000000",

--- a/websites/B/BBC/metadata.json
+++ b/websites/B/BBC/metadata.json
@@ -31,7 +31,7 @@
     "www.bbc.com"
   ],
   "regExp": "^https?[:][/][/](www[.])?bbc[.](com|co[.]uk)[/]",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/B/BBC/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/B/BBC/assets/thumbnail.png",
   "color": "#000000",

--- a/websites/B/BBC/metadata.json
+++ b/websites/B/BBC/metadata.json
@@ -31,7 +31,7 @@
     "www.bbc.com"
   ],
   "regExp": "^https?[:][/][/](www[.])?bbc[.](com|co[.]uk)[/]",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/B/BBC/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/B/BBC/assets/thumbnail.png",
   "color": "#000000",

--- a/websites/B/BBC/presence.ts
+++ b/websites/B/BBC/presence.ts
@@ -20,7 +20,7 @@ function getStrings() {
     {
       play: 'general.playing',
       pause: 'general.paused',
-      Live: 'general.Live',
+      Live: 'general.live',
       browse: 'general.browsing',
       searchSomething: 'general.searchSomething',
       viewTeam: 'twitch.viewTeam',
@@ -57,6 +57,17 @@ function formatChannelName(channelId?: string): string {
   return channelMap[channelId.toLowerCase()] || channelId.toUpperCase()
 }
 
+const LIVE_DURATION_THRESHOLD = 86400 * 30 // nothing on iPlayer is 30 days long
+function isEpochAnchored(value: number): boolean {
+  return Number.isFinite(value) && value > LIVE_DURATION_THRESHOLD
+}
+function isLiveTimeline(media: { duration: number, currentTime: number }): boolean {
+  // `duration` alone is ambiguous: MSE streams (live or VOD) can report
+  // Infinity while the seekable range is still unresolved. `currentTime`
+  // anchored to wall-clock epoch seconds is the reliable live signature.
+  return isEpochAnchored(media.currentTime) || isEpochAnchored(media.duration)
+}
+
 const serviceName = (() => {
   switch (location.pathname.split('/')[1]) {
     case 'iplayer':
@@ -90,6 +101,7 @@ let SoundMedia: MediaData = {
 }
 let iPlayer: IPlayerData
 let soundData: SoundData
+let lastPath: string | undefined
 
 presence.on('iFrameData', (data: IFrameData) => {
   if (data.audio)
@@ -126,7 +138,16 @@ presence.on('UpdateData', async () => {
     }
   }
   const handleVideo = () => {
-    presenceData.type = ActivityType.Watching;
+    presenceData.type = ActivityType.Watching
+
+    if (isLiveTimeline(VideoMedia)) {
+      presenceData.smallImageKey = Assets.Live
+      presenceData.smallImageText = strings.Live
+      delete presenceData.startTimestamp
+      delete presenceData.endTimestamp
+      return
+    }
+
     [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestamps(VideoMedia.currentTime, VideoMedia.duration)
 
     presenceData.smallImageKey = VideoMedia.paused
@@ -144,9 +165,23 @@ presence.on('UpdateData', async () => {
 
   if (path.includes('/iplayer')) {
     presenceData.type = ActivityType.Watching
-    iPlayer ??= await presence
-      .getPageVariable('__IPLAYER_REDUX_STATE__')
-      .then(data => data.__IPLAYER_REDUX_STATE__) as IPlayerData
+    if (lastPath !== path) {
+      lastPath = path
+      const data = await presence.getPageVariable<Record<string, any>>(
+        '__IPLAYER_REDUX_STATE__.episode',
+        '__IPLAYER_REDUX_STATE__.versions',
+        '__IPLAYER_REDUX_STATE__.channel',
+        '__IPLAYER_REDUX_STATE__.header',
+        '__IPLAYER_REDUX_STATE__.relatedEpisodes',
+      )
+      iPlayer = {
+        episode: data['__IPLAYER_REDUX_STATE__.episode'],
+        versions: data['__IPLAYER_REDUX_STATE__.versions'],
+        channel: data['__IPLAYER_REDUX_STATE__.channel'],
+        header: data['__IPLAYER_REDUX_STATE__.header'],
+        relatedEpisodes: data['__IPLAYER_REDUX_STATE__.relatedEpisodes'],
+      } as IPlayerData
+    }
 
     let iPlayerVideo: HTMLVideoElement | MediaData | undefined = document
       .querySelector('smp-toucan-player')
@@ -159,14 +194,28 @@ presence.on('UpdateData', async () => {
       iPlayerVideo = VideoMedia
     // OD Programming:
     if (iPlayerVideo && path.includes('/iplayer/episode')) {
-      if (!iPlayerVideo.duration || iPlayer.episode?.Live) {
-        if (iPlayer.channel?.onAir || iPlayer.episode?.Live) {
+      const simulcast = iPlayer.versions?.find(version => version.kind === 'simulcast')
+      const isSimulcast = Boolean(simulcast) || iPlayer.episode?.live
+      if (!iPlayerVideo.duration || isSimulcast || isLiveTimeline(iPlayerVideo)) {
+        if (iPlayer.channel?.onAir || isSimulcast || isLiveTimeline(iPlayerVideo)) {
           presenceData.details = (iPlayer.channel ?? iPlayer.episode)?.title
           presenceData.state = strings.Live
 
           setCover(iPlayer.episode?.images?.standard)
 
           presenceData.smallImageKey = Assets.Live
+
+          if (simulcast?.startTime) {
+            presenceData.startTimestamp = simulcast.startTime
+            if (simulcast.endTime && simulcast.endTime > Math.floor(Date.now() / 1000))
+              presenceData.endTimestamp = simulcast.endTime
+            else
+              delete presenceData.endTimestamp
+          }
+          else {
+            delete presenceData.startTimestamp
+            delete presenceData.endTimestamp
+          }
         }
         else if (!iPlayer.channel) {
           setCover(
@@ -270,7 +319,6 @@ presence.on('UpdateData', async () => {
         presenceData.smallImageText = strings.Live
 
         delete presenceData.startTimestamp
-        presenceData.startTimestamp = Date.now() // milliseconds
         delete presenceData.endTimestamp
       }
       else {
@@ -282,9 +330,15 @@ presence.on('UpdateData', async () => {
   }
   else if (path.includes('/sounds')) {
     presenceData.type = ActivityType.Listening
-    soundData ??= await presence
-      .getPageVariable('__PRELOADED_STATE__')
-      .then(data => data.__PRELOADED_STATE__) as SoundData
+    if (lastPath !== path) {
+      lastPath = path
+      const data = await presence.getPageVariable<Record<string, any>>(
+        '__PRELOADED_STATE__.programmes',
+      )
+      soundData = {
+        programmes: data['__PRELOADED_STATE__.programmes'],
+      } as SoundData
+    }
 
     if (path.includes('/play/')) {
       const isLive = path.includes('Live:')
@@ -815,7 +869,7 @@ interface IPlayerData {
   episode?: {
     title: string
     subtitle: string
-    Live: boolean
+    live: boolean
     images: {
       portrait?: string
       standard: string
@@ -826,6 +880,11 @@ interface IPlayerData {
       category: string
     }
   }
+  versions?: {
+    kind: string
+    startTime: number
+    endTime: number
+  }[]
   relatedEpisodes?: {
     count: number
     episodes: {

--- a/websites/B/BBC/presence.ts
+++ b/websites/B/BBC/presence.ts
@@ -198,12 +198,22 @@ presence.on('UpdateData', async () => {
       const isSimulcast = Boolean(simulcast) || iPlayer.episode?.live
       if (!iPlayerVideo.duration || isSimulcast || isLiveTimeline(iPlayerVideo)) {
         if (iPlayer.channel?.onAir || isSimulcast || isLiveTimeline(iPlayerVideo)) {
-          presenceData.details = (iPlayer.channel ?? iPlayer.episode)?.title
-          presenceData.state = strings.Live
+          if (usePresenceName) {
+            presenceData.name = iPlayer.episode?.title ?? presenceData.name
+            presenceData.details = iPlayer.episode?.subtitle?.match(/: (.*)/)?.[1]
+              ?? iPlayer.episode?.subtitle
+              ?? strings.Live
+            presenceData.state = iPlayer.episode?.subtitle ?? strings.Live
+          }
+          else {
+            presenceData.details = (iPlayer.channel ?? iPlayer.episode)?.title
+            presenceData.state = iPlayer.episode?.subtitle || strings.Live
+          }
 
           setCover(iPlayer.episode?.images?.standard)
 
           presenceData.smallImageKey = Assets.Live
+          presenceData.smallImageText = strings.Live
 
           if (simulcast?.startTime) {
             presenceData.startTimestamp = simulcast.startTime


### PR DESCRIPTION
## Description
Fixes BBC iPlayer live simulcast episodes (e.g. World Cup matches) showing a nonsense epoch-based elapsed timer (`495288:08:16`+) instead of a Live badge.

Root causes:
- Redux state (`__IPLAYER_REDUX_STATE__`) was fetched once via `??=` and never refreshed on SPA navigation, so live detection always ran against stale/empty state.
- Live DASH/HLS simulcast streams report `video.currentTime`/`duration` anchored to Unix epoch seconds which slip past the live check into the VOD timestamp branch.
- `episode.Live` was checked with the wrong casing (BBC's actual field is lowercase `episode.live`) so that flag never worked regardless of staleness.
- `channel`/`header` no longer exist in BBC's current redux shape for simulcast content; live detection now uses `episode.live` and `versions[].kind === 'simulcast'` instead. This also exposes real scheduled  `startTime`/`endTime` for a correct elapsed/remaining timer.
- `/iplayer/live` channel branch set `startTimestamp` in milliseconds instead of seconds.
- Fetching the entire redux tree via `getPageVariable('__IPLAYER_REDUX_STATE__')` also crashed the Firefox extension (`DOMException: Function object could not be cloned`). Switched to scoped dot-notation fetches for just the fields used.

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected</summary>
<br>
Before:<br>
<img width="289" height="120" alt="image" src="https://github.com/user-attachments/assets/1c8e02c5-2508-44cd-85c5-8ef5050675cb" /> <br>
<img width="472" height="158" alt="image" src="https://github.com/user-attachments/assets/bf26d387-6218-4faf-9d50-653900d25934" />
<br>
After:<br>
With 'iPlayer Title as Presence'<br>
<img width="446" height="160" alt="image" src="https://github.com/user-attachments/assets/310bb20c-662a-4e72-9dcd-91fa7417fad1" /> <br>
Without 'iPlayer Title as Presence'<br>
<img width="459" height="162" alt="Screenshot_20260703_024744" src="https://github.com/user-attachments/assets/17482455-2105-45f9-9b74-c536cd1aab16" /> <br>



</details>