### PR TITLE
fix(atomicradio): browsing status showing numeric router IDs

### DIFF
--- a/websites/A/atomicradio/metadata.json
+++ b/websites/A/atomicradio/metadata.json
@@ -5,13 +5,19 @@
     "name": "VocalZero",
     "id": "223891083724193792"
   },
+  "contributors": [
+    {
+      "name": "InstabilSpielt",
+      "id": "425706045453893642"
+    }
+  ],
   "service": "atomicradio",
   "description": {
     "en": "The future of radio is here. Experience 12 Spaces with non-stop music you'll love."
   },
   "url": "atomic.radio",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*atomic[.]radio[/]",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/A/atomicradio/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/atomicradio/assets/thumbnail.jpg",
   "color": "#a9f923",

--- a/websites/A/atomicradio/presence.ts
+++ b/websites/A/atomicradio/presence.ts
@@ -18,10 +18,7 @@ presence.on('UpdateData', () => {
   if (player && currentSpaceItem) {
     const currentSpace = JSON.parse(currentSpaceItem)
     presenceData.largeImageKey = currentSpace.current_track.artwork
-    presenceData.smallImageKey = player.querySelector<HTMLButtonElement>('[id*="-button"]')?.id
-      === 'play-button'
-      ? Assets.Play
-      : Assets.Pause
+    presenceData.smallImageKey = Assets.Play
     presenceData.details = currentSpace.current_track.title
     presenceData.state = currentSpace.current_track.artist
     presenceData.startTimestamp = Math.floor(new Date(currentSpace.current_track.startingAt).getTime() / 1000)
@@ -34,11 +31,8 @@ presence.on('UpdateData', () => {
       },
     ]
   }
-  else if (document.location.pathname === '/') {
-    presenceData.details = 'Browsing spaces...'
-  }
   else {
-    presenceData.details = `Browsing ${document.location.pathname.split('/').at(-1)}...`
+    presenceData.details = 'Browsing...'
   }
   if (presenceData.details)
     presence.setActivity(presenceData)


### PR DESCRIPTION
## Description
- Fix playback state detection by always showing `Assets.Play` when `currentSpace` exists in localStorage
- Fix browsing status showing numeric router IDs

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<img width="281" height="110" alt="image" src="https://github.com/user-attachments/assets/e4fd94a8-274d-441b-b4f0-91ab2dcae878" />



