### PR TITLE
feat(Pinterest): add privacy mode

### DIFF
--- a/websites/P/Pinterest/metadata.json
+++ b/websites/P/Pinterest/metadata.json
@@ -19,7 +19,7 @@
   },
   "url": "www.pinterest.com",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*pinterest([.][a-z]+)+[/]",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/P/Pinterest/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/P/Pinterest/assets/thumbnail.jpg",
   "color": "#cc2127",
@@ -29,6 +29,12 @@
     "imageboard"
   ],
   "settings": [
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "icon": "fad fa-user-secret",
+      "value": false
+    },
     {
       "id": "buttons",
       "title": "Show Buttons",

--- a/websites/P/Pinterest/presence.ts
+++ b/websites/P/Pinterest/presence.ts
@@ -18,7 +18,10 @@ presence.on('UpdateData', async () => {
   }
   const { pathname, hostname, href } = document.location
   const pathList = pathname.split('/').filter(Boolean)
-  const buttons = await presence.getSetting<boolean>('buttons')
+  const [privacy, buttons] = await Promise.all([
+    presence.getSetting<boolean>('privacy'),
+    presence.getSetting<boolean>('buttons'),
+  ])
   const ideasHubPage = document.querySelector('[data-test-id="ideas-hub-page-header"]')
     || document.querySelector('[data-test-id="control-ideas-redesign-header"]')
   const search = document.querySelector<HTMLInputElement>(
@@ -151,8 +154,32 @@ presence.on('UpdateData', async () => {
     }
   }
 
-  if (!buttons && presenceData.buttons)
+  if (privacy) {
+    switch (true) {
+      case !!search?.value:
+        presenceData.details = 'Searching Pinterest'
+        break
+      case !!document.querySelector('[data-test-id="profile-name"]'):
+        presenceData.details = 'Viewing a profile'
+        break
+      case pathname.includes('/pin/'):
+        presenceData.details = video ? 'Viewing a video pin' : 'Viewing a pin'
+        break
+      case pathname.includes('/ideas/'):
+        presenceData.details = 'Browsing through ideas'
+        break
+    }
+
+    presenceData.startTimestamp = browsingTimestamp
+    delete presenceData.state
     delete presenceData.buttons
+    delete presenceData.endTimestamp
+    delete presenceData.smallImageKey
+    delete presenceData.smallImageText
+  }
+  else if (!buttons && presenceData.buttons) {
+    delete presenceData.buttons
+  }
   if (presenceData.details)
     presence.setActivity(presenceData)
 })


### PR DESCRIPTION
## Description

Adds an optional Privacy Mode setting to Pinterest. When enabled, the activity keeps generic page context while hiding search queries, profile identities, pin titles, creator names, reaction counts, playback progress, and direct buttons.

Privacy Mode is disabled by default, so existing behavior stays unchanged.

Closes #11011

## Acknowledgements

- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Validation

- Ran `npm run lint`
- Ran `pmd build Pinterest --validate`
- Loaded the activity through `pmd dev Pinterest` with zero compilation errors
- Verified normal and private pin presence in Discord

## Screenshots

<details>
<summary>Proof showing the modification working as expected</summary>

### Activity setting

<img width="405" height="508" alt="Pinterest activity settings with Privacy Mode" src="https://github.com/user-attachments/assets/9dfe341b-20ae-48f0-a013-0adc02018de0" />

### Privacy Mode enabled

<img width="252" height="102" alt="Pinterest presence with creator hidden" src="https://github.com/user-attachments/assets/ec5e638d-1202-4cab-8ee9-cb6a18d6eaf2" />

### Privacy Mode disabled

<img width="284" height="124" alt="Pinterest presence showing the pin creator" src="https://github.com/user-attachments/assets/82744699-6a3d-4c4d-be89-d1d4efbe3915" />

</details>