### PR TITLE
fix(Peacock): resolve activity stuck on "Browsing..." during playback

### DIFF
--- a/websites/P/Peacock/metadata.json
+++ b/websites/P/Peacock/metadata.json
@@ -9,6 +9,10 @@
     {
       "name": "hash.king",
       "id": "608311692644057088"
+    },
+    {
+      "name": "not__bob",
+      "id": "1446263635268735151"
     }
   ],
   "service": "Peacock",
@@ -21,7 +25,7 @@
     "peacocktv.com"
   ],
   "regExp": "^https?[:][/][/](www[.])?peacocktv[.]com[/]",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/P/Peacock/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/P/Peacock/assets/thumbnail.png",
   "color": "#FCCC12",
@@ -30,5 +34,56 @@
     "video",
     "tv",
     "movies"
+  ],
+  "settings": [
+    {
+      "id": "lang",
+      "multiLanguage": true
+    },
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "icon": "fad fa-user-secret",
+      "value": false
+    },
+    {
+      "id": "usePresenceName",
+      "title": "Show Title as Presence",
+      "icon": "fad fa-user-edit",
+      "value": true,
+      "if": {
+        "privacy": false
+      }
+    },
+    {
+      "id": "showCover",
+      "title": "Show Cover Art",
+      "icon": "fas fa-images",
+      "value": true,
+      "if": {
+        "privacy": false
+      }
+    },
+    {
+      "id": "showBrowsingStatus",
+      "title": "Show Browsing Status",
+      "icon": "fad fa-book-reader",
+      "value": true
+    },
+    {
+      "id": "showTimestamps",
+      "title": "Show Timestamps",
+      "icon": "fad fa-stopwatch",
+      "value": true,
+      "if": {
+        "privacy": false
+      }
+    },
+    {
+      "id": "showSmallImage",
+      "title": "Show Play/Pause Icon",
+      "icon": "fad fa-pause",
+      "value": true
+    }
   ]
 }

--- a/websites/P/Peacock/metadata.json
+++ b/websites/P/Peacock/metadata.json
@@ -5,6 +5,12 @@
     "name": "Kedi",
     "id": "238668511222693888"
   },
+  "contributors": [
+    {
+      "name": "hash.king",
+      "id": "608311692644057088"
+    }
+  ],
   "service": "Peacock",
   "description": {
     "en": "Watch TV shows and movies online with Peacock. Stream iconic shows and movies, exclusive Peacock originals, live news and sports and more.",
@@ -15,7 +21,7 @@
     "peacocktv.com"
   ],
   "regExp": "^https?[:][/][/](www[.])?peacocktv[.]com[/]",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/P/Peacock/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/P/Peacock/assets/thumbnail.png",
   "color": "#FCCC12",

--- a/websites/P/Peacock/presence.ts
+++ b/websites/P/Peacock/presence.ts
@@ -7,19 +7,46 @@ const newStrings = presence.getStrings({
   play: 'general.playing',
   pause: 'general.paused',
   live: 'general.live',
+  browsing: 'general.browsing',
+  watchingVid: 'general.watchingVid',
 })
 const elapsed = Math.floor(Date.now() / 1000)
 
 let strings: Awaited<typeof newStrings>
 
