### PR TITLE
feat(Anikoto): add activity

### DIFF
--- a/websites/A/Anikoto/iframe.ts
+++ b/websites/A/Anikoto/iframe.ts
@@ -1,0 +1,354 @@
+interface IFrameVideoData {
+  currentTime?: number
+  duration?: number
+  paused?: boolean
+  readyState?: number
+  sampledAt?: number
+  src?: string
+  title?: string
+  url?: string
+}
+
+const iframe = new iFrame()
+const PARENT_MESSAGE_SOURCE = 'premid-anikoto'
+const PLAYBACK_POLL_INTERVAL_MS = 500
+const PLAYING_REFRESH_INTERVAL_MS = 1_500
+const SELECTED_VIDEO_SCORE_LEEWAY = 700
+let lastSend = 0
+let lastStateKey: string | undefined
+let lastStateSentAt = 0
+let selectedVideo: HTMLVideoElement | undefined
+
+function getCleanText(selector: string): string | undefined {
+  return document.querySelector(selector)?.textContent?.replace(/\s+/g, ' ').trim() || undefined
+}
+
+function getKnownDuration(video: HTMLVideoElement): number {
+  const duration = video.duration
+
+  if (Number.isFinite(duration) && duration > 0 && duration !== Number.POSITIVE_INFINITY)
+    return duration
+
+  try {
+    if (video.seekable?.length) {
+      const end = video.seekable.end(video.seekable.length - 1)
+      if (Number.isFinite(end) && end > 0)
+        return end
+    }
+  }
+  catch {
+    // Ignore media ranges that are unavailable while the player is loading.
+  }
+
+  try {
+    if (video.buffered?.length) {
+      const end = video.buffered.end(video.buffered.length - 1)
+      if (Number.isFinite(end) && end > 0)
+        return end
+    }
+  }
+  catch {
+    // Ignore media ranges that are unavailable while the player is loading.
+  }
+
+  return Number.NaN
+}
+
+function collectVideos(root: Document | ShadowRoot): HTMLVideoElement[] {
+  const videos = [...root.querySelectorAll<HTMLVideoElement>('video')]
+
+  for (const element of root.querySelectorAll<HTMLElement>('*')) {
+    if (element.shadowRoot)
+      videos.push(...collectVideos(element.shadowRoot))
+  }
+
+  return videos
+}
+
+function getVisibleArea(element: Element): number {
+  const rect = element.getBoundingClientRect()
+  return Math.max(0, rect.width) * Math.max(0, rect.height)
+}
+
+function isElementVisible(element: Element): boolean {
+  const rect = element.getBoundingClientRect()
+
+  if (rect.width <= 1 || rect.height <= 1)
+    return false
+
+  const style = window.getComputedStyle(element)
+
+  return style.display !== 'none'
+    && style.visibility !== 'hidden'
+    && Number(style.opacity || 1) > 0
+}
+
+function getPlayerRoot(video: HTMLVideoElement): HTMLElement {
+  return video.closest<HTMLElement>(
+    [
+      '.jwplayer',
+      '.plyr',
+      '.video-js',
+      '.dplayer',
+      '.art-video-player',
+      '.artplayer-app',
+      '.xgplayer',
+      '.player',
+      '#player',
+    ].join(', '),
+  ) ?? document.documentElement
+}
+
+function getStateFromClassName(className: string): boolean | undefined {
+  const normalized = className.toLowerCase()
+
+  if (
+    /\b(?:jw-state-paused|vjs-paused|plyr--paused|dplayer-paused|art-paused|xgplayer-is-pause)\b/.test(normalized)
+  ) {
+    return true
+  }
+
+  if (
+    /\b(?:jw-state-playing|vjs-playing|plyr--playing|dplayer-playing|art-playing|xgplayer-is-playing|xgplayer-playing)\b/.test(normalized)
+  ) {
+    return false
+  }
+
+  return undefined
+}
+
+function getButtonPlaybackState(root: HTMLElement): boolean | undefined {
+  const controls = [...root.querySelectorAll<HTMLElement>(
+    [
+      '[aria-label]',
+      '[title]',
+      '[data-title]',
+      '.jw-icon-playback',
+      '.plyr__control',
+      '.vjs-play-control',
+      '.dplayer-play-icon',
+      '.art-control-playAndPause',
+      '.xgplayer-play',
+    ].join(', '),
+  )].filter(isElementVisible)
+
+  for (const control of controls) {
+    const label = [
+      control.getAttribute('aria-label'),
+      control.getAttribute('title'),
+      control.getAttribute('data-title'),
+      control.textContent,
+    ].join(' ').toLowerCase()
+
+    if (/\b(?:pause|paused)\b/.test(label))
+      return false
+
+    if (/\b(?:play|replay|resume)\b/.test(label))
+      return true
+  }
+
+  return undefined
+}
+
+function getDomPlaybackState(video: HTMLVideoElement): boolean | undefined {
+  const root = getPlayerRoot(video)
+  const roots = [root, document.documentElement]
+
+  for (const element of roots) {
+    const state = getStateFromClassName(element.className)
+
+    if (state !== undefined)
+      return state
+  }
+
+  return getButtonPlaybackState(root)
+}
+
+function getVideoScore(video: HTMLVideoElement): number {
+  const duration = getKnownDuration(video)
+  const visibleArea = getVisibleArea(video)
+  const domPlaybackState = getDomPlaybackState(video)
+  const isPlaying = domPlaybackState === false || (!video.paused && !video.ended)
+
+  return (
+    Math.min(visibleArea / 40, 8000)
+    + (isPlaying ? 250 : 0)
+    + (video.currentTime > 0 ? 1200 : 0)
+    + (Number.isFinite(duration) && duration > 0 ? Math.min(duration, 1000) : 0)
+    + (isElementVisible(video) ? 500 : 0)
+    + (selectedVideo === video ? 500 : 0)
+    + video.readyState
+  )
+}
+
+function pickBestVideo(): HTMLVideoElement | undefined {
+  const videos = collectVideos(document).filter(video => video.readyState > 0 || video.currentTime > 0)
+
+  if (!videos.length)
+    return undefined
+
+  const best = videos.reduce((best, candidate) => {
+    return getVideoScore(candidate) > getVideoScore(best) ? candidate : best
+  })
+
+  if (selectedVideo?.isConnected && videos.includes(selectedVideo)) {
+    const selectedScore = getVideoScore(selectedVideo)
+    const bestScore = getVideoScore(best)
+
+    if (selectedScore + SELECTED_VIDEO_SCORE_LEEWAY >= bestScore)
+      return selectedVideo
+  }
+
+  selectedVideo = best
+  return best
+}
+
+function postParentVideoState(video: IFrameVideoData | null): void {
+  try {
+    if (window.parent === window)
+      return
+
+    window.parent.postMessage({
+      source: PARENT_MESSAGE_SOURCE,
+      type: 'video-state',
+      frameUrl: document.location.href,
+      sampledAt: Date.now(),
+      video,
+    }, '*')
+  }
+  catch {
+    // Ignore pages that block parent messaging.
+  }
+}
+
+function sendVideoPayload(video: IFrameVideoData | null): void {
+  const payload = {
+    sampledAt: Date.now(),
+    video,
+  }
+
+  iframe.send(payload)
+  postParentVideoState(video)
+}
+
+function sendNoVideoState(): void {
+  selectedVideo = undefined
+  sendVideoPayload(null)
+}
+
+function getCurrentVideoState(): IFrameVideoData | null {
+  try {
+    const video = pickBestVideo()
+
+    if (!video)
+      return null
+
+    const duration = getKnownDuration(video)
+
+    return {
+      currentTime: Number.isFinite(video.currentTime) ? video.currentTime : undefined,
+      duration: Number.isFinite(duration) ? duration : undefined,
+      paused: getDomPlaybackState(video) ?? (video.paused || video.ended),
+      readyState: video.readyState,
+      sampledAt: Date.now(),
+      src: video.currentSrc || video.src || undefined,
+      title:
+        getCleanText('.video-title')
+        ?? getCleanText('.jw-title-primary')
+        ?? getCleanText('.plyr__video-title')
+        ?? document.title?.replace(/\s+/g, ' ').trim()
+        ?? undefined,
+      url: document.location.href,
+    }
+  }
+  catch {
+    // Ignore inaccessible or transient iframe states.
+    return null
+  }
+}
+
+function sendVideoState(): void {
+  const video = getCurrentVideoState()
+
+  if (!video) {
+    sendNoVideoState()
+    return
+  }
+
+  sendVideoPayload(video)
+}
+
+function sendVideoStateThrottled(): void {
+  const now = Date.now()
+
+  if (now - lastSend < 250)
+    return
+
+  lastSend = now
+  sendVideoState()
+}
+
+function getStateKey(video: IFrameVideoData | null): string {
+  if (!video)
+    return 'no-video'
+
+  const time = Number.isFinite(video.currentTime)
+    ? Math.floor((video.currentTime ?? 0) * 2) / 2
+    : ''
+
+  return [
+    video.paused === true ? 'paused' : video.paused === false ? 'playing' : 'unknown',
+    time,
+    Number.isFinite(video.duration) ? Math.round(video.duration ?? 0) : '',
+    video.src ?? video.url ?? '',
+  ].join('|')
+}
+
+function sendVideoStateOnChange(): void {
+  const video = getCurrentVideoState()
+  const stateKey = getStateKey(video)
+  const now = Date.now()
+  const refreshInterval = video?.paused ? 5_000 : PLAYING_REFRESH_INTERVAL_MS
+
+  if (stateKey === lastStateKey && now - lastStateSentAt < refreshInterval)
+    return
+
+  lastStateKey = stateKey
+  lastStateSentAt = now
+
+  if (video)
+    sendVideoPayload(video)
+  else
+    sendNoVideoState()
+}
+
+iframe.on('UpdateData', sendVideoState)
+
+document.addEventListener('loadedmetadata', sendVideoState, true)
+document.addEventListener('durationchange', sendVideoState, true)
+document.addEventListener('canplay', sendVideoState, true)
+document.addEventListener('playing', sendVideoState, true)
+document.addEventListener('play', sendVideoState, true)
+document.addEventListener('pause', sendVideoState, true)
+document.addEventListener('ended', sendVideoState, true)
+document.addEventListener('seeked', sendVideoState, true)
+document.addEventListener('timeupdate', sendVideoStateThrottled, true)
+document.addEventListener('progress', sendVideoStateThrottled, true)
+
+window.setInterval(sendVideoStateOnChange, PLAYBACK_POLL_INTERVAL_MS)
+
+let mutationTimer: number | undefined
+const observer = new MutationObserver(() => {
+  if (mutationTimer !== undefined)
+    window.clearTimeout(mutationTimer)
+
+  mutationTimer = window.setTimeout(() => {
+    mutationTimer = undefined
+    sendVideoState()
+  }, 400)
+})
+
+observer.observe(document.documentElement, {
+  childList: true,
+  subtree: true,
+})

