### PR TITLE
fix(TradingView): restore chart details

### DIFF
--- a/websites/T/TradingView/metadata.json
+++ b/websites/T/TradingView/metadata.json
@@ -17,7 +17,7 @@
     "status.tradingview.com"
   ],
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*tradingview[.]com[/]",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/T/TradingView/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/T/TradingView/assets/thumbnail.png",
   "color": "#2196f3",

--- a/websites/T/TradingView/presence.ts
+++ b/websites/T/TradingView/presence.ts
@@ -136,44 +136,31 @@ presence.on('UpdateData', async () => {
   else if (window.location.pathname.startsWith('/chart')) {
     presenceData.details = 'Viewing Chart...'
 
-    // Full Interactive Chart - primary selector
-    const primaryTitle = document
+    const tickerTitle = document
+      .querySelector('[data-qa-id="details-element symbol"]')
+      ?.textContent
+      ?.trim()
+    const detailsTitle = document
+      .querySelector('[data-qa-id="details-element description"]')
+      ?.textContent
+      ?.trim()
+    const legendTitle = document
+      .querySelector('[data-qa-id="title-wrapper legend-source-title"] button')
+      ?.textContent
+      ?.trim()
+    const popupIdeaTitle = document
       .querySelector(
-        'body > div.js-rootresizer__contents > div > div.layout__area--right > div > div.widgetbar-pages > div.widgetbar-pagescontent > div.widgetbar-page.active > div.widget-X9EuSe_t.widgetbar-widget.widgetbar-widget-detail > div.widgetbar-widgetbody > div > div.wrapper-Tv7LSjUz > div:nth-child(1) > div:nth-child(1) > span > a > span.text-eFCYpbUa',
+        '#overlap-manager-root > div > div.tv-dialog__modal-wrap > div > div > div > div:nth-child(1) > div > div > div > div:nth-child(1) > div.tv-chart-view__header > div.tv-chart-view__title.selectable > div > div.tv-chart-view__title-row.tv-chart-view__title-row--symbol.tv-chart-view__symbol.js-chart-view__symbol.js-chart-view__ticker.quote-ticker-inited > a:nth-child(1)',
       )
       ?.textContent
       ?.trim()
-
-    let title = primaryTitle
-    let tickerTitle: string | undefined
-
-    // Only get tickerTitle if primary selector found a title
-    if (primaryTitle) {
-      tickerTitle = document
-        .querySelector(
-          'body > div.js-rootresizer__contents > div > div.layout__area--right > div > div.widgetbar-pages > div.widgetbar-pagescontent > div.widgetbar-page.active > div.widget-X9EuSe_t.widgetbar-widget.widgetbar-widget-detail > div.widgetHeader-X9EuSe_t > div > span.title-ZJX9Rmzv',
-        )
-        ?.textContent
-        ?.trim()
-    }
-    else {
-      // Fallback to other selectors that don't have ticker
-      title
-        // Popup Chart Idea
-        = document
-          .querySelector(
-            '#overlap-manager-root > div > div.tv-dialog__modal-wrap > div > div > div > div:nth-child(1) > div > div > div > div:nth-child(1) > div.tv-chart-view__header > div.tv-chart-view__title.selectable > div > div.tv-chart-view__title-row.tv-chart-view__title-row--symbol.tv-chart-view__symbol.js-chart-view__symbol.js-chart-view__ticker.quote-ticker-inited > a:nth-child(1)',
-          )
-          ?.textContent
-          ?.trim()
-        // Full Chart Idea Page
-          || document
-            .querySelector(
-              'body > div.tv-main > div.tv-content > div > div > div:nth-child(1) > div.tv-chart-view__header > div.tv-chart-view__title.selectable > div > div.tv-chart-view__title-row.tv-chart-view__title-row--symbol.tv-chart-view__symbol.js-chart-view__symbol.js-chart-view__ticker.quote-ticker-inited > a:nth-child(1)',
-            )
-            ?.textContent
-            ?.trim()
-    }
+    const fullIdeaTitle = document
+      .querySelector(
+        'body > div.tv-main > div.tv-content > div > div > div:nth-child(1) > div.tv-chart-view__header > div.tv-chart-view__title.selectable > div > div.tv-chart-view__title-row.tv-chart-view__title-row--symbol.tv-chart-view__symbol.js-chart-view__symbol.js-chart-view__ticker.quote-ticker-inited > a:nth-child(1)',
+      )
+      ?.textContent
+      ?.trim()
+    const title = detailsTitle || legendTitle || popupIdeaTitle || fullIdeaTitle
 
     if (title)
       presenceData.state = tickerTitle ? `${tickerTitle} • ${title}` : title // e.g. "AAPL • Apple Inc."


### PR DESCRIPTION
## Description

Fixes full-chart presences that only showed `Viewing Chart...` without the selected symbol details.

The previous implementation depended on long selectors containing TradingView generated class names such as `widget-X9EuSe_t`, `wrapper-Tv7LSjUz`, and `text-eFCYpbUa`. TradingView regenerated those classes, so both the company-name and ticker lookups started returning `null`. This is the same failure mode that required the earlier selector update in #10017.

This change replaces those generated-class selectors with TradingView stable `data-qa-id` hooks:

- `details-element symbol` for the ticker
- `details-element description` for the company/index name
- `title-wrapper legend-source-title` as a fallback when the details sidebar is closed

The change is larger than replacing one class hash because another generated-class replacement would break on a future frontend build. The fallback chain also preserves the existing popup-chart and full-idea-page selectors, so those routes retain their previous behavior.

Closes #10999

## Reproduction and validation

Tested on `https://www.tradingview.com/chart/?symbol=NASDAQ%3AAAPL`:

1. With the details sidebar open, the old title and ticker selectors both returned `null`.
2. On the same page, the new selectors returned `AAPL` and `Apple Inc`, producing `AAPL • Apple Inc`.
3. Closed **Watchlist, details, and news** to remove the details sidebar. The details selectors then returned `null`, while the chart-legend fallback returned `Apple Inc`, so the presence still has a useful title.
4. Reopened the sidebar and confirmed the ticker and description selectors resolved again.
5. Loaded the activity through `pmd dev TradingView` and verified `IBOV • Índice Bovespa` in Discord.
6. Ran `npm run lint`.
7. Ran `pmd build TradingView --validate`.

## Acknowledgements

- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots

<details>
<summary>Proof showing the modification working as expected</summary>

<img width="246" height="118" alt="TradingView presence showing IBOV and Índice Bovespa" src="https://github.com/user-attachments/assets/67e732e1-8762-418d-a515-6b331533aaff" />

</details>