### PR TITLE
feat(ChillBox): add activity

### DIFF
--- a/websites/C/ChillBox/metadata.json
+++ b/websites/C/ChillBox/metadata.json
@@ -13,7 +13,7 @@
   "url": "chillbox.cc",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*chillbox[.]cc[/]",
   "version": "1.0.0",
-  "logo": "https://chillbox.cc/apple-touch-icon.png",
+  "logo": "https://chillbox.cc/premid/logo-512.png",
   "thumbnail": "https://chillbox.cc/og-image.png",
   "color": "#facc15",
   "category": "games",

--- a/websites/C/ChillBox/metadata.json
+++ b/websites/C/ChillBox/metadata.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "name": "uzipayx",
+    "id": "327216187199062027"
+  },
+  "service": "ChillBox",
+  "description": {
+    "en": "ChillBox — free multiplayer mini-games in the browser: Croco, Corridor, Checkers, Beachball, Bomberman. Shows the game you play, score and match timer.",
+    "ru": "ChillBox — бесплатные мультиплеерные мини-игры в браузере: Крокодил, Коридор, Шашки, Бичбол, Бомбермен. Показывает игру, счёт и таймер матча."
+  },
+  "url": "chillbox.cc",
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*chillbox[.]cc[/]",
+  "version": "1.0.0",
+  "logo": "https://chillbox.cc/apple-touch-icon.png",
+  "thumbnail": "https://chillbox.cc/og-image.png",
+  "color": "#facc15",
+  "category": "games",
+  "tags": [
+    "games",
+    "multiplayer",
+    "browser-games"
+  ]
+}

--- a/websites/C/ChillBox/presence.ts
+++ b/websites/C/ChillBox/presence.ts
@@ -1,5 +1,5 @@
 enum ActivityAssets {
-  Logo = 'https://chillbox.cc/apple-touch-icon.png',
+  Logo = 'https://chillbox.cc/premid/logo-512.png',
 }
 
 const presence = new Presence({
@@ -75,20 +75,24 @@ presence.on('UpdateData', async () => {
     presenceData.state = `${cb.players}/${cb.maxPlayers}`
   if (cb.matchStartTs)
     presenceData.startTimestamp = Math.floor(cb.matchStartTs / 1000)
-  const buttons: [ButtonData, ...ButtonData[]] = [
-    {
-      label: s.play,
-      url: cb.gameId ? `https://chillbox.cc/g/${cb.gameId}` : 'https://chillbox.cc/',
-    },
-  ]
+  const playButton: ButtonData = {
+    label: s.play,
+    url: cb.gameId ? `https://chillbox.cc/g/${cb.gameId}` : 'https://chillbox.cc/',
+  }
   // Watch button ONLY when the user themselves is on /watch: since they are watching
   // via this link, the room is watchable; we never expose other people's rooms.
   if (cb.page === 'watch' && cb.gameId && cb.roomId) {
-    buttons.push({
-      label: s.watchBtn,
-      url: `https://chillbox.cc/g/${cb.gameId}/watch/${cb.roomId}`,
-    })
+    presenceData.buttons = [
+      playButton,
+      {
+        label: s.watchBtn,
+        url: `https://chillbox.cc/g/${cb.gameId}/watch/${cb.roomId}`,
+      },
+    ]
   }
-  presenceData.buttons = buttons
+  else {
+    presenceData.buttons = [playButton]
+  }
+  presenceData.setActivity
   presence.setActivity(presenceData)
 })

--- a/websites/C/ChillBox/presence.ts
+++ b/websites/C/ChillBox/presence.ts
@@ -93,6 +93,5 @@ presence.on('UpdateData', async () => {
   else {
     presenceData.buttons = [playButton]
   }
-  presenceData.setActivity
   presence.setActivity(presenceData)
 })

--- a/websites/C/ChillBox/presence.ts
+++ b/websites/C/ChillBox/presence.ts
@@ -1,0 +1,94 @@
+enum ActivityAssets {
+  Logo = 'https://chillbox.cc/apple-touch-icon.png',
+}
+
+const presence = new Presence({
+  clientId: '1524175002168066089',
+})
+
+interface CbPresence {
+  v: 1
+  page: 'home' | 'hub' | 'lobby' | 'match' | 'watch' | 'local' | 'other'
+  gameId: string | null
+  gameName: { ru: string, en: string } | null
+  roomId: string | null
+  phase: string | null
+  players: number | null
+  maxPlayers: number | null
+  matchStartTs: number | null
+  details: string | null
+}
+
+const STR = {
+  ru: {
+    home: 'В меню',
+    hub: 'Выбирает комнату',
+    lobby: 'В лобби',
+    match: 'В игре',
+    watch: 'Смотрит матч',
+    local: 'Играет локально',
+    other: 'На сайте',
+    play: 'Играть на ChillBox',
+    watchBtn: 'Смотреть матч',
+  },
+  en: {
+    home: 'In the menu',
+    hub: 'Browsing rooms',
+    lobby: 'In a lobby',
+    match: 'Playing',
+    watch: 'Watching a match',
+    local: 'Playing locally',
+    other: 'On the site',
+    play: 'Play on ChillBox',
+    watchBtn: 'Watch match',
+  },
+}
+
+// The site publishes live presence data into a DOM tag (kept in sync by the app itself).
+function readTag(): CbPresence | null {
+  try {
+    const el = document.getElementById('chillbox-presence')
+    return el?.textContent ? (JSON.parse(el.textContent) as CbPresence) : null
+  }
+  catch {
+    return null
+  }
+}
+
+presence.on('UpdateData', async () => {
+  const lang = document.documentElement.lang === 'en' ? 'en' : 'ru'
+  const s = STR[lang]
+  const cb = readTag()
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+  }
+  if (!cb || cb.page === 'other' || cb.page === 'home') {
+    presenceData.details = s.home
+    presence.setActivity(presenceData)
+    return
+  }
+  const game = cb.gameName ? cb.gameName[lang] : null
+  presenceData.details = game ? `${s[cb.page]}: ${game}` : s[cb.page]
+  if (cb.details)
+    presenceData.state = cb.details
+  else if (cb.page === 'lobby' && cb.players != null && cb.maxPlayers != null)
+    presenceData.state = `${cb.players}/${cb.maxPlayers}`
+  if (cb.matchStartTs)
+    presenceData.startTimestamp = Math.floor(cb.matchStartTs / 1000)
+  const buttons: [ButtonData, ...ButtonData[]] = [
+    {
+      label: s.play,
+      url: cb.gameId ? `https://chillbox.cc/g/${cb.gameId}` : 'https://chillbox.cc/',
+    },
+  ]
+  // Watch button ONLY when the user themselves is on /watch: since they are watching
+  // via this link, the room is watchable; we never expose other people's rooms.
+  if (cb.page === 'watch' && cb.gameId && cb.roomId) {
+    buttons.push({
+      label: s.watchBtn,
+      url: `https://chillbox.cc/g/${cb.gameId}/watch/${cb.roomId}`,
+    })
+  }
+  presenceData.buttons = buttons
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description

New activity for **ChillBox** (https://chillbox.cc) — free multiplayer mini-games in the browser: Croco (drawing & guessing), Corridor (Quoridor), Checkers, Beachball volleyball and Bomberman. RU/EN interface.

I am the developer of the site. The site publishes live presence data (current game, page kind, lobby player count, match score/timer) into a dedicated JSON DOM tag `#chillbox-presence` specifically for this activity — the presence reads one stable tag instead of scraping the DOM, so it won't break on UI changes. The payload is versioned (`v: 1`).

What the activity shows:
- menu / browsing rooms / lobby (with player count) / playing / watching / playing locally
- game name localized (RU/EN, follows the site language)
- match elapsed time via `startTimestamp`, live score in `state`
- buttons: "Play on ChillBox" (game hub) and, only when the user is on a public watch page themselves, "Watch match" (never exposes other people's rooms)

Logo/thumbnail are currently hosted on the site's own domain — happy to re-upload wherever the review process requires.