### PR TITLE
fix(CHZZK): read stream info from api instead of hashed dom classes

### DIFF
--- a/websites/C/CHZZK/metadata.json
+++ b/websites/C/CHZZK/metadata.json
@@ -14,7 +14,7 @@
   },
   "url": "chzzk.naver.com",
   "regExp": "^https?[:][/][/]chzzk[.]naver[.]com[/]",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/C/CHZZK/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/C/CHZZK/assets/thumbnail.png",
   "color": "#00ffa3",

--- a/websites/C/CHZZK/presence.ts
+++ b/websites/C/CHZZK/presence.ts
@@ -1,4 +1,4 @@
-import { ActivityType, getTimestampsFromMedia, timestampFromFormat } from 'premid'
+import { ActivityType, getTimestampsFromMedia } from 'premid'
 
 const presence = new Presence({
   clientId: '1232944311415603281',
@@ -32,6 +32,67 @@ enum ChzzkAssets {
   Pause = 'https://cdn.rcd.gg/PreMiD/websites/C/CHZZK/assets/4.png',
 }
 
+// CHZZK renders fully-hashed CSS module class names (e.g. `_title_1aj24_25`) that
+// change on every deploy, so page metadata is read from the public API instead of
+// scraping the DOM. The `<video>` element (stable player class) is still used for
+// VOD progress and paused state.
+const API_BASE = 'https://api.chzzk.naver.com/service/v3'
+
+interface ChannelInfo {
+  channelName?: string
+  channelImageUrl?: string
+}
+interface LiveDetail {
+  liveTitle?: string
+  status?: string
+  openDate?: string
+  channel?: ChannelInfo
+}
+interface VideoDetail {
+  videoTitle?: string
+  channel?: ChannelInfo
+}
+
+const cache = new Map<string, { data: unknown, expires: number }>()
+const inFlight = new Map<string, Promise<unknown>>()
+
+async function fetchInfo<T>(
+  key: string,
+  url: string,
+  ttl: number,
+): Promise<T | null> {
+  const cached = cache.get(key)
+  if (cached && cached.expires > Date.now())
+    return cached.data as T | null
+
+  let promise = inFlight.get(key)
+  if (!promise) {
+    promise = fetch(url, { headers: { Accept: 'application/json' } })
+      .then(res => res.json())
+      .then((json) => {
+        const data = json?.content ?? null
+        cache.set(key, { data, expires: Date.now() + ttl })
+        return data
+      })
+      .catch(() => null)
+      .finally(() => inFlight.delete(key))
+    inFlight.set(key, promise)
+  }
+  return (await promise) as T | null
+}
+
+// CHZZK `openDate` is "YYYY-MM-DD HH:mm:ss" in KST (UTC+9); convert to a
+// timezone-independent unix timestamp (seconds) for the elapsed-time counter.
+function kstToUnix(date: string): number {
+  const p = date.match(/\d+/g)?.map(Number)
+  if (!p || p.length < 6)
+    return Math.floor(Date.now() / 1000)
+  return Math.floor(
+    (Date.UTC(p[0]!, p[1]! - 1, p[2]!, p[3]!, p[4]!, p[5]!)
+      - 9 * 60 * 60 * 1000) / 1000,
+  )
+}
+
 let strings: Awaited<ReturnType<typeof getStrings>>
 
 presence.on('UpdateData', async () => {
@@ -54,64 +115,94 @@ presence.on('UpdateData', async () => {
     type: ActivityType.Watching,
   }
   const { pathname, href } = document.location
+  const [, route, id] = pathname.split('/')
+  const video = document.querySelector('video')
 
-  switch (pathname.split('/')[1]) {
-    case 'video':
-    case 'live':
-      {
-        const video = document.querySelector('video')
-        if (
-          document.querySelector<HTMLElement>('div.ad_info_area')?.offsetParent
-        ) {
-          presenceData.details = strings.ad
-          presenceData.smallImageKey = ChzzkAssets.Play
-          presenceData.smallImageText = strings.play
-        }
-        else {
-          const streamerLogo = new URL(
-            document.querySelector<HTMLImageElement>(
-              '[class^=video_information_thumbnail] img',
-            )!.src,
-          )
-          presenceData.details = document.querySelector(
-            'h2[class^=video_information_title]',
-          )?.textContent
-          presenceData.state = document.querySelector(
-            'div[class^=video_information_name]>span>span',
-          )?.textContent
-          presenceData.largeImageKey = showStreamerLogo
-            ? streamerLogo.href.replace(streamerLogo.search, '')
-            : ActivityAssets.Logo
+  // Best-effort ad detection kept from the previous implementation.
+  const adPlaying = !!document.querySelector<HTMLElement>(
+    'div.ad_info_area',
+  )?.offsetParent
 
-          if (pathname.startsWith('/live')) {
-            presenceData.smallImageKey = ChzzkAssets.Live
-            presenceData.smallImageText = strings.live
-            if (showElapsedTime) {
-              presenceData.startTimestamp = Math.floor(Date.now() / 1000)
-                - timestampFromFormat(
-                  document.querySelector('span[class^=video_information_count]')
-                    ?.textContent ?? '',
-                )
-            }
-            presenceData.buttons = [{ url: href, label: strings.watchStream }]
-          }
-          else {
-            presenceData.smallImageKey = ChzzkAssets.Play
-            presenceData.smallImageText = strings.play;
-            [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestampsFromMedia(video!)
-            presenceData.buttons = [{ url: href, label: strings.watchVideo }]
-          }
+  switch (route) {
+    case 'live': {
+      if (!id)
+        break
+      if (adPlaying) {
+        presenceData.details = strings.ad
+        presenceData.smallImageKey = ChzzkAssets.Play
+        presenceData.smallImageText = strings.play
+        break
+      }
 
-          if (video!.paused) {
-            presenceData.smallImageKey = ChzzkAssets.Pause
-            presenceData.smallImageText = strings.pause
-            delete presenceData.startTimestamp
-          }
+      const info = await fetchInfo<LiveDetail>(
+        `live:${id}`,
+        `${API_BASE}/channels/${id}/live-detail`,
+        30_000,
+      )
+      if (!info || info.status !== 'OPEN')
+        break
 
-          break
+      presenceData.details = info.liveTitle
+      presenceData.state = info.channel?.channelName
+      presenceData.largeImageKey
+        = showStreamerLogo && info.channel?.channelImageUrl
+          ? info.channel.channelImageUrl
+          : ActivityAssets.Logo
+      presenceData.smallImageKey = ChzzkAssets.Live
+      presenceData.smallImageText = strings.live
+      presenceData.buttons = [{ url: href, label: strings.watchStream }]
+
+      if (showElapsedTime && info.openDate)
+        presenceData.startTimestamp = kstToUnix(info.openDate)
+
+      if (video?.paused) {
+        presenceData.smallImageKey = ChzzkAssets.Pause
+        presenceData.smallImageText = strings.pause
+        delete presenceData.startTimestamp
+      }
+      break
+    }
+    case 'video': {
+      if (!id)
+        break
+      if (adPlaying) {
+        presenceData.details = strings.ad
+        presenceData.smallImageKey = ChzzkAssets.Play
+        presenceData.smallImageText = strings.play
+        break
+      }
+
+      const info = await fetchInfo<VideoDetail>(
+        `video:${id}`,
+        `${API_BASE}/videos/${id}`,
+        600_000,
+      )
+      if (!info)
+        break
+
+      presenceData.details = info.videoTitle
+      presenceData.state = info.channel?.channelName
+      presenceData.largeImageKey
+        = showStreamerLogo && info.channel?.channelImageUrl
+          ? info.channel.channelImageUrl
+          : ActivityAssets.Logo
+      presenceData.smallImageKey = ChzzkAssets.Play
+      presenceData.smallImageText = strings.play
+      presenceData.buttons = [{ url: href, label: strings.watchVideo }]
+
+      if (video) {
+        [presenceData.startTimestamp, presenceData.endTimestamp]
+          = getTimestampsFromMedia(video)
+
+        if (video.paused) {
+          presenceData.smallImageKey = ChzzkAssets.Pause
+          presenceData.smallImageText = strings.pause
+          delete presenceData.startTimestamp
+          delete presenceData.endTimestamp
         }
       }
       break
+    }
   }
   presence.setActivity(presenceData)
 })


### PR DESCRIPTION
## Description

CHZZK switched its build to fully hashed CSS module class names (e.g. `_title_1aj24_25`) that change on every deploy. The existing `video_information_*` selectors all return `null`, and because the streamer-logo lookup used a non-null assertion (`querySelector(...)!.src`), the whole `UpdateData` handler throws — so nothing shows up at all, on both live and video pages.

Instead of chasing the class names again (this has already been patched twice: #9025, #10219), this reads the stream metadata from CHZZK's public API, which is stable across deploys:

- live: `https://api.chzzk.naver.com/service/v3/channels/{channelId}/live-detail`
- video: `https://api.chzzk.naver.com/service/v3/videos/{videoNo}`

From there it uses the live/video title, channel name, channel image and `openDate`. The `<video>` element (stable player class, not a hashed module class) is still used for VOD progress and the paused state. Responses are cached per id with an in-flight guard so `UpdateData` doesn't refetch on every tick.

Two things worth calling out:

- The requests go to `api.chzzk.naver.com`, which is the activity website's own API, and use the Fetch API only.
- `kstToUnix` is a small custom helper: CHZZK returns `openDate` as an absolute wall-clock time in KST (`"YYYY-MM-DD HH:mm:ss"`), and none of the built-in timestamp helpers convert an absolute date to a unix timestamp, so it parses it in a timezone-independent way for the elapsed-time counter.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the modification is working as expected </summary>

<img width="283" height="163" alt="premid-1" src="https://github.com/user-attachments/assets/1c8d6b1c-71c4-4545-b59d-aeefecae0c08" />

<img width="286" height="154" alt="premid-2" src="https://github.com/user-attachments/assets/82e74ef0-0819-4998-8a70-1ff3fb6d319e" />
<img width="419" height="522" alt="premid-3" src="https://github.com/user-attachments/assets/4e8cc1be-9309-4b21-89e8-756cbc2e872f" />

</details>