+function getCoverKey(): string | undefined {
+  const heroImage = document.querySelector<HTMLImageElement>('[data-testid="immersive-image"]')
+  return heroImage?.srcset.split(',')[0]?.trim().split(' ')[0]
+}
+
+function findWatchingVideo(): HTMLVideoElement | null {
+  const video = document.querySelector<HTMLVideoElement>('#core-video-shaka')
+    || document.querySelector<HTMLVideoElement>('.video-player-component video')
+
+  // The detail page autoplays a muted preview clip in the background; that
+  // isn't the user deliberately watching something, so it doesn't count.
+  if (video?.closest('[data-gsp-shortform-player]'))
+    return null
+
+  return video
+}
+
 presence.on('UpdateData', async () => {
+  const [privacy, showBrowsingStatus, showTimestamps, showSmallImage, usePresenceName, showCover] = await Promise.all([
+    presence.getSetting<boolean>('privacy'),
+    presence.getSetting<boolean>('showBrowsingStatus'),
+    presence.getSetting<boolean>('showTimestamps'),
+    presence.getSetting<boolean>('showSmallImage'),
+    presence.getSetting<boolean>('usePresenceName'),
+    presence.getSetting<boolean>('showCover'),
+  ])
+
   let extra = '...'
 
   const path = document.location.pathname
   const presenceData: PresenceData = {
     largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/P/Peacock/assets/logo.png',
     startTimestamp: elapsed,
-    type: ActivityType.Watching,
   }
 
   strings ??= await newStrings
@@ -34,16 +61,22 @@ presence.on('UpdateData', async () => {
     extra = ' Sports'
   else if (path.includes('/watch/latino/highlights'))
     extra = ' Latino'
+  else if (path.includes('/watch/my-stuff'))
+    extra = ' My Stuff'
 
-  presenceData.details = `Browsing${extra}`
+  presenceData.details = `${strings.browsing}${extra}`
 
   if (path.includes('/watch/search'))
     presenceData.details = 'Searching...'
 
+  let isWatching = false
+
   if (path.includes('/watch/playback') || path.includes('/watch/asset')) {
-    const video = document.querySelector<HTMLVideoElement>('#core-video-shaka')
-      || document.querySelector<HTMLVideoElement>('.video-player-component video')
+    const video = findWatchingVideo()
     if (video) {
+      isWatching = true
+      ;(presenceData as PresenceData).type = ActivityType.Watching
+
       const title = document.querySelector('[data-testid="metadata-title"]')
         || document.querySelector('.playback-header__title')
         || document.querySelector('.playback-metadata__container-title')
@@ -61,35 +94,76 @@ presence.on('UpdateData', async () => {
           '.swiper-slide-active .playlist-item-overlay__container-title',
         )
 
-      if (desc)
-        presenceData.state = desc.textContent
+      if (privacy) {
+        presenceData.details = strings.watchingVid
+        delete presenceData.state
+      }
+      else {
+        let titleText = title?.textContent ?? undefined
+        if (titleText && path.includes('/watch/playback/playlist'))
+          titleText += ' Playlist'
 
-      if (title) {
-        presenceData.details = title.textContent
-        if (path.includes('/watch/playback/playlist'))
-          presenceData.details += ' Playlist'
+        if (usePresenceName && titleText) {
+          presenceData.name = titleText
+          if (desc)
+            presenceData.details = desc.textContent
+        }
+        else {
+          if (titleText)
+            presenceData.details = titleText
+          if (desc)
+            presenceData.state = desc.textContent
+        }
       }
 
-      presenceData.smallImageKey = live
-        ? Assets.Live
-        : video.paused
-          ? Assets.Pause
-          : Assets.Play
-      presenceData.smallImageText = live
-        ? strings.live
-        : video.paused
-          ? strings.pause
-          : strings.play
+      if (showSmallImage) {
+        presenceData.smallImageKey = live
+          ? Assets.Live
+          : video.paused
+            ? Assets.Pause
+            : Assets.Play
+        presenceData.smallImageText = live
+          ? strings.live
+          : video.paused
+            ? strings.pause
+            : strings.play
+      }
 
-      if (!live)
+      if (showTimestamps && !live && !privacy && !video.paused) {
         [presenceData.startTimestamp, presenceData.endTimestamp] = timestamps
-
-      if (video.paused) {
+      }
+      else {
         delete presenceData.startTimestamp
         delete presenceData.endTimestamp
       }
     }
+    else if (path.includes('/watch/asset') && !privacy) {
+      isWatching = true
+
+      const synopsis = document.querySelector('[data-testid="synopsis"]')
+      const titleText = document.title.replace(/ - Peacock$/, '')
+
+      if (usePresenceName) {
+        presenceData.name = titleText
+        if (synopsis)
+          presenceData.details = synopsis.textContent
+      }
+      else {
+        presenceData.details = titleText
+        if (synopsis)
+          presenceData.state = synopsis.textContent
+      }
+
+      if (showCover) {
+        const cover = getCoverKey()
+        if (cover)
+          presenceData.largeImageKey = cover
+      }
+    }
   }
+
+  if (!isWatching && !path.includes('/watch/search') && !showBrowsingStatus)
+    return presence.clearActivity()
 
   presence.setActivity(presenceData)
 })

--- a/websites/P/Peacock/presence.ts
+++ b/websites/P/Peacock/presence.ts
@@ -15,7 +15,7 @@ let strings: Awaited<typeof newStrings>
 presence.on('UpdateData', async () => {
   let extra = '...'
 
-  const path = window.location.pathname
+  const path = document.location.pathname
   const presenceData: PresenceData = {
     largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/P/Peacock/assets/logo.png',
     startTimestamp: elapsed,
@@ -41,24 +41,25 @@ presence.on('UpdateData', async () => {
     presenceData.details = 'Searching...'
 
   if (path.includes('/watch/playback') || path.includes('/watch/asset')) {
-    const video = document.querySelector<HTMLVideoElement>(
-      '.video-player-component video',
-    )
+    const video = document.querySelector<HTMLVideoElement>('#core-video-shaka')
+      || document.querySelector<HTMLVideoElement>('.video-player-component video')
     if (video) {
-      const title = document.querySelector('.playback-header__title')
+      const title = document.querySelector('[data-testid="metadata-title"]')
+        || document.querySelector('.playback-header__title')
         || document.querySelector('.playback-metadata__container-title')
       const timestamps = getTimestamps(
         Math.floor(video.currentTime),
         Math.floor(video.duration),
       )
       const live = timestamps[1] === Infinity
-      const desc = document.querySelector(
-        '.playback-metadata__container-episode-metadata-info',
-      )
-      || document.querySelector('.playback-metadata__container-description')
-      || document.querySelector(
-        '.swiper-slide-active .playlist-item-overlay__container-title',
-      )
+      const desc = document.querySelector('[data-testid="metadata-description"]')
+        || document.querySelector(
+          '.playback-metadata__container-episode-metadata-info',
+        )
+        || document.querySelector('.playback-metadata__container-description')
+        || document.querySelector(
+          '.swiper-slide-active .playlist-item-overlay__container-title',
+        )
 
       if (desc)
         presenceData.state = desc.textContent


### PR DESCRIPTION
## Description

Fixes #10595. Peacock's frontend now ships hashed CSS-in-JS class names, so the old selectors (`.video-player-component`, `.playback-header__title`, `.playback-metadata__container-*`) never match anything anymore, silently skipping the whole video-detection block and leaving the activity stuck on "Browsing..." no matter how long you watch. Confirmed against live-captured DOM from an actual playback session.

**Fix:**
- Video detection now targets the stable `#core-video-shaka` id (Shaka Player), with the old class selector kept as a fallback.
- Title/description now target `[data-testid="metadata-title"]` / `[data-testid="metadata-description"]` first (Peacock's stable test ids), falling back to the old class selectors.
- `window.location` → `document.location` per the Activity Guidelines.

**Also added, while in the file:**
- Handles the show/movie detail page (`/watch/asset/...`, no video element — just a synopsis and a "Play" button) with its own title/synopsis/cover-art display, previously fell through to the generic "Browsing..." text.
- That detail page also autoplays a muted shortform preview clip in the background using the same player id as real playback; excluded via `[data-gsp-shortform-player]` so it isn't mistaken for the user actually watching something (no false progress timestamp).
- `/watch/my-stuff` gets its own "Browsing My Stuff" label instead of falling through to the generic default.
- `type` now defaults to Playing and only promotes to Watching once a real video is confirmed playing, instead of hardcoding Watching everywhere (browsing/search/the detail page correctly stay Playing).
- New settings: Privacy Mode, Show Title as Presence (name = title, matching the Jellyfin/Netflix activities' style), Show Cover Art (from the detail page's hero image), Show Browsing Status, Show Timestamps, Show Play/Pause Icon.
- Version bumped 1.1.1 → 2.0.0.

**Known limitation:** we looked into also surfacing the season/episode (e.g. "S1E2") via `largeImageText`, parsed from Peacock's "S1 E2: Episode Title" text next to the player. Live testing showed it doesn't reliably parse from what's actually available in Peacock's DOM across different shows, so it was dropped rather than shipped inconsistent — episode playback intentionally falls back to just the series name + synopsis.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

Screenshots are in a comment below.

</details>
