### PR TITLE
fix(VK): add vk.ru domain support

### DIFF
--- a/websites/V/VK/metadata.json
+++ b/websites/V/VK/metadata.json
@@ -20,9 +20,12 @@
     "en": "VK is a Russian social media platform for messaging, sharing music and videos, and connecting with friends and communities.",
     "ru": "ВК это российская социальная платформа для общения, обмена музыкой и видео, а также связи с друзьями и сообществами."
   },
-  "url": "vk.com",
-  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*vk[.]com[/]",
-  "version": "2.5.1",
+  "url": [
+    "vk.com",
+    "vk.ru"
+  ],
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*(vk[.]com|vk[.]ru)[/]",
+  "version": "2.5.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/V/VK/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/V/VK/assets/thumbnail.png",
   "color": "#0077FF",


### PR DESCRIPTION
## Description
VK has migrated to `vk.ru` domain. This PR adds support for the new domain.

## Changes
- Added `vk.ru` to `url` array in metadata.json
- Updated `regExp` to match both `vk.com` and `vk.ru` domains

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)