### PR TITLE
fix(Homestuck^2): update domain

### DIFF
--- a/websites/H/Homestuck^2/metadata.json
+++ b/websites/H/Homestuck^2/metadata.json
@@ -5,7 +5,7 @@
     "name": "john",
     "id": "156937406375919616"
   },
-  "service": "Homestuck: Beyond Canon",
+  "service": "Homestuck^2",
   "description": {
     "en": "The Beyond Canon website hosts Homestuck: Beyond Canon, the official continuation of Homestuck, along with news and bonus content for supporters."
   },

--- a/websites/H/Homestuck^2/metadata.json
+++ b/websites/H/Homestuck^2/metadata.json
@@ -5,16 +5,16 @@
     "name": "john",
     "id": "156937406375919616"
   },
-  "service": "Homestuck^2",
+  "service": "Homestuck: Beyond Canon",
   "description": {
-    "en": "The Homestuck^2 website hosts the official continuation of the popular MSPaintAdventure Homestuck and all Patreon-driven bonus content."
+    "en": "The Beyond Canon website hosts Homestuck: Beyond Canon, the official continuation of Homestuck, along with news and bonus content for supporters."
   },
   "url": [
-    "www.homestuck2.com",
-    "homestuck2.com"
+    "www.beyondcanon.com",
+    "beyondcanon.com"
   ],
-  "regExp": "^https?[:][/][/](www[.])?homestuck2[.]com[/]",
-  "version": "1.1.0",
+  "regExp": "^https?[:][/][/](www[.])?beyondcanon[.]com[/]",
+  "version": "1.1.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/H/Homestuck%5E2/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/H/Homestuck%5E2/assets/thumbnail.png",
   "color": "#f2a400",
@@ -22,7 +22,7 @@
   "tags": [
     "webcomic",
     "comic",
-    "homestuck-2",
+    "beyondcanon",
     "andrew-hussie",
     "mspaintadventures"
   ]

--- a/websites/H/Homestuck^2/presence.ts
+++ b/websites/H/Homestuck^2/presence.ts
@@ -16,28 +16,37 @@ presence.on('UpdateData', async () => {
   const { pathname } = document.location
   const pathArr = pathname.split('/')
 
-  switch (pathArr[1]) {
+  switch (pathArr[0]) {
     case '':
       presenceData.details = 'Viewing the home page'
       break
+  }
 
+  switch (pathArr[1]) {
     case 'story':
-      presenceData.details = 'Reading Homestuck^2'
+      presenceData.details = 'Reading Homestuck: Beyond Canon'
       presenceData.smallImageKey = ActivityAssets.Heart
+
       if (!pathArr[2])
         presenceData.state = `Page 1 of ${await getPages()}`
-      else presenceData.state = `Page ${pathArr[2]} of ${await getPages()}`
+      else if (!(pathArr[2] === 'log'))
+        presenceData.state = `Page ${pathArr[2]} of ${await getPages()}`
 
-      if (document.querySelector('h2')) {
-        presenceData.smallImageText = document.querySelector('h2')?.textContent
+      if (pathArr[2] === 'log') {
+        presenceData.details = 'Viewing the adventure log'
+      }
+
+      if (document.querySelector('h1')) {
+        presenceData.smallImageText = document.querySelector('h1')?.textContent
       }
       else {
-        presenceData.smallImageText = document.querySelector('title')?.textContent
+        presenceData.smallImageText = document.querySelector('.title__content')?.textContent
       }
+
       presenceData.buttons = [
         {
           label: 'Read Along',
-          url: `https://www.homestuck2.com${pathname}`,
+          url: `https://www.beyondcanon.com${pathname}`,
         },
       ]
       break
@@ -53,7 +62,7 @@ presence.on('UpdateData', async () => {
           presenceData.buttons = [
             {
               label: 'Read Along',
-              url: `https://www.homestuck2.com${pathname}`,
+              url: `https://www.beyondcanon.com${pathname}`,
             },
           ]
           break
@@ -66,7 +75,7 @@ presence.on('UpdateData', async () => {
           presenceData.buttons = [
             {
               label: 'Read Along',
-              url: `https://www.homestuck2.com${pathname}`,
+              url: `https://www.beyondcanon.com${pathname}`,
             },
           ]
           break
@@ -79,7 +88,7 @@ presence.on('UpdateData', async () => {
           presenceData.buttons = [
             {
               label: 'Read Along',
-              url: `https://www.homestuck2.com${pathname}`,
+              url: `https://www.beyondcanon.com${pathname}`,
             },
           ]
           break
@@ -92,7 +101,7 @@ presence.on('UpdateData', async () => {
           presenceData.buttons = [
             {
               label: 'Read Along',
-              url: `https://www.homestuck2.com${pathname}`,
+              url: `https://www.beyondcanon.com${pathname}`,
             },
           ]
           break
@@ -105,7 +114,7 @@ presence.on('UpdateData', async () => {
           presenceData.buttons = [
             {
               label: 'Read Along',
-              url: `https://www.homestuck2.com${pathname}`,
+              url: `https://www.beyondcanon.com${pathname}`,
             },
           ]
           break
@@ -127,16 +136,20 @@ presence.on('UpdateData', async () => {
       presenceData.details = 'Viewing the credits'
       break
 
-    case 'log':
-      presenceData.details = 'Viewing the adventure log'
-      break
-
     case 'privacy-policy':
       presenceData.details = 'Viewing the privacy policy'
       break
 
+    case 'cookie-policy':
+      presenceData.details = 'Viewing the cookie policy'
+      break
+
     case 'recap':
       presenceData.details = 'Viewing recap'
+      break
+
+    case 'news':
+      presenceData.details = 'Viewing the news page'
       break
 
     default:
@@ -146,12 +159,12 @@ presence.on('UpdateData', async () => {
 
   if (presenceData.details)
     presence.setActivity(presenceData)
-  else presence.setActivity()
+  else presence.clearActivity()
 })
 
 async function getPages() {
   const response = await fetch(
-    `https://api.rss2json.com/v1/api.json?rss_url=${'https://homestuck2.com/story/rss'}`,
+    `https://api.rss2json.com/v1/api.json?rss_url=${'https://beyondcanon.com/story/feed'}`,
   )
   const data = await response.json()
   return data.items[0].title

--- a/websites/H/Homestuck^2/presence.ts
+++ b/websites/H/Homestuck^2/presence.ts
@@ -10,6 +10,7 @@ enum ActivityAssets {
 
 presence.on('UpdateData', async () => {
   const presenceData: PresenceData = {
+    name: 'Homestuck: Beyond Canon',
     largeImageKey: ActivityAssets.Logo,
     startTimestamp: browsingTimestamp,
   }


### PR DESCRIPTION
- Update metadata and URLs to match the Beyond Canon rebrand.
- Fix pathname parsing for page detection and update the RSS feed endpoint.
- Add support for newly available pages on the website.

close #10185 

## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
This PR fixes the issue reported in #10185 and restores the activity's functionality.

The metadata and URLs have been updated to reflect the Beyond Canon rebrand. The RSS feed endpoint was also updated so that `getPages()` works correctly again.

Additionally, this PR fixes issues with pathname parsing and page detection, adds support for the `news` and `cookie-policy` pages, replaces `presence.setActivity()` with `presence.clearActivity()`, and updates the activity title accordingly. :)

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="212" height="92" alt="Captura de pantalla 2026-07-12 052555" src="https://github.com/user-attachments/assets/762d57e4-7f94-4191-93eb-beb6ed3fb14c" />
<img width="229" height="100" alt="Captura de pantalla 2026-07-12 052600" src="https://github.com/user-attachments/assets/fcd3a542-64ea-4cd2-aeca-5f0c8cebe185" />
<img width="210" height="86" alt="Captura de pantalla 2026-07-12 052606" src="https://github.com/user-attachments/assets/a49ea7af-868b-482f-92fe-6170dceb6ea0" />
<img width="960" height="600" alt="Captura de pantalla 2026-07-12 052909" src="https://github.com/user-attachments/assets/f8d23818-d474-4099-8406-6e4a066fad61" />




</details>