--- a/websites/A/Anikoto/metadata.json
+++ b/websites/A/Anikoto/metadata.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "name": "FLIXDTR",
+    "id": "537557377503985664"
+  },
+  "service": "Anikoto",
+  "description": {
+    "en": "Anikoto is an anime streaming website.",
+    "fr": "Anikoto est un site de streaming d'anime."
+  },
+  "url": "anikototv.to",
+  "regExp": "^https?://(www\\.)?anikototv\\.to/",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/3CY0qmm.png",
+  "thumbnail": "https://i.imgur.com/gRdHdau.png",
+  "color": "#26A3D6",
+  "category": "anime",
+  "tags": [
+    "anime",
+    "streaming",
+    "video"
+  ],
+  "iframe": true,
+  "iFrameRegExp": "^https?://([^/]+\\.)?(vidtube\\.site|nekostream\\.[^/]+|megacloud\\.[^/]+|vidplay\\.[^/]+|myvidplay\\.[^/]+|dsvplay\\.[^/]+|vidsrc\\.[^/]+|vidstream\\.[^/]+|vidstreaming\\.[^/]+|vidcloud\\.[^/]+|rapid-cloud\\.[^/]+|filemoon\\.[^/]+|streamtape\\.[^/]+|dood(?:stream)?\\.[^/]+|mp4upload\\.[^/]+|streamsb\\.[^/]+|mcloud\\.[^/]+|rabbitstream\\.[^/]+|vidhide(?:vip)?\\.[^/]+|vidmoly\\.[^/]+|voe\\.[^/]+|uqload\\.[^/]+|streamwish\\.[^/]+|embedwish\\.[^/]+|mixdrop\\.[^/]+)/.*",
+  "settings": [
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "icon": "fad fa-user-secret",
+      "value": false
+    },
+    {
+      "id": "showButtons",
+      "title": "Show Buttons",
+      "icon": "fad fa-link",
+      "value": true,
+      "if": {
+        "privacy": false
+      }
+    },
+    {
+      "id": "showTimer",
+      "title": "Show Timer",
+      "icon": "fad fa-stopwatch",
+      "value": true,
+      "if": {
+        "privacy": false
+      }
+    },
+    {
+      "id": "showExactDetails",
+      "title": "Show Exact Details",
+      "icon": "fad fa-info-circle",
+      "value": true,
+      "if": {
+        "privacy": false
+      }
+    }
+  ]
+}

