### PR TITLE
fix(YouTube): guard corrupt localStorage in pvPrivacyUI (v6.3.3)

### DIFF
--- a/websites/Y/YouTube/metadata.json
+++ b/websites/Y/YouTube/metadata.json
@@ -74,7 +74,7 @@
     "m.youtube.com"
   ],
   "regExp": "^https?[:][/][/](www|studio|m)[.]youtube[.]com[/]",
-  "version": "6.3.2",
+  "version": "6.3.3",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/thumbnail.jpg",
   "color": "#E40813",

--- a/websites/Y/YouTube/util/pvPrivacyUI.ts
+++ b/websites/Y/YouTube/util/pvPrivacyUI.ts
@@ -7,11 +7,19 @@ function removeExpiredPrivacyOverwrites(array?: VPArray) {
     return []
   return array.filter(entry => entry.ttl > Date.now())
 }
+function safeParse(raw: string | null): VPArray {
+  try {
+    return JSON.parse(raw ?? '[]')
+  }
+  catch {
+    return []
+  }
+}
 let perVideoPrivacyArray: VPArray = removeExpiredPrivacyOverwrites(
-  JSON.parse(localStorage.getItem('pmdEnablePrivacy') ?? '[]'),
+  safeParse(localStorage.getItem('pmdEnablePrivacy')),
 )
 let perVideoNonPrivacyArray: VPArray = removeExpiredPrivacyOverwrites(
-  JSON.parse(localStorage.getItem('pmdDisablePrivacy') ?? '[]'),
+  safeParse(localStorage.getItem('pmdDisablePrivacy')),
 )
 
 localStorage.setItem('pmdEnablePrivacy', JSON.stringify(perVideoPrivacyArray))


### PR DESCRIPTION
Belt-and-suspenders hardening for a possible co-trigger of the "raw stack trace on YouTube" field report (extension-side central fix is PreMiD/Extension#781).

The two module-load `JSON.parse(localStorage.getItem(...))` calls in `pvPrivacyUI.ts` ran outside any try/catch and threw **synchronously** at activity load when `pmdEnablePrivacy` / `pmdDisablePrivacy` held corrupt JSON. Wrapped in a tiny `safeParse` that falls back to `[]`.

Metadata patch bump `6.3.2 → 6.3.3`.

## Testing
On a YouTube tab: `localStorage.setItem('pmdEnablePrivacy','{bad')`, reload. Before: uncaught trace at activity load. After: no trace, activity works.