### PR TITLE
fix(Crunchyroll): add Bitmovin video selector

### DIFF
--- a/websites/C/Crunchyroll/iframe.ts
+++ b/websites/C/Crunchyroll/iframe.ts
@@ -5,6 +5,7 @@ iframe.on('UpdateData', () => {
     = document.querySelector<HTMLVideoElement>('video')
       ?? document.querySelector<HTMLVideoElement>('#player0')
       ?? document.querySelector<HTMLVideoElement>('#player_html5_api')
+      ?? document.querySelector<HTMLVideoElement>('#bitmovinplayer-video-null')
 
   if (video && !Number.isNaN(video.duration)) {
     iframe.send({

--- a/websites/C/Crunchyroll/metadata.json
+++ b/websites/C/Crunchyroll/metadata.json
@@ -42,7 +42,7 @@
   },
   "url": "www.crunchyroll.com",
   "regExp": "^https?[:][/][/](www[.])?crunchyroll[.]com[/]",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/C/Crunchyroll/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/C/Crunchyroll/assets/thumbnail.png",
   "color": "#f47521",


### PR DESCRIPTION
close #10636

## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
This PR fixes the issue reported in #10636, where the activity only showed "Browsing" instead of displaying when an anime was being watched.

This happened because Crunchyroll appears to have started using Bitmovin as its video player. I added support for it in `iframe.ts` while keeping the existing selectors as fallbacks, in case the change is rolled out gradually or varies by region. If none of the other players are detected, the activity will now fall back to the Bitmovin player.

The activity now correctly shows when a user is watching an anime. I also verified that the other pages continue to work as expected. :)

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="208" height="92" alt="Captura de pantalla 2026-07-13 081913" src="https://github.com/user-attachments/assets/f8083126-aa4b-4783-aa0a-74c6f36d71bb" />
<img width="209" height="83" alt="Captura de pantalla 2026-07-13 081852" src="https://github.com/user-attachments/assets/3b84ecaa-b3b7-4b23-8c2c-cdfc80855d28" />
<img width="211" height="89" alt="Captura de pantalla 2026-07-13 081833" src="https://github.com/user-attachments/assets/098b8a85-a6a4-4732-88b4-033391c42c34" />



</details>
