### PR TITLE
feat(Department of Justice): add activity

### DIFF
--- a/websites/D/Department of Justice/metadata.json
+++ b/websites/D/Department of Justice/metadata.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.17",
+  "apiVersion": 1,
+  "author": {
+    "id": "752175229924802701",
+    "name": "dddaviii"
+  },
+  "service": "Department of Justice",
+  "description": {
+    "en": "The United States Department of Justice enforces federal law, ensures public safety, and provides access to news, legal documents, and public resources."
+  },
+  "url": "justice.gov",
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*justice[.]gov[/]",
+  "version": "1.0.0",
+  "logo": "https://images.weserv.nl/?url=www.justice.gov%2Fd9%2Fstyles%2Fcoh_medium%2Fpublic%2F2025-03%2Fdoj-seal-257x257.png%3Fitok%3DqL5GWp29&w=512&h=512&fit=contain&output=png&filename=logo.png",
+  "thumbnail": "https://www.justice.gov/themes/custom/usdoj_uswds/images/metatag-image--default.png",
+  "color": "#162E51",
+  "category": "other",
+  "tags": [
+    "government",
+    "law",
+    "legal",
+    "news"
+  ],
+  "settings": [
+    {
+      "id": "privacyMode",
+      "title": "Privacy Mode",
+      "icon": "fad fa-user-secret",
+      "value": false
+    },
+    {
+      "id": "showButtons",
+      "title": "Show Buttons",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "privacyMode": false
+      }
+    }
+  ]
+}

