### PR TITLE
feat(AnimeX): add status and sub display options

### DIFF
--- a/websites/A/AnimeX/metadata.json
+++ b/websites/A/AnimeX/metadata.json
@@ -11,7 +11,7 @@
   },
   "url": "animex.one",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*animex[.]one[/]",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeX/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeX/assets/thumbnail.png",
   "color": "#E63946",
@@ -26,6 +26,22 @@
       "title": "Show Timestamp",
       "icon": "fa-solid fa-clock",
       "value": true
+    },
+    {
+      "id": "displayType",
+      "title": "Pick status display",
+      "icon": "fad fa-user-edit",
+      "value": 0,
+      "values": [
+        "Activity Name",
+        "Anime Name"
+      ]
+    },
+    {
+      "id": "hideSubType",
+      "title": "Hide Sub option",
+      "icon": "fad fa-subtitles-slash",
+      "value": false
     }
   ]
 }

--- a/websites/A/AnimeX/presence.ts
+++ b/websites/A/AnimeX/presence.ts
@@ -1,4 +1,4 @@
-import { ActivityType, Assets, getTimestamps } from 'premid'
+import { ActivityType, Assets, getTimestamps, StatusDisplayType } from 'premid'
 
 const presence = new Presence({ clientId: '1508462512339943425' })
 
@@ -61,10 +61,12 @@ function getGenres(): string {
 presence.on(
   'UpdateData',
   async () => {
-    const [showButtons, showTimestamp] = await Promise.all(
+    const [showButtons, showTimestamp, displayType, hideSubType] = await Promise.all(
       [
         presence.getSetting<boolean>('showButtons').catch(() => true),
         presence.getSetting<boolean>('showTimestamp').catch(() => true),
+        presence.getSetting<number>('displayType'),
+        presence.getSetting<boolean>('hideSubType'),
       ],
     )
 
@@ -104,8 +106,7 @@ presence.on(
           : animeTitle
 
       presenceData.details = animeTitle
-      presenceData.state = `${episodeNum !== null ? `Episode ${episodeNum}` : 'Unknown Episode'}${subDub ? ` \u00B7 ${subDub}` : ''}`
-
+      presenceData.state = `${episodeNum !== null ? `Episode ${episodeNum}` : 'Unknown Episode'}${!hideSubType && subDub ? ` \u00B7 ${subDub}` : ''}`
       if (video) {
         const paused = video.paused
         presenceData.smallImageKey = paused ? Assets.Pause : Assets.Play
@@ -247,6 +248,17 @@ presence.on(
       }
       delete presenceData.endTimestamp
       delete presenceData.buttons
+    }
+
+    switch (displayType) {
+      case 0:
+        presenceData.statusDisplayType = StatusDisplayType.Name
+        break
+      case 1:
+        presenceData.statusDisplayType = pathname.startsWith('/watch')
+          ? StatusDisplayType.Details
+          : StatusDisplayType.Name
+        break
     }
 
     presence.setActivity(presenceData)


### PR DESCRIPTION
close #11002

## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
This PR adds two new features to the AnimeX activity, as suggested in issue #11002:
1. Adds a new **"Pick status display"** option, allowing users to choose between displaying the activity name or the anime title currently being played.
2. Adds a new **"Hide Sub type"** option, allowing users to choose whether to display or hide the selected sub/dub type.

Additionally, the version has been bumped to `2.0.0` to follow the repository's versioning scheme:

`<NEW-FEATURE>.<HUGE-BUGFIX>.<SMALL-BUGFIX-OR-METADATA-CHANGES>`

Since this PR introduces new user-facing features, the **NEW-FEATURE** version number has been incremented.


## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="296" height="139" alt="Captura de pantalla 2026-07-14 213416" src="https://github.com/user-attachments/assets/bebf2930-af76-49ec-8958-f3b23397153f" />
<img width="311" height="452" alt="Captura de pantalla 2026-07-14 213406" src="https://github.com/user-attachments/assets/9f209885-704b-4656-bed7-79b99f235f56" />
<img width="320" height="145" alt="Captura de pantalla 2026-07-14 213232" src="https://github.com/user-attachments/assets/4b660d24-f712-4031-8819-bc10e1152f4b" />
<img width="195" height="35" alt="Captura de pantalla 2026-07-14 213201" src="https://github.com/user-attachments/assets/273e6af6-72ff-4c4f-9b72-3f6aeabe0ebb" />



</details>
