### PR TITLE
fix(untitled.stream): uses blob instead of direct url

### DIFF
--- a/websites/U/untitled.stream/metadata.json
+++ b/websites/U/untitled.stream/metadata.json
@@ -17,7 +17,7 @@
   },
   "url": "untitled.stream",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*untitled[.]stream[/]",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/U/untitled.stream/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/U/untitled.stream/assets/thumbnail.png",
   "color": "#B9ACE3",

--- a/websites/U/untitled.stream/presence.ts
+++ b/websites/U/untitled.stream/presence.ts
@@ -30,6 +30,20 @@ async function getProjectData(projectUrl: string): Promise<LibraryProject> {
   return data?.project ?? null
 }
 
+const cachedCoverArtBlobs = new Map<string, Blob>()
+
+async function getCoverArtBlob(imageUrl: URL) {
+  const cached = cachedCoverArtBlobs.get(imageUrl.pathname)
+  if (cached) {
+    return cached
+  }
+
+  const blob = await fetch(imageUrl.href).then(res => res.blob())
+  cachedCoverArtBlobs.set(imageUrl.pathname, blob)
+
+  return blob
+}
+
 function isPlaying() {
   const audioTag = document.querySelector<HTMLAudioElement>('body > audio')
 
@@ -52,7 +66,6 @@ presence.on('UpdateData', async () => {
 
   const title = getElementText('.playbar-title')
   const subtitle = getElementText('.playbar-subtitle')
-  const coverArt = document.querySelector<HTMLImageElement>('.bg-playbar img')?.src
 
   const presenceData: PresenceData = {
     name: '[untitled].stream',
@@ -62,8 +75,9 @@ presence.on('UpdateData', async () => {
     statusDisplayType: StatusDisplayType.Details,
   }
 
-  if (coverArt) {
-    presenceData.largeImageKey = await fetch(coverArt).then(res => res.blob())
+  const coverArtSrc = document.querySelector<HTMLImageElement>('.bg-playbar img')?.src
+  if (coverArtSrc) {
+    presenceData.largeImageKey = await getCoverArtBlob(new URL(coverArtSrc))
   }
 
   if (libraryData?.project && lastProjectRef) {

--- a/websites/U/untitled.stream/presence.ts
+++ b/websites/U/untitled.stream/presence.ts
@@ -59,8 +59,11 @@ presence.on('UpdateData', async () => {
     details: title,
     largeImageText: subtitle,
     type: ActivityType.Listening,
-    largeImageKey: coverArt,
     statusDisplayType: StatusDisplayType.Details,
+  }
+
+  if (coverArt) {
+    presenceData.largeImageKey = await fetch(coverArt).then(res => res.blob())
   }
 
   if (libraryData?.project && lastProjectRef) {


### PR DESCRIPTION
## Description
[untitled].stream now uses signed url's to all images, and urls with query params are not rendering at Discord Activities. That approach fixes it using image blobs.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<p>Before:</p>
<img width="501" height="252" alt="image" src="https://github.com/user-attachments/assets/176fd29d-79a8-455d-95a2-18b8224fc070" />

<p>Now:</p>
<img width="463" height="200" alt="image" src="https://github.com/user-attachments/assets/7c25fa35-7e56-4722-bf34-3bcf1c192d7e" />
</details>
