### PR TITLE
feat(404Anime): add activity

### DIFF
--- a/websites/0-9/404Anime/metadata.json
+++ b/websites/0-9/404Anime/metadata.json
@@ -1,0 +1,23 @@
+{
+  "apiVersion": 1,
+  "author": {
+    "name": "error.4.04",
+    "id": "692495122025152583"
+  },
+  "service": "404Anime",
+  "description": {
+    "en": "Anime streaming watch activity for 404Anime."
+  },
+  "url": "404anime.ca",
+  "regExp": "^https?[:][/][/]404anime[.]ca[/]",
+  "version": "1.0.0",
+  "logo": "https://404anime.ca/logo.png",
+  "thumbnail": "https://404anime.ca/og-image.png",
+  "color": "#facc15",
+  "category": "anime",
+  "tags": [
+    "anime",
+    "video",
+    "streaming"
+  ]
+}

--- a/websites/0-9/404Anime/metadata.json
+++ b/websites/0-9/404Anime/metadata.json
@@ -7,7 +7,7 @@
   },
   "service": "404Anime",
   "description": {
-    "en": "Anime streaming watch activity for 404Anime."
+    "en": "404Anime is a free, ad-free anime streaming website where you can watch subbed and dubbed anime online."
   },
   "url": "404anime.ca",
   "regExp": "^https?[:][/][/]404anime[.]ca[/]",

--- a/websites/0-9/404Anime/metadata.json
+++ b/websites/0-9/404Anime/metadata.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://schemas.premid.app/metadata/1.17",
   "apiVersion": 1,
   "author": {
     "name": "error.4.04",

--- a/websites/0-9/404Anime/presence.ts
+++ b/websites/0-9/404Anime/presence.ts
@@ -1,0 +1,224 @@
+import { ActivityType, Assets, getTimestamps, supports } from 'premid'
+
+const presence = new Presence({
+  clientId: '503557087041683458',
+})
+
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://404anime.ca/logo.png',
+}
+
+interface Anime404PremidPresence {
+  page?: string
+  mediaType?: 'anime' | 'movie' | 'tv'
+  animeId?: number
+  animeTitle?: string
+  episode?: number
+  season?: number
+  episodeTitle?: string | null
+  audio?: 'sub' | 'dub'
+  server?: string
+  cover?: string | null
+  url?: string
+  currentTime?: number
+  duration?: number
+  paused?: boolean
+}
+
+function truncate(value: string, max = 128): string {
+  return value.length > max ? `${value.slice(0, max - 1)}...` : value
+}
+
+function getVideoFallback(): Pick<
+  Anime404PremidPresence,
+  'currentTime' | 'duration' | 'paused'
+> {
+  const video = document.querySelector<HTMLVideoElement>('video')
+
+  if (!video) {
+    return {
+      currentTime: 0,
+      duration: 0,
+      paused: true,
+    }
+  }
+
+  return {
+    currentTime: Number.isFinite(video.currentTime) ? video.currentTime : 0,
+    duration: Number.isFinite(video.duration) ? video.duration : 0,
+    paused: video.paused,
+  }
+}
+
+async function getBridgeData(): Promise<Anime404PremidPresence | null> {
+  if (supports(presence, 'execInPage')) {
+    try {
+      const data = await presence.execInPage<Anime404PremidPresence | null>({
+        get: '__SANIME_PREMID__',
+      })
+
+      if (data?.animeTitle || data?.episode)
+        return data
+    }
+    catch {
+      // Fall back to the older variable reader below.
+    }
+  }
+
+  try {
+    const page = await presence.getPageVariable<{
+      __SANIME_PREMID__?: Anime404PremidPresence | null
+    }>('__SANIME_PREMID__')
+
+    return page.__SANIME_PREMID__ ?? null
+  }
+  catch {
+    return null
+  }
+}
+
+function applyPlayback(
+  presenceData: PresenceData,
+  currentTime = 0,
+  duration = 0,
+  paused = true,
+): void {
+  if (paused) {
+    presenceData.smallImageKey = Assets.Pause
+    presenceData.smallImageText = 'Paused'
+    delete presenceData.startTimestamp
+    delete presenceData.endTimestamp
+    return
+  }
+
+  presenceData.smallImageKey = Assets.Play
+  presenceData.smallImageText = 'Playing'
+
+  if (duration > 0) {
+    [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestamps(
+      currentTime,
+      duration,
+    )
+  }
+  else {
+    presenceData.startTimestamp = Date.now() - currentTime * 1000
+    delete presenceData.endTimestamp
+  }
+}
+
+function getBrowsingState(pathname: string): string {
+  if (pathname === '/welcome')
+    return 'Getting started'
+
+  if (pathname === '/' || pathname === '/index.html')
+    return 'Browsing anime'
+
+  if (pathname.startsWith('/search'))
+    return 'Searching anime'
+
+  if (pathname.startsWith('/latest'))
+    return 'Browsing latest releases'
+
+  if (pathname.startsWith('/schedule'))
+    return 'Checking the schedule'
+
+  if (pathname.startsWith('/seasons'))
+    return 'Browsing seasons'
+
+  if (pathname.startsWith('/movies'))
+    return 'Browsing movies and shows'
+
+  if (pathname.startsWith('/watchlist'))
+    return 'Viewing watchlist'
+
+  if (pathname.startsWith('/history'))
+    return 'Viewing watch history'
+
+  if (pathname.startsWith('/profile'))
+    return 'Viewing profile'
+
+  if (pathname.startsWith('/login') || pathname.startsWith('/auth'))
+    return 'Signing in'
+
+  if (pathname.startsWith('/privacy'))
+    return 'Reading privacy policy'
+
+  if (pathname.startsWith('/anime/'))
+    return 'Viewing anime details'
+
+  if (pathname.startsWith('/movie/'))
+    return 'Viewing movie details'
+
+  if (pathname.startsWith('/tv/'))
+    return 'Viewing show details'
+
+  if (pathname.startsWith('/studio/'))
+    return 'Viewing studio details'
+
+  if (pathname.startsWith('/person/'))
+    return 'Viewing staff details'
+
+  return 'Exploring 404Anime'
+}
+
+presence.on('UpdateData', async () => {
+  const bridge = await getBridgeData()
+  const fallback = getVideoFallback()
+  const data = {
+    ...fallback,
+    ...bridge,
+  }
+
+  const isWatchPage = document.location.pathname.includes('/watch/')
+  const isMovieWatchPage = /^\/(?:movie|tv)\//.test(document.location.pathname)
+  const title = data.animeTitle || document.title.replace(/\s*[-|].*$/, '')
+  const episodeLabel = data.episode
+    ? data.season
+      ? `S${data.season}E${data.episode}`
+      : `Episode ${data.episode}`
+    : null
+
+  const presenceData: PresenceData = {
+    name: '404Anime',
+    type: ActivityType.Watching,
+    largeImageKey: data.cover || ActivityAssets.Logo,
+    largeImageText: data.episode
+      ? `Season 1, Episode ${data.episode}`
+      : '404Anime',
+  }
+
+  if ((isWatchPage || isMovieWatchPage) && title) {
+    presenceData.details = truncate(
+      episodeLabel ? `${title} - ${episodeLabel}` : title,
+    )
+    presenceData.state = truncate(
+      [
+        data.mediaType === 'movie'
+          ? 'Movie'
+          : data.mediaType === 'tv'
+            ? data.episodeTitle || 'TV Episode'
+            : data.audio ? data.audio.toUpperCase() : null,
+      ]
+        .filter(Boolean)
+        .join(' - '),
+    )
+
+    applyPlayback(
+      presenceData,
+      data.currentTime,
+      data.duration,
+      data.paused,
+    )
+  }
+  else {
+    presenceData.details = '404Anime'
+    presenceData.state = getBrowsingState(document.location.pathname)
+    presenceData.startTimestamp = browsingTimestamp
+    presenceData.smallImageKey = Assets.Search
+    presenceData.smallImageText = 'Browsing'
+  }
+
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description
Adds a 404Anime activity with browsing states for app pages and watching states for anime, movie, and TV playback. Playback pages show title, episode/season when available, poster art, play/pause state, and Discord native timestamps.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npx eslint "websites/0-9/404Anime" --cache`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Validation
- `npx pmd build "404Anime" --validate`
- `npx eslint "websites/0-9/404Anime" --cache`

## Screenshots
<details>
<summary>Proof showing the creation/modification is working as expected</summary>

Tested locally with the PreMiD extension showing 404Anime watch activity in Discord.
<img width="286" height="120" alt="image" src="https://github.com/user-attachments/assets/db3f63c2-5e74-4598-be94-f79c4f8901d3" />
<img width="300" height="135" alt="image" src="https://github.com/user-attachments/assets/7fe551a9-89c2-4ed4-a373-c5d34bf808f0" />

</details>