--- a/websites/D/Department of Justice/presence.ts
+++ b/websites/D/Department of Justice/presence.ts
@@ -1,0 +1,110 @@
+import { Assets } from 'premid'
+
+const presence = new Presence({
+  clientId: '503557087041683458',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://images.weserv.nl/?url=www.justice.gov%2Fd9%2Fstyles%2Fcoh_medium%2Fpublic%2F2025-03%2Fdoj-seal-257x257.png%3Fitok%3DqL5GWp29&w=512&h=512&fit=contain&output=png&filename=logo.png',
+}
+
+function getPageTitle(): string {
+  const heading = document.querySelector('main h1')?.textContent?.trim()
+  const openGraphTitle = document.querySelector<HTMLMetaElement>('meta[property="og:title"]')?.content.trim()
+  const documentTitle = document.title
+    .split('|')
+    .map(part => part.trim())
+    .find(part => part && part !== 'United States Department of Justice')
+
+  const title = heading || openGraphTitle || documentTitle || ''
+  return title.length > 128 ? `${title.slice(0, 125)}...` : title
+}
+
+presence.on('UpdateData', async () => {
+  const { pathname, href, search } = document.location
+  const [privacyMode, showButtons] = await Promise.all([
+    presence.getSetting<boolean>('privacyMode'),
+    presence.getSetting<boolean>('showButtons'),
+  ])
+  const pageTitle = getPageTitle()
+  const presenceData: PresenceData = {
+    name: 'Department of Justice',
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+    smallImageKey: Assets.Viewing,
+  }
+
+  let buttonLabel = 'View Page'
+
+  if (pathname === '/') {
+    presenceData.details = 'Viewing the homepage'
+  }
+  else if (pathname.startsWith('/search')) {
+    const query = new URLSearchParams(search).get('search_api_fulltext')?.trim()
+    presenceData.details = 'Searching the website'
+    presenceData.state = query ? `Searching for: ${query}` : 'Viewing search results'
+    presenceData.smallImageKey = Assets.Search
+    buttonLabel = 'View Search Results'
+  }
+  else if (pathname.toLowerCase().endsWith('.pdf')) {
+    const fileName = decodeURIComponent(pathname.split('/').pop() || '')
+    presenceData.details = 'Viewing a document'
+    presenceData.state = fileName || 'Department document'
+    presenceData.smallImageKey = Assets.Reading
+    buttonLabel = 'View Document'
+  }
+  else if (/\/pr\//.test(pathname)) {
+    presenceData.details = 'Reading a press release'
+    presenceData.state = pageTitle
+    presenceData.smallImageKey = Assets.Reading
+    buttonLabel = 'Read Press Release'
+  }
+  else if (/\/speech\//.test(pathname)) {
+    presenceData.details = 'Reading a speech'
+    presenceData.state = pageTitle
+    presenceData.smallImageKey = Assets.Reading
+    buttonLabel = 'Read Speech'
+  }
+  else if (/\/video\//.test(pathname)) {
+    presenceData.details = 'Watching a video'
+    presenceData.state = pageTitle
+    buttonLabel = 'Watch Video'
+  }
+  else if (/\/(?:blog|podcast)\//.test(pathname)) {
+    presenceData.details = pathname.includes('/podcast/') ? 'Viewing a podcast' : 'Reading a blog post'
+    presenceData.state = pageTitle
+    presenceData.smallImageKey = Assets.Reading
+    buttonLabel = pathname.includes('/podcast/') ? 'View Podcast' : 'Read Blog Post'
+  }
+  else if (/\/(?:media|document)\//.test(pathname)) {
+    presenceData.details = 'Viewing a document'
+    presenceData.state = pageTitle || 'Department document'
+    presenceData.smallImageKey = Assets.Reading
+    buttonLabel = 'View Document'
+  }
+  else if (/(?:^|\/)news(?:\/|$)/.test(pathname)) {
+    presenceData.details = 'Browsing news'
+    presenceData.state = pageTitle
+  }
+  else if (/\/(?:select-)?(?:publications?|documents?)(?:\/|$)/.test(pathname) || /\/(?:foia|legal-policies)(?:\/|$)/.test(pathname)) {
+    presenceData.details = 'Browsing documents'
+    presenceData.state = pageTitle
+    presenceData.smallImageKey = Assets.Reading
+  }
+  else {
+    presenceData.details = 'Browsing the website'
+    presenceData.state = pageTitle
+  }
+
+  if (privacyMode) {
+    presenceData.details = 'Browsing the Department of Justice'
+    delete presenceData.state
+    delete presenceData.buttons
+  }
+  else if (showButtons && pathname !== '/') {
+    presenceData.buttons = [{ label: buttonLabel, url: href }]
+  }
+
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description

Adds a Department of Justice activity for `justice.gov`, closes #10295.

The activity shows useful context across the site instead of a single generic browsing status:

- page titles for press releases, speeches, videos, blog posts, office pages, and news listings
- document filenames for direct PDF URLs
- search terms on the DOJ search page
- optional current-page buttons
- a privacy mode that hides page-specific context and buttons

Direct PDFs are detected from the URL rather than the page DOM because browser PDF viewers do not expose the normal DOJ page structure. For example, `/files/DataSet%2011/EFTA02595115.pdf` displays `Viewing a document` and `EFTA02595115.pdf`.

## Acknowledgements

- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Validation

- `npm run lint` — currently stops on 578 existing `ts/no-deprecated` findings in other activities; no Department of Justice files are reported
- `npx eslint "websites/D/Department of Justice/presence.ts" "websites/D/Department of Justice/metadata.json"`
- `npx pmd build "Department of Justice" --validate`
- exercised 12 activity scenarios covering the homepage, search, direct PDFs, press releases, speeches, videos, blogs, media documents, news, publications, generic office pages, and privacy mode
- loaded the compiled activity into PreMiD 2.13.1 and tested it against the live website

## Screenshots

<details>
<summary>Proof showing the activity working on the live website</summary>

<!-- Screenshots attached below -->
<img width="574" height="914" alt="image" src="https://github.com/user-attachments/assets/00871ef9-d872-4df2-8315-a54f5769205c" />
<img width="582" height="788" alt="image" src="https://github.com/user-attachments/assets/f27c5bce-9247-44c7-bf5a-7a48e6725053" />
<img width="590" height="1056" alt="image" src="https://github.com/user-attachments/assets/246f61d4-924a-4cff-b226-fa701230f7a3" />

</details>
