### PR TITLE
feat(Tidal): add statusDisplayType option

### DIFF
--- a/websites/T/Tidal/metadata.json
+++ b/websites/T/Tidal/metadata.json
@@ -59,16 +59,16 @@
       "icon": "fas fa-compress-arrows-alt",
       "value": true
     },
-	{
+    {
       "id": "displayType",
       "title": "Status Display",
       "icon": "fad fa-user-edit",
       "value": 0,
-	  "values": [
-		"Activity name",
-		"Song",
-		"Artist"
-	  ]
+      "values": [
+        "Activity name",
+        "Song",
+        "Artist"
+      ]
     }
   ]
 }

--- a/websites/T/Tidal/metadata.json
+++ b/websites/T/Tidal/metadata.json
@@ -28,7 +28,7 @@
     "tidal.com"
   ],
   "regExp": "^https?[:][/][/](listen[.])?tidal[.]com[/]",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/T/Tidal/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/T/Tidal/assets/thumbnail.png",
   "color": "#000000",
@@ -58,6 +58,17 @@
       "title": "Show Buttons",
       "icon": "fas fa-compress-arrows-alt",
       "value": true
+    },
+	{
+      "id": "displayType",
+      "title": "Status Display",
+      "icon": "fad fa-user-edit",
+      "value": 0,
+	  "values": [
+		"Activity name",
+		"Song",
+		"Artist"
+	  ]
     }
   ]
 }

--- a/websites/T/Tidal/presence.ts
+++ b/websites/T/Tidal/presence.ts
@@ -1,4 +1,4 @@
-import { ActivityType, Assets, getTimestamps, timestampFromFormat, StatusDisplayType } from 'premid'
+import { ActivityType, Assets, getTimestamps, StatusDisplayType, timestampFromFormat } from 'premid'
 
 const LOGO_URL = 'https://cdn.rcd.gg/PreMiD/websites/T/Tidal/assets/logo.png'
 
@@ -26,7 +26,7 @@ presence.on('UpdateData', async () => {
     presence.getSetting<boolean>('timestamps'),
     presence.getSetting<boolean>('cover'),
     presence.getSetting<boolean>('buttons'),
-	presence.getSetting<number>('displayType')
+    presence.getSetting<number>('displayType'),
   ])
 
   if (oldLang !== newLang || !strings) {
@@ -100,20 +100,20 @@ presence.on('UpdateData', async () => {
       },
     ]
   }
-  console.log('displayType:', displayType)
+
   switch (displayType) {
-	case 0: {
-	  presenceData.statusDisplayType = StatusDisplayType.Name
-	  break
-	}
-	case 1: {
-	  presenceData.statusDisplayType = StatusDisplayType.Details
-	  break
-	}
-	case 2: {
-	  presenceData.statusDisplayType = StatusDisplayType.State
-	  break
-	}
+    case 0: {
+      presenceData.statusDisplayType = StatusDisplayType.Name
+      break
+    }
+    case 1: {
+      presenceData.statusDisplayType = StatusDisplayType.Details
+      break
+    }
+    case 2: {
+      presenceData.statusDisplayType = StatusDisplayType.State
+      break
+    }
   }
 
   if (!timestamps)

--- a/websites/T/Tidal/presence.ts
+++ b/websites/T/Tidal/presence.ts
@@ -1,4 +1,4 @@
-import { ActivityType, Assets, getTimestamps, timestampFromFormat } from 'premid'
+import { ActivityType, Assets, getTimestamps, timestampFromFormat, StatusDisplayType } from 'premid'
 
 const LOGO_URL = 'https://cdn.rcd.gg/PreMiD/websites/T/Tidal/assets/logo.png'
 
@@ -21,11 +21,12 @@ presence.on('UpdateData', async () => {
   if (!document.querySelector('[data-test="track-info"]'))
     return presence.setActivity({ largeImageKey: LOGO_URL })
 
-  const [newLang, timestamps, cover, buttons] = await Promise.all([
+  const [newLang, timestamps, cover, buttons, displayType] = await Promise.all([
     presence.getSetting<string>('lang').catch(() => 'en'),
     presence.getSetting<boolean>('timestamps'),
     presence.getSetting<boolean>('cover'),
     presence.getSetting<boolean>('buttons'),
+	presence.getSetting<number>('displayType')
   ])
 
   if (oldLang !== newLang || !strings) {
@@ -98,6 +99,21 @@ presence.on('UpdateData', async () => {
         url: songTitle?.href ?? '',
       },
     ]
+  }
+  console.log('displayType:', displayType)
+  switch (displayType) {
+	case 0: {
+	  presenceData.statusDisplayType = StatusDisplayType.Name
+	  break
+	}
+	case 1: {
+	  presenceData.statusDisplayType = StatusDisplayType.Details
+	  break
+	}
+	case 2: {
+	  presenceData.statusDisplayType = StatusDisplayType.State
+	  break
+	}
   }
 
   if (!timestamps)


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
- Add an option to select the name of the activity, performer, or song to be displayed under the profile name in the list of server members
## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="385" height="160" alt="image" src="https://github.com/user-attachments/assets/7756e320-98ab-49d4-9500-656fbad5630e" />
<img width="275" height="58" alt="image" src="https://github.com/user-attachments/assets/c7ea04fc-2f85-4e0e-a8a7-fce1bd34fc5c" />
<img width="160" height="53" alt="image" src="https://github.com/user-attachments/assets/0ed847b7-6705-423e-aa3d-32974eca0472" />