--- a/websites/A/Anikoto/metadata.json
+++ b/websites/A/Anikoto/metadata.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "$schema": "https://schemas.premid.app/metadata/1.17",
   "apiVersion": 1,
   "author": {
     "name": "FLIXDTR",

--- a/websites/A/Anikoto/metadata.json
+++ b/websites/A/Anikoto/metadata.json
@@ -10,8 +10,14 @@
     "en": "Anikoto is an anime streaming website.",
     "fr": "Anikoto est un site de streaming d'anime."
   },
-  "url": "anikototv.to",
-  "regExp": "^https?[:][/][/](www[.])?anikototv[.]to[/]",
+  "url": [
+    "anikototv.to",
+    "anikoto.cz",
+    "anikoto.me",
+    "anikoto.net",
+    "anikototv.se"
+  ],
+  "regExp": "^https?[:][/][/](www[.])?(anikototv[.]to|anikoto[.]cz|anikoto[.]me|anikoto[.]net|anikototv[.]se)[/]",
   "version": "1.0.0",
   "logo": "https://i.imgur.com/3CY0qmm.png",
   "thumbnail": "https://i.imgur.com/gRdHdau.png",
@@ -23,7 +29,7 @@
     "video"
   ],
   "iframe": true,
-  "iFrameRegExp": "^https?[:][/][/]([^/]+[.])?(vidtube[.]site|nekostream[.][^/]+|megacloud[.][^/]+|vidplay[.][^/]+|myvidplay[.][^/]+|dsvplay[.][^/]+|vidsrc[.][^/]+|vidstream[.][^/]+|vidstreaming[.][^/]+|vidcloud[.][^/]+|rapid-cloud[.][^/]+|filemoon[.][^/]+|streamtape[.][^/]+|dood(?:stream)?[.][^/]+|mp4upload[.][^/]+|streamsb[.][^/]+|mcloud[.][^/]+|rabbitstream[.][^/]+|vidhide(?:vip)?[.][^/]+|vidmoly[.][^/]+|voe[.][^/]+|uqload[.][^/]+|streamwish[.][^/]+|embedwish[.][^/]+|mixdrop[.][^/]+)[/].*",
+  "iFrameRegExp": "^https?[:][/][/]([^/]+[.])?(vidtube[.]site|megaplay[.]buzz|vidwish[.]live|nekostream[.][^/]+|megacloud[.][^/]+|vidplay[.][^/]+|myvidplay[.][^/]+|dsvplay[.][^/]+|vidsrc[.][^/]+|vidstream[.][^/]+|vidstreaming[.][^/]+|vidcloud[.][^/]+|rapid-cloud[.][^/]+|filemoon[.][^/]+|streamtape[.][^/]+|dood(?:stream)?[.][^/]+|mp4upload[.][^/]+|streamsb[.][^/]+|mcloud[.][^/]+|rabbitstream[.][^/]+|vidhide(?:vip)?[.][^/]+|vidmoly[.][^/]+|voe[.][^/]+|uqload[.][^/]+|streamwish[.][^/]+|embedwish[.][^/]+|mixdrop[.][^/]+)[/].*",
   "settings": [
     {
       "id": "privacy",

--- a/websites/A/Anikoto/metadata.json
+++ b/websites/A/Anikoto/metadata.json
@@ -11,7 +11,7 @@
     "fr": "Anikoto est un site de streaming d'anime."
   },
   "url": "anikototv.to",
-  "regExp": "^https?://(www\\.)?anikototv\\.to/",
+  "regExp": "^https?[:][/][/](www[.])?anikototv[.]to[/]",
   "version": "1.0.0",
   "logo": "https://i.imgur.com/3CY0qmm.png",
   "thumbnail": "https://i.imgur.com/gRdHdau.png",
@@ -23,7 +23,7 @@
     "video"
   ],
   "iframe": true,
-  "iFrameRegExp": "^https?://([^/]+\\.)?(vidtube\\.site|nekostream\\.[^/]+|megacloud\\.[^/]+|vidplay\\.[^/]+|myvidplay\\.[^/]+|dsvplay\\.[^/]+|vidsrc\\.[^/]+|vidstream\\.[^/]+|vidstreaming\\.[^/]+|vidcloud\\.[^/]+|rapid-cloud\\.[^/]+|filemoon\\.[^/]+|streamtape\\.[^/]+|dood(?:stream)?\\.[^/]+|mp4upload\\.[^/]+|streamsb\\.[^/]+|mcloud\\.[^/]+|rabbitstream\\.[^/]+|vidhide(?:vip)?\\.[^/]+|vidmoly\\.[^/]+|voe\\.[^/]+|uqload\\.[^/]+|streamwish\\.[^/]+|embedwish\\.[^/]+|mixdrop\\.[^/]+)/.*",
+  "iFrameRegExp": "^https?[:][/][/]([^/]+[.])?(vidtube[.]site|nekostream[.][^/]+|megacloud[.][^/]+|vidplay[.][^/]+|myvidplay[.][^/]+|dsvplay[.][^/]+|vidsrc[.][^/]+|vidstream[.][^/]+|vidstreaming[.][^/]+|vidcloud[.][^/]+|rapid-cloud[.][^/]+|filemoon[.][^/]+|streamtape[.][^/]+|dood(?:stream)?[.][^/]+|mp4upload[.][^/]+|streamsb[.][^/]+|mcloud[.][^/]+|rabbitstream[.][^/]+|vidhide(?:vip)?[.][^/]+|vidmoly[.][^/]+|voe[.][^/]+|uqload[.][^/]+|streamwish[.][^/]+|embedwish[.][^/]+|mixdrop[.][^/]+)[/].*",
   "settings": [
     {
       "id": "privacy",

--- a/websites/A/Anikoto/presence.ts
+++ b/websites/A/Anikoto/presence.ts
@@ -1,0 +1,918 @@
+import { ActivityType, Assets, getTimestamps } from 'premid'
+
+type Nullable<T> = T | null | undefined
+
+interface IFrameVideoData {
+  currentTime?: number
+  duration?: number
+  paused?: boolean
+  readyState?: number
+  sampledAt?: number
+  src?: string
+  title?: string
+  url?: string
+}
+
+interface IFramePayload {
+  pageUrl?: string
+  sampledAt?: number
+  video?: IFrameVideoData | null
+}
+
+interface VideoCandidate {
+  data: IFrameVideoData
+  priority: number
+}
+
+interface Settings {
+  showButtons: boolean
+  showExactDetails: boolean
+  showTimer: boolean
+  privacy: boolean
+}
+
+interface WatchInfo {
+  activeEpisode?: HTMLAnchorElement
+  animeUrl?: string
+  episodeLabel?: string
+  episodeUrl?: string
+  poster?: string
+  title?: string
+}
+
+const presence = new Presence({
+  clientId: '1524344097022672976',
+})
+
+enum ActivityAssets {
+  Logo = 'https://i.imgur.com/3CY0qmm.png',
+}
+
+const VIDEO_DATA_TTL_MS = 12_000
+const MESSAGE_VIDEO_DATA_TTL_MS = 7_500
+const VIDEO_CANDIDATE_TIE_MS = 500
+const PRESENCE_REFRESH_THROTTLE_MS = 1_000
+const RECENT_EXPLICIT_PAUSE_MS = 5_000
+const STATIONARY_VIDEO_PAUSE_MS = 2_500
+const STATIONARY_VIDEO_EPSILON_SECONDS = 0.08
+const PARENT_MESSAGE_SOURCE = 'premid-anikoto'
+
+let browsingTimestamp = Math.floor(Date.now() / 1000)
+let iframeData: IFramePayload = {}
+let lastPageKey = document.location.href
+let wasWatching = false
+let messageVideoData: IFrameVideoData | undefined
+let activityUpdateInFlight = false
+let activityUpdateQueued = false
+let activityUpdateTimer: number | undefined
+let lastPresenceUpdateAt = 0
+let lastVideoSnapshot:
+  | {
+    currentTime: number
+    key: string
+    paused: boolean
+    sampledAt: number
+    stationarySince: number
+  }
+  | undefined
+
+presence.on('iFrameData', (data: IFramePayload) => {
+  const previousPaused = iframeData.video?.paused
+
+  iframeData = {
+    ...data,
+    pageUrl: document.location.href,
+    sampledAt: Date.now(),
+  }
+
+  const nextPaused = iframeData.video?.paused
+
+  if (nextPaused !== undefined && nextPaused !== previousPaused) {
+    scheduleActivityUpdate(true)
+  }
+  else if (iframeData.video && Date.now() - lastPresenceUpdateAt > PRESENCE_REFRESH_THROTTLE_MS) {
+    scheduleActivityUpdate()
+  }
+})
+
+window.addEventListener('message', (event) => {
+  try {
+    let data = event.data as unknown
+
+    if (typeof data === 'string')
+      data = JSON.parse(data) as unknown
+
+    if (!data || typeof data !== 'object')
+      return
+
+    const parentPayload = data as {
+      frameUrl?: string
+      sampledAt?: number
+      source?: string
+      type?: string
+      video?: IFrameVideoData | null
+    }
+
+    if (parentPayload.source === PARENT_MESSAGE_SOURCE && parentPayload.type === 'video-state') {
+      updateFrameVideoData(parentPayload.video ?? null, parentPayload.frameUrl)
+      return
+    }
+
+    const payload = data as {
+      channel?: string
+      currentTime?: number | string
+      duration?: number | string
+      event?: string
+      paused?: boolean | string
+      state?: string
+      status?: string
+      time?: number | string
+      type?: string
+    }
+    const currentTime = Number(payload.currentTime ?? payload.time)
+    const duration = Number(payload.duration)
+    const postedPlaybackState = getPostedPlaybackState(payload)
+    const isTimeUpdate = payload.type === 'watching-log'
+      || (payload.channel === 'megacloud' && payload.event === 'time')
+
+    if (postedPlaybackState !== undefined) {
+      messageVideoData = {
+        currentTime: Number.isFinite(currentTime) && currentTime >= 0
+          ? currentTime
+          : messageVideoData?.currentTime,
+        duration: Number.isFinite(duration) && duration > 0 ? duration : messageVideoData?.duration,
+        paused: postedPlaybackState,
+        readyState: 4,
+        sampledAt: Date.now(),
+        src: 'postMessage',
+        url: document.location.href,
+      }
+
+      scheduleActivityUpdate(true)
+    }
+    else if (isTimeUpdate && Number.isFinite(currentTime) && currentTime > 0) {
+      const previousTime = messageVideoData?.currentTime
+      const hasAdvanced = Number.isFinite(previousTime)
+        && currentTime - (previousTime ?? 0) > 0.5
+
+      messageVideoData = {
+        currentTime,
+        duration: Number.isFinite(duration) && duration > 0 ? duration : undefined,
+        paused: hasAdvanced && !hasRecentExplicitPause() ? false : undefined,
+        readyState: 4,
+        sampledAt: Date.now(),
+        src: 'postMessage',
+        url: document.location.href,
+      }
+
+      if (!getFreshVideoData(iframeData.video ?? undefined, VIDEO_DATA_TTL_MS))
+        scheduleActivityUpdate()
+    }
+    else if (
+      payload.type === 'complete'
+      || (payload.channel === 'megacloud' && payload.event === 'complete')
+    ) {
+      messageVideoData = {
+        currentTime: Number.isFinite(duration) ? duration : messageVideoData?.currentTime,
+        duration: Number.isFinite(duration) && duration > 0 ? duration : messageVideoData?.duration,
+        paused: true,
+        readyState: 4,
+        sampledAt: Date.now(),
+        src: 'postMessage',
+        url: document.location.href,
+      }
+
+      scheduleActivityUpdate(true)
+    }
+  }
+  catch {
+    // Ignore unrelated cross-frame messages.
+  }
+})
+
+function cleanText(text: Nullable<string>): string | undefined {
+  return text?.replace(/\s+/g, ' ').trim() || undefined
+}
+
+function truncate(text: Nullable<string>, maxLength = 128): string | undefined {
+  const clean = cleanText(text)
+
+  if (!clean)
+    return undefined
+
+  return clean.length > maxLength ? `${clean.slice(0, maxLength - 1)}...` : clean
+}
+
+function safeDecode(value: string | undefined): string | undefined {
+  if (!value)
+    return undefined
+
+  try {
+    return decodeURIComponent(value)
+  }
+  catch {
+    return value
+  }
+}
+
+function absoluteUrl(url: Nullable<string>): string | undefined {
+  if (!url)
+    return undefined
+
+  try {
+    const parsed = new URL(url, document.location.origin)
+
+    if (!['http:', 'https:'].includes(parsed.protocol))
+      return undefined
+
+    return parsed.href
+  }
+  catch {
+    return undefined
+  }
+}
+
+function getMetaContent(property: string): string | undefined {
+  return document
+    .querySelector<HTMLMetaElement>(`meta[property="${property}"], meta[name="${property}"]`)
+    ?.content
+}
+
+function getImageUrl(selector: string): string | undefined {
+  const image = document.querySelector<HTMLImageElement>(selector)
+  return absoluteUrl(image?.currentSrc || image?.src || image?.getAttribute('src'))
+}
+
+function getBackgroundImageUrl(selector: string): string | undefined {
+  const element = document.querySelector<HTMLElement>(selector)
+  const style = element?.style.backgroundImage || element?.getAttribute('style') || ''
+  const match = style.match(/url\((['"]?)(.*?)\1\)/i)
+
+  return absoluteUrl(match?.[2])
+}
+
+function getSearchTerm(): string | undefined {
+  const params = new URLSearchParams(document.location.search)
+  return cleanText(
+    params.get('keyword')
+    ?? document.querySelector<HTMLInputElement>('#search input[name="keyword"]')?.value,
+  )
+}
+
+function getReadableSlug(slug: string | undefined): string | undefined {
+  if (!slug)
+    return undefined
+
+  return slug
+    .split('-')
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function getAnimeUrl(watchMain: HTMLElement | null, pathEpisode: string | undefined): string | undefined {
+  const fromDataset = absoluteUrl(watchMain?.dataset.url)
+
+  if (fromDataset)
+    return fromDataset
+
+  if (pathEpisode) {
+    return absoluteUrl(
+      document.location.href
+        .replace(/\/ep-[^/?#]+/i, '')
+        .replace(/[?#].*$/, ''),
+    )
+  }
+
+  return document.location.pathname.startsWith('/watch/')
+    ? absoluteUrl(document.location.href)
+    : undefined
+}
+
+function cleanMetaTitle(title: Nullable<string>): string | undefined {
+  if (!title)
+    return undefined
+
+  let cleanTitle = title
+  const siteIndex = cleanTitle.search(/\s+-\s+Anikoto\b/i)
+
+  if (siteIndex >= 0)
+    cleanTitle = cleanTitle.slice(0, siteIndex)
+
+  const episodeIndex = cleanTitle.search(/\bEpisode\s+\d+\b/i)
+
+  if (episodeIndex > 0)
+    cleanTitle = cleanTitle.slice(0, episodeIndex)
+
+  return cleanTitle
+    .replace(/\bWatch Online Free\b/gi, '')
+    .replace(/\bWatch Anime Online\b/gi, '')
+    .replace(/(?:^|\s)Anime$/i, '')
+    .replace(/\s+/g, ' ')
+    .replace(/\s+-\s*$/, '')
+    .trim() || undefined
+}
+
+function getAnimeTitle(): string | undefined {
+  return truncate(
+    document.querySelector('#w-info h1.title, #watch-main h1.title, h1[itemprop="name"], h1.title.d-title')
+      ?.textContent
+      ?? cleanMetaTitle(getMetaContent('og:title')),
+  )
+}
+
+function getWatchInfo(): WatchInfo {
+  const watchMain = document.querySelector<HTMLElement>('#watch-main')
+  const activeEpisode = document.querySelector<HTMLAnchorElement>(
+    '#w-episodes a.active[data-num], .episodes a.active[data-num], .detail-seasons a.active[data-num], a.active[enabled="1"][data-timestamp]',
+  )
+  const pathEpisode = document.location.pathname.match(/\/ep-([^/?#]+)/i)?.[1]
+  const title = getAnimeTitle()
+  const animeUrl = getAnimeUrl(watchMain, pathEpisode)
+  const episodeUrl = absoluteUrl(pathEpisode ? document.location.href : activeEpisode?.href || document.location.href)
+  const episodeLabel = truncate(
+    pathEpisode
+      ? `Episode ${safeDecode(pathEpisode)}`
+      : watchMain?.dataset.epName
+        ? `Episode ${watchMain.dataset.epName}`
+        : activeEpisode?.dataset.num
+          ? `Episode ${activeEpisode.dataset.num}`
+          : undefined,
+  )
+
+  return {
+    activeEpisode: activeEpisode ?? undefined,
+    animeUrl,
+    episodeLabel,
+    episodeUrl,
+    poster:
+      getImageUrl('#w-info .poster img, .poster img[itemprop="image"]')
+      ?? getBackgroundImageUrl('#player')
+      ?? absoluteUrl(getMetaContent('og:image')),
+    title,
+  }
+}
+
+function getPageTitleFromDocument(): string | undefined {
+  return truncate(
+    document.querySelector('main h1, #body h1, .head .title, .block .title, h1.title')?.textContent
+    ?? document.title?.replace(/\s*-\s*Anikoto.*$/i, ''),
+  )
+}
+
+function getMemberPageLabel(pathname: string): string | undefined {
+  const normalizedPath = pathname.replace(/\/+$/, '') || '/member'
+
+  if (normalizedPath === '/member' || normalizedPath === '/member/profile')
+    return 'Profile'
+
+  const routes: Record<string, string> = {
+    '/member/watch-list': 'Watch List',
+    '/member/continue-watching': 'Continue Watching',
+    '/member/notification': 'Notifications',
+    '/member/notifications': 'Notifications',
+    '/member/settings': 'Settings',
+    '/member/import': 'Import',
+    '/member/anilist-sync': 'AniList Sync',
+  }
+
+  return routes[normalizedPath] ?? getReadableSlug(normalizedPath.split('/').pop())
+}
+
+function getPageContext(): { details?: string, state?: string, smallImageKey?: string, smallImageText?: string } {
+  const { pathname } = document.location
+
+  if (pathname === '/' || pathname === '/home') {
+    return {
+      details: 'Browsing Anikoto',
+      state: pathname === '/' ? 'Landing page' : 'Home page',
+      smallImageKey: Assets.Reading,
+      smallImageText: 'Browsing',
+    }
+  }
+
+  if (pathname.startsWith('/member')) {
+    return {
+      details: 'Browsing Anikoto',
+      state: getMemberPageLabel(pathname),
+      smallImageKey: Assets.Reading,
+      smallImageText: 'Browsing',
+    }
+  }
+
+  if (pathname.startsWith('/az-list')) {
+    return {
+      details: 'Browsing anime',
+      state: 'A-Z List',
+      smallImageKey: Assets.Search,
+      smallImageText: 'Browsing',
+    }
+  }
+
+  if (pathname.startsWith('/filter')) {
+    const searchTerm = getSearchTerm()
+
+    return {
+      details: searchTerm ? 'Searching anime' : 'Browsing filters',
+      state: searchTerm ? truncate(searchTerm) : 'Filter page',
+      smallImageKey: Assets.Search,
+      smallImageText: 'Searching',
+    }
+  }
+
+  const genre = pathname.match(/^\/genre\/([^/?#]+)/i)?.[1]
+  if (genre) {
+    return {
+      details: 'Browsing by genre',
+      state: truncate(getReadableSlug(safeDecode(genre))),
+      smallImageKey: Assets.Search,
+      smallImageText: 'Browsing',
+    }
+  }
+
+  const section = pathname.match(/^\/(latest-updated|new-release|most-viewed|status|type|watch2gether|random)(?:\/([^/?#]+))?/i)
+  if (section) {
+    const label = getReadableSlug(section[2] ? `${section[1]} ${section[2]}` : section[1])
+
+    return {
+      details: 'Browsing Anikoto',
+      state: truncate(label),
+      smallImageKey: Assets.Reading,
+      smallImageText: 'Browsing',
+    }
+  }
+
+  if (pathname.startsWith('/watch/')) {
+    const info = getWatchInfo()
+
+    return {
+      details: 'Viewing anime',
+      state: info.title,
+      smallImageKey: Assets.Reading,
+      smallImageText: 'Viewing anime',
+    }
+  }
+
+  return {
+    details: 'Browsing Anikoto',
+    state: getPageTitleFromDocument(),
+    smallImageKey: Assets.Reading,
+    smallImageText: 'Browsing',
+  }
+}
+
+async function getSettings(): Promise<Settings> {
+  const [showButtons, showTimer, showExactDetails, privacy] = await Promise.all([
+    presence.getSetting<boolean>('showButtons'),
+    presence.getSetting<boolean>('showTimer'),
+    presence.getSetting<boolean>('showExactDetails'),
+    presence.getSetting<boolean>('privacy'),
+  ])
+
+  return {
+    showButtons,
+    showExactDetails,
+    showTimer,
+    privacy,
+  }
+}
+
+function getVideoData(): IFrameVideoData | undefined {
+  const candidates = [
+    { data: getPageVideoData(), priority: 3 },
+    {
+      data: iframeData.pageUrl === document.location.href
+        ? getFreshVideoData(iframeData.video ?? undefined, VIDEO_DATA_TTL_MS)
+        : undefined,
+      priority: 2,
+    },
+    { data: getFreshVideoData(messageVideoData, MESSAGE_VIDEO_DATA_TTL_MS), priority: 1 },
+  ].filter((candidate): candidate is VideoCandidate => !!candidate.data)
+
+  const recentExplicitPause = candidates.find((candidate) => {
+    return candidate.priority > 1
+      && candidate.data.paused === true
+      && Date.now() - (candidate.data.sampledAt ?? 0) <= RECENT_EXPLICIT_PAUSE_MS
+  })
+
+  const newerExplicitPlay = recentExplicitPause
+    ? candidates.some((candidate) => {
+        return candidate.priority > 1
+          && candidate.data.paused === false
+          && (candidate.data.sampledAt ?? 0) > (recentExplicitPause.data.sampledAt ?? 0)
+      })
+    : false
+
+  if (recentExplicitPause && !newerExplicitPlay)
+    return inferPlaybackState(recentExplicitPause.data)
+
+  const latest = candidates.reduce<VideoCandidate | undefined>((best, candidate) => {
+    if (!best)
+      return candidate
+
+    const sampledDiff = (candidate.data.sampledAt ?? 0) - (best.data.sampledAt ?? 0)
+
+    if (Math.abs(sampledDiff) <= VIDEO_CANDIDATE_TIE_MS)
+      return candidate.priority > best.priority ? candidate : best
+
+    return sampledDiff > 0 ? candidate : best
+  }, undefined)?.data
+
+  return latest ? inferPlaybackState(latest) : undefined
+}
+
+function getPageVideoData(): IFrameVideoData | undefined {
+  const video = document.querySelector<HTMLVideoElement>('video')
+
+  if (!video || video.readyState <= 0)
+    return undefined
+
+  return {
+    currentTime: video.currentTime,
+    duration: video.duration,
+    paused: video.paused,
+    readyState: video.readyState,
+    sampledAt: Date.now(),
+    src: video.currentSrc || video.src || undefined,
+    title: document.title,
+    url: document.location.href,
+  }
+}
+
+function normalizeFrameVideoData(
+  videoData: IFrameVideoData | null | undefined,
+  frameUrl: string | undefined,
+): IFrameVideoData | null {
+  if (!videoData || typeof videoData !== 'object')
+    return null
+
+  const currentTime = Number(videoData.currentTime)
+  const duration = Number(videoData.duration)
+  const readyState = Number(videoData.readyState)
+
+  return {
+    currentTime: Number.isFinite(currentTime) && currentTime >= 0 ? currentTime : undefined,
+    duration: Number.isFinite(duration) && duration > 0 ? duration : undefined,
+    paused: typeof videoData.paused === 'boolean' ? videoData.paused : undefined,
+    readyState: Number.isFinite(readyState) ? readyState : undefined,
+    sampledAt: Date.now(),
+    src: typeof videoData.src === 'string' ? videoData.src : undefined,
+    title: typeof videoData.title === 'string' ? truncate(videoData.title) : undefined,
+    url: absoluteUrl(frameUrl) ?? absoluteUrl(videoData.url) ?? document.location.href,
+  }
+}
+
+function updateFrameVideoData(videoData: IFrameVideoData | null, frameUrl: string | undefined): void {
+  const previousVideo = iframeData.video ?? null
+  const previousPaused = previousVideo?.paused
+  const nextVideo = normalizeFrameVideoData(videoData, frameUrl)
+
+  if (!nextVideo) {
+    if (previousVideo?.url === absoluteUrl(frameUrl)) {
+      iframeData = {
+        pageUrl: document.location.href,
+        sampledAt: Date.now(),
+        video: null,
+      }
+      scheduleActivityUpdate(true)
+    }
+
+    return
+  }
+
+  iframeData = {
+    pageUrl: document.location.href,
+    sampledAt: Date.now(),
+    video: nextVideo,
+  }
+
+  if (nextVideo.paused !== undefined && nextVideo.paused !== previousPaused)
+    scheduleActivityUpdate(true)
+  else
+    scheduleActivityUpdate()
+}
+
+function getPostedPlaybackState(payload: {
+  event?: string
+  paused?: boolean | string
+  state?: string
+  status?: string
+  type?: string
+}): boolean | undefined {
+  if (typeof payload.paused === 'boolean')
+    return payload.paused
+
+  if (typeof payload.paused === 'string') {
+    const paused = payload.paused.toLowerCase()
+
+    if (paused === 'true')
+      return true
+
+    if (paused === 'false')
+      return false
+  }
+
+  const states = [payload.event, payload.type, payload.state, payload.status]
+    .map(value => value?.toLowerCase().replace(/[^a-z]/g, ''))
+    .filter((value): value is string => !!value)
+
+  if (!states.length)
+    return undefined
+
+  if (states.some(state => ['pause', 'paused', 'playerpause', 'videopause', 'playbackpaused'].includes(state)))
+    return true
+
+  if (states.some(state => ['play', 'playing', 'resume', 'resumed', 'playerplay', 'videoplay', 'playbackplaying'].includes(state)))
+    return false
+
+  return undefined
+}
+
+function getFreshVideoData(videoData: IFrameVideoData | null | undefined, ttl: number): IFrameVideoData | undefined {
+  if (!videoData)
+    return undefined
+
+  const sampledAt = videoData.sampledAt ?? 0
+
+  if (!sampledAt || Date.now() - sampledAt > ttl)
+    return undefined
+
+  if (
+    !Number.isFinite(videoData.currentTime)
+    && !Number.isFinite(videoData.duration)
+    && !videoData.readyState
+  ) {
+    return undefined
+  }
+
+  return videoData
+}
+
+function hasRecentExplicitPause(): boolean {
+  const frameVideo = iframeData.pageUrl === document.location.href
+    ? getFreshVideoData(iframeData.video ?? undefined, VIDEO_DATA_TTL_MS)
+    : undefined
+  const pageVideo = getPageVideoData()
+
+  return [pageVideo, frameVideo].some((videoData) => {
+    return videoData?.paused === true
+      && Date.now() - (videoData.sampledAt ?? 0) <= RECENT_EXPLICIT_PAUSE_MS
+  })
+}
+
+function inferPlaybackState(videoData: IFrameVideoData): IFrameVideoData {
+  const sampledAt = videoData.sampledAt ?? Date.now()
+  const currentTime = Number(videoData.currentTime ?? 0)
+  const key = videoData.src || videoData.url || document.location.href
+  const inferred = { ...videoData }
+  let stationarySince = sampledAt
+
+  if (
+    lastVideoSnapshot
+    && lastVideoSnapshot.key === key
+    && sampledAt > lastVideoSnapshot.sampledAt
+  ) {
+    const timeDelta = currentTime - lastVideoSnapshot.currentTime
+    const isAdvancing = timeDelta > STATIONARY_VIDEO_EPSILON_SECONDS
+    const isStationary = Math.abs(timeDelta) <= STATIONARY_VIDEO_EPSILON_SECONDS
+
+    stationarySince = isStationary ? lastVideoSnapshot.stationarySince : sampledAt
+
+    if (inferred.paused === undefined && isAdvancing)
+      inferred.paused = false
+
+    if (
+      inferred.paused !== true
+      && isStationary
+      && currentTime > 0
+      && sampledAt - stationarySince >= STATIONARY_VIDEO_PAUSE_MS
+    ) {
+      inferred.paused = true
+    }
+  }
+
+  if (Number.isFinite(currentTime)) {
+    lastVideoSnapshot = {
+      currentTime,
+      key,
+      paused: inferred.paused ?? false,
+      sampledAt,
+      stationarySince,
+    }
+  }
+
+  return inferred
+}
+
+function handlePageChange(currentKey: string): void {
+  if (currentKey !== lastPageKey) {
+    iframeData = {}
+    lastVideoSnapshot = undefined
+    messageVideoData = undefined
+    browsingTimestamp = Math.floor(Date.now() / 1000)
+    lastPageKey = currentKey
+    wasWatching = false
+  }
+}
+
+function updateBrowsingTimestamp(currentKey: string, isWatching: boolean): void {
+  handlePageChange(currentKey)
+
+  if (wasWatching !== isWatching)
+    browsingTimestamp = Math.floor(Date.now() / 1000)
+
+  wasWatching = isWatching
+}
+
+function applyButtons(presenceData: PresenceData, info: WatchInfo, settings: Settings): void {
+  if (!settings.showButtons || settings.privacy)
+    return
+
+  const buttons: { label: string, url: string }[] = []
+
+  if (info.episodeUrl) {
+    buttons.push({
+      label: 'Watch Episode',
+      url: info.episodeUrl,
+    })
+  }
+
+  if (info.animeUrl && info.animeUrl !== info.episodeUrl) {
+    buttons.push({
+      label: 'View Anime',
+      url: info.animeUrl,
+    })
+  }
+
+  const [firstButton, secondButton] = buttons
+
+  if (firstButton && secondButton)
+    presenceData.buttons = [firstButton, secondButton]
+  else if (firstButton)
+    presenceData.buttons = [firstButton]
+}
+
+function getAdjustedCurrentTime(videoData: IFrameVideoData): number {
+  const currentTime = videoData.currentTime ?? 0
+
+  if (videoData.paused || !videoData.sampledAt)
+    return currentTime
+
+  return currentTime + Math.max(0, (Date.now() - videoData.sampledAt) / 1000)
+}
+
+function applyPlaybackTimer(presenceData: PresenceData, videoData: IFrameVideoData | undefined, showTimer: boolean): void {
+  if (
+    !showTimer
+    || !videoData
+    || videoData.paused
+    || !Number.isFinite(videoData.currentTime)
+    || !Number.isFinite(videoData.duration)
+    || (videoData.duration ?? 0) <= 0
+  ) {
+    return
+  }
+
+  const currentTime = Math.min(
+    getAdjustedCurrentTime(videoData),
+    videoData.duration ?? Number.POSITIVE_INFINITY,
+  )
+  const [startTimestamp, endTimestamp] = getTimestamps(
+    currentTime,
+    videoData.duration ?? 0,
+  )
+
+  presenceData.startTimestamp = startTimestamp
+  presenceData.endTimestamp = endTimestamp
+}
+
+function buildWatchPresence(settings: Settings): PresenceData | undefined {
+  const info = getWatchInfo()
+
+  if (!info.title && !info.episodeLabel)
+    return undefined
+
+  const videoData = getVideoData()
+  const paused = videoData?.paused
+  const playbackState = paused === undefined ? undefined : paused ? 'Paused' : 'Playing'
+  const hasEpisodePath = /\/watch\/[^/]+\/ep-[^/?#]+/i.test(document.location.pathname)
+  const hasEpisodeDataset = !!document.querySelector<HTMLElement>('#watch-main')?.dataset.epName
+  const hasLoadedEpisodePlayer = !!document.querySelector('#player iframe, #w-servers .servers, #w-servers .tip b')
+  const isEpisodePage = hasEpisodePath || hasEpisodeDataset || (!!info.activeEpisode && hasLoadedEpisodePlayer)
+
+  if (!isEpisodePage)
+    return undefined
+
+  const presenceData: PresenceData = {
+    type: ActivityType.Watching,
+    largeImageKey: settings.privacy ? ActivityAssets.Logo : info.poster || ActivityAssets.Logo,
+    largeImageText: settings.privacy ? 'Anikoto' : info.title,
+    smallImageKey: paused === undefined ? Assets.Reading : paused ? Assets.Pause : Assets.Play,
+    smallImageText: playbackState ?? 'Episode page',
+  }
+
+  if (settings.privacy) {
+    presenceData.details = 'Watching anime'
+    presenceData.state = playbackState
+  }
+  else if (settings.showExactDetails) {
+    presenceData.details = truncate(info.title) ?? 'Watching anime'
+    presenceData.state = truncate([info.episodeLabel, playbackState].filter(Boolean).join(' - '))
+  }
+  else {
+    presenceData.details = 'Watching anime'
+    presenceData.state = playbackState
+      ? `${info.episodeLabel ?? 'Episode'} - ${playbackState}`
+      : info.episodeLabel
+  }
+
+  applyPlaybackTimer(presenceData, videoData, settings.showTimer)
+  applyButtons(presenceData, info, settings)
+
+  return presenceData.details ? presenceData : undefined
+}
+
+function buildBrowsingPresence(settings: Settings): PresenceData | undefined {
+  if (settings.privacy)
+    return undefined
+
+  const pageContext = getPageContext()
+
+  if (!pageContext.details)
+    return undefined
+
+  const presenceData: PresenceData = {
+    type: ActivityType.Watching,
+    largeImageKey: ActivityAssets.Logo,
+    largeImageText: 'Anikoto',
+    details: pageContext.details,
+    state: settings.showExactDetails ? pageContext.state : undefined,
+    smallImageKey: pageContext.smallImageKey,
+    smallImageText: pageContext.smallImageText,
+  }
+
+  if (settings.showTimer)
+    presenceData.startTimestamp = browsingTimestamp
+
+  return presenceData
+}
+
+function scheduleActivityUpdate(immediate = false): void {
+  if (activityUpdateTimer !== undefined) {
+    if (!immediate)
+      return
+
+    window.clearTimeout(activityUpdateTimer)
+  }
+
+  const delay = immediate
+    ? 0
+    : Math.max(0, PRESENCE_REFRESH_THROTTLE_MS - (Date.now() - lastPresenceUpdateAt))
+
+  activityUpdateTimer = window.setTimeout(() => {
+    activityUpdateTimer = undefined
+    void updateActivity()
+  }, delay)
+}
+
+async function updateActivity(): Promise<void> {
+  if (activityUpdateInFlight) {
+    activityUpdateQueued = true
+    return
+  }
+
+  activityUpdateInFlight = true
+
+  try {
+    handlePageChange(document.location.href)
+
+    const settings = await getSettings()
+    const watchingPresence = buildWatchPresence(settings)
+
+    updateBrowsingTimestamp(document.location.href, !!watchingPresence)
+
+    const presenceData = watchingPresence ?? buildBrowsingPresence(settings)
+
+    if (presenceData?.details)
+      presence.setActivity(presenceData)
+    else
+      presence.clearActivity()
+
+    lastPresenceUpdateAt = Date.now()
+  }
+  catch {
+    presence.clearActivity()
+  }
+  finally {
+    activityUpdateInFlight = false
+
+    if (activityUpdateQueued) {
+      activityUpdateQueued = false
+      scheduleActivityUpdate(true)
+    }
+  }
+}
+
+presence.on('UpdateData', () => {
+  void updateActivity()
+})


### PR DESCRIPTION
## Description
Adds support for Anikoto as a PreMiD activity.

The activity covers browsing pages, search/filter pages, member pages, and episode playback pages. Episode playback shows the anime title, current episode, playing/paused state, poster artwork when available, optional timestamps, and optional buttons for the current episode/anime page.

The `iframe.ts` helper is included because Anikoto uses external embedded video providers. Some providers do not reliably expose pause/play changes to the top-level page, so the iframe helper reads the accessible video/player state and posts sanitized playback data back to the activity without changing page behavior.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Validation
- `npx eslint websites/A/Anikoto --cache`
- `npx pmd build "Anikoto" --validate`
- `npx pmd check-dns "Anikoto"`
- GitHub PR checks are passing.

## Screenshots
<details>
<summary>Proof showing the creation/modification is working as expected</summary>

**Continue Watching / Watch List**
<img width="933" height="521" alt="image5" src="https://github.com/user-attachments/assets/bf84b2ad-4899-41ee-90a1-1dec272b62a9" />

**Home page**
<img width="933" height="520" alt="image4" src="https://github.com/user-attachments/assets/9a5f77fc-323e-4729-97bd-1b3767627ac4" />

**Episode playing**
<img width="931" height="519" alt="image2" src="https://github.com/user-attachments/assets/85c32a09-7c72-43dc-9611-b2a928f3a0ba" />

**Episode paused**
<img width="934" height="517" alt="Image6" src="https://github.com/user-attachments/assets/0b886035-b522-4b0a-86f7-86e28c09d112" />

**Search / filter page**
<img width="1859" height="1030" alt="image" src="https://github.com/user-attachments/assets/72dd8712-ac24-49cd-b9f2-a8c58e4e4ae8" />

**Activity settings**
<img width="409" height="593" alt="image1" src="https://github.com/user-attachments/assets/b59b293e-ef05-4096-bc5a-4f64f2896fe1" />

</details>