### PR TITLE
fix(Otakudesu): update domain

### DIFF
--- a/websites/O/Otakudesu/metadata.json
+++ b/websites/O/Otakudesu/metadata.json
@@ -11,9 +11,9 @@
     "id": "Download, nonton dan streaming anime subtitle Indonesia dengan resolusi 240p, 360p, 480p, & 720p dengan format MP4 & MKV bersama dengan batchnya",
     "nl": "Download, bekijk en stream anime met Indonesische ondertiteling en met 240p, 360p, 480p en 720p resolutie met MP4-formaat en MKV samen met de batch."
   },
-  "url": "otakudesu.best",
-  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*otakudesu[.]best[/]",
-  "version": "2.1.1",
+  "url": "otakudesu.blog",
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*otakudesu[.]blog[/]",
+  "version": "2.1.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/O/Otakudesu/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/O/Otakudesu/assets/thumbnail.png",
   "color": "#ffffff",


### PR DESCRIPTION
close #10364

## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
This PR fixes #10364.

It looks like the domain was changed to `.best` in the past, as mentioned by the user. However, the website now appears to have moved to the `.blog` domain, since visiting the `.best` URL redirects there.

I also verified that the rest of the site's sections are still displayed correctly in the activity.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="960" height="600" alt="Captura de pantalla 2026-07-13 161226" src="https://github.com/user-attachments/assets/ef88a637-6c8f-4d8a-863d-c949f030e5e5" />
<img width="210" height="85" alt="Captura de pantalla 2026-07-13 161154" src="https://github.com/user-attachments/assets/3fab0392-8a42-46c4-a5db-f2424c4811c6" />
<img width="209" height="93" alt="Captura de pantalla 2026-07-13 161143" src="https://github.com/user-attachments/assets/d870747c-cd8b-406d-adf5-f43f54f3ad42" />



</details>
