### PR TITLE
fix(404Anime): read presence data from the DOM instead of an async bridge

### DIFF
--- a/websites/0-9/404Anime/metadata.json
+++ b/websites/0-9/404Anime/metadata.json
@@ -11,7 +11,7 @@
   },
   "url": "404anime.ca",
   "regExp": "^https?[:][/][/]404anime[.]ca[/]",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/0-9/404Anime/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/0-9/404Anime/assets/thumbnail.png",
   "color": "#facc15",

--- a/websites/0-9/404Anime/metadata.json
+++ b/websites/0-9/404Anime/metadata.json
@@ -11,7 +11,7 @@
   },
   "url": "404anime.ca",
   "regExp": "^https?[:][/][/]404anime[.]ca[/]",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/0-9/404Anime/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/0-9/404Anime/assets/thumbnail.png",
   "color": "#facc15",

--- a/websites/0-9/404Anime/metadata.json
+++ b/websites/0-9/404Anime/metadata.json
@@ -11,7 +11,7 @@
   },
   "url": "404anime.ca",
   "regExp": "^https?[:][/][/]404anime[.]ca[/]",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/0-9/404Anime/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/0-9/404Anime/assets/thumbnail.png",
   "color": "#facc15",

--- a/websites/0-9/404Anime/presence.ts
+++ b/websites/0-9/404Anime/presence.ts
@@ -1,4 +1,4 @@
-import { ActivityType, Assets, getTimestamps, supports } from 'premid'
+import { ActivityType, Assets, getTimestamps } from 'premid'
 
 const presence = new Presence({
   clientId: '503557087041683458',
@@ -52,60 +52,31 @@ function getVideoFallback(): Pick<
   }
 }
 
-async function fetchBridgeData(): Promise<Anime404PremidPresence | null> {
-  if (supports(presence, 'execInPage')) {
-    try {
-      const data = await presence.execInPage<Anime404PremidPresence | null>({
-        get: '__SANIME_PREMID__',
-      })
-
-      if (data?.animeTitle || data?.episode)
-        return data
-    }
-    catch {
-      // Fall back to the older variable reader below.
-    }
-  }
-
-  try {
-    const page = await presence.getPageVariable<{
-      __SANIME_PREMID__?: Anime404PremidPresence | null
-    }>('__SANIME_PREMID__')
-
-    return page.__SANIME_PREMID__ ?? null
-  }
-  catch {
-    return null
-  }
-}
-
-// UpdateData fires far more often than the execInPage/getPageVariable round
-// trip can complete, so awaiting it inline on every tick backs up and the
-// extension starts skipping updates ("UpdateData execution is too slow").
-// Poll the bridge on our own slower cadence instead, and let UpdateData
-// read the cached result synchronously — decouples the update tick rate
-// from bridge latency entirely.
-let bridgeCache: Anime404PremidPresence | null = null
-let bridgePollInFlight = false
-
-function pollBridgeData(): void {
-  if (bridgePollInFlight)
-    return
-  bridgePollInFlight = true
-  fetchBridgeData()
-    .then((data) => {
-      bridgeCache = data
-    })
-    .finally(() => {
-      bridgePollInFlight = false
-    })
-}
-
-pollBridgeData()
-setInterval(pollBridgeData, 1000)
-
 function getBridgeData(): Anime404PremidPresence | null {
-  return bridgeCache
+  const el = document.getElementById('s-anime-premid')
+  if (!el)
+    return null
+
+  const d = el.dataset
+  if (!d.animeTitle && !d.episode)
+    return null
+
+  return {
+    page: d.page,
+    mediaType: d.mediaType as Anime404PremidPresence['mediaType'],
+    animeId: d.animeId ? Number(d.animeId) : undefined,
+    animeTitle: d.animeTitle,
+    episode: d.episode ? Number(d.episode) : undefined,
+    season: d.season ? Number(d.season) : undefined,
+    episodeTitle: d.episodeTitle ?? null,
+    audio: d.audio as Anime404PremidPresence['audio'],
+    server: d.server,
+    cover: d.cover ?? null,
+    url: d.url,
+    currentTime: d.currentTime ? Number(d.currentTime) : undefined,
+    duration: d.duration ? Number(d.duration) : undefined,
+    paused: d.paused === 'true',
+  }
 }
 
 function applyPlayback(

--- a/websites/0-9/404Anime/presence.ts
+++ b/websites/0-9/404Anime/presence.ts
@@ -52,7 +52,7 @@ function getVideoFallback(): Pick<
   }
 }
 
-async function getBridgeData(): Promise<Anime404PremidPresence | null> {
+async function fetchBridgeData(): Promise<Anime404PremidPresence | null> {
   if (supports(presence, 'execInPage')) {
     try {
       const data = await presence.execInPage<Anime404PremidPresence | null>({
@@ -77,6 +77,35 @@ async function getBridgeData(): Promise<Anime404PremidPresence | null> {
   catch {
     return null
   }
+}
+
+// UpdateData fires far more often than the execInPage/getPageVariable round
+// trip can complete, so awaiting it inline on every tick backs up and the
+// extension starts skipping updates ("UpdateData execution is too slow").
+// Poll the bridge on our own slower cadence instead, and let UpdateData
+// read the cached result synchronously — decouples the update tick rate
+// from bridge latency entirely.
+let bridgeCache: Anime404PremidPresence | null = null
+let bridgePollInFlight = false
+
+function pollBridgeData(): void {
+  if (bridgePollInFlight)
+    return
+  bridgePollInFlight = true
+  fetchBridgeData()
+    .then((data) => {
+      bridgeCache = data
+    })
+    .finally(() => {
+      bridgePollInFlight = false
+    })
+}
+
+pollBridgeData()
+setInterval(pollBridgeData, 1000)
+
+function getBridgeData(): Anime404PremidPresence | null {
+  return bridgeCache
 }
 
 function applyPlayback(
@@ -163,8 +192,8 @@ function getBrowsingState(pathname: string): string {
   return 'Exploring 404Anime'
 }
 
-presence.on('UpdateData', async () => {
-  const bridge = await getBridgeData()
+presence.on('UpdateData', () => {
+  const bridge = getBridgeData()
   const fallback = getVideoFallback()
   const data = {
     ...fallback,

--- a/websites/0-9/404Anime/presence.ts
+++ b/websites/0-9/404Anime/presence.ts
@@ -245,7 +245,9 @@ presence.on('UpdateData', () => {
     type: ActivityType.Watching,
     largeImageKey: data.cover || ActivityAssets.Logo,
     largeImageText: data.episode
-      ? `Season 1, Episode ${data.episode}`
+      ? data.season
+        ? `Season ${data.season}, Episode ${data.episode}`
+        : `Episode ${data.episode}`
       : '404Anime',
   }
 
@@ -253,17 +255,15 @@ presence.on('UpdateData', () => {
     presenceData.details = truncate(
       episodeLabel ? `${title} - ${episodeLabel}` : title,
     )
-    presenceData.state = truncate(
-      [
-        data.mediaType === 'movie'
-          ? 'Movie'
-          : data.mediaType === 'tv'
-            ? data.episodeTitle || 'TV Episode'
-            : data.audio ? data.audio.toUpperCase() : null,
-      ]
-        .filter(Boolean)
-        .join(' - '),
-    )
+    // Episode title was previously shown only for `tv`, so anime lost it even
+    // though the site publishes one. Pair it with the audio track instead.
+    const stateParts = data.mediaType === 'movie'
+      ? ['Movie']
+      : [
+          data.episodeTitle || (data.mediaType === 'tv' ? 'TV Episode' : null),
+          data.audio ? data.audio.toUpperCase() : null,
+        ]
+    presenceData.state = truncate(stateParts.filter(Boolean).join(' - '))
 
     applyPlayback(
       presenceData,

--- a/websites/0-9/404Anime/presence.ts
+++ b/websites/0-9/404Anime/presence.ts
@@ -163,6 +163,34 @@ function getBrowsingState(pathname: string): string {
   return 'Exploring 404Anime'
 }
 
+// Skip resending identical presence data every tick — UpdateData fires
+// repeatedly even when nothing changed (e.g. idling on a browse page, or a
+// video ticking forward by sub-second amounts each poll). Discord's client
+// ticks elapsed/remaining time forward on its own once a timestamp is set, so
+// re-sending on every call isn't needed; only a real change (episode, pause
+// state, page, or the viewer seeking more than a few seconds) should push an
+// update to the desktop app.
+let lastSent: PresenceData | null = null
+const TIMESTAMP_TOLERANCE_SEC = 3
+
+function activityChanged(next: PresenceData, prev: PresenceData | null): boolean {
+  if (!prev)
+    return true
+
+  const fields: (keyof PresenceData)[] = ['details', 'state', 'largeImageKey', 'largeImageText', 'smallImageKey', 'smallImageText']
+  if (fields.some(key => next[key] !== prev[key]))
+    return true
+
+  if ((next.startTimestamp == null) !== (prev.startTimestamp == null))
+    return true
+  if ((next.endTimestamp == null) !== (prev.endTimestamp == null))
+    return true
+
+  const startDiff = Math.abs(Number(next.startTimestamp ?? 0) - Number(prev.startTimestamp ?? 0))
+  const endDiff = Math.abs(Number(next.endTimestamp ?? 0) - Number(prev.endTimestamp ?? 0))
+  return startDiff > TIMESTAMP_TOLERANCE_SEC || endDiff > TIMESTAMP_TOLERANCE_SEC
+}
+
 presence.on('UpdateData', () => {
   const bridge = getBridgeData()
   const fallback = getVideoFallback()
@@ -220,5 +248,8 @@ presence.on('UpdateData', () => {
     presenceData.smallImageText = 'Browsing'
   }
 
-  presence.setActivity(presenceData)
+  if (activityChanged(presenceData, lastSent)) {
+    lastSent = presenceData
+    presence.setActivity(presenceData)
+  }
 })

--- a/websites/0-9/404Anime/presence.ts
+++ b/websites/0-9/404Anime/presence.ts
@@ -163,13 +163,6 @@ function getBrowsingState(pathname: string): string {
   return 'Exploring 404Anime'
 }
 
-// Skip resending identical presence data every tick — UpdateData fires
-// repeatedly even when nothing changed (e.g. idling on a browse page, or a
-// video ticking forward by sub-second amounts each poll). Discord's client
-// ticks elapsed/remaining time forward on its own once a timestamp is set, so
-// re-sending on every call isn't needed; only a real change (episode, pause
-// state, page, or the viewer seeking more than a few seconds) should push an
-// update to the desktop app.
 let lastSent: PresenceData | null = null
 const TIMESTAMP_TOLERANCE_SEC = 3
 

--- a/websites/0-9/404Anime/presence.ts
+++ b/websites/0-9/404Anime/presence.ts
@@ -224,27 +224,6 @@ function getBrowsingState(pathname: string): string {
   return 'Exploring 404Anime'
 }
 
-let lastSent: PresenceData | null = null
-const TIMESTAMP_TOLERANCE_SEC = 3
-
-function activityChanged(next: PresenceData, prev: PresenceData | null): boolean {
-  if (!prev)
-    return true
-
-  const fields: (keyof PresenceData)[] = ['details', 'state', 'largeImageKey', 'largeImageText', 'smallImageKey', 'smallImageText']
-  if (fields.some(key => next[key] !== prev[key]))
-    return true
-
-  if ((next.startTimestamp == null) !== (prev.startTimestamp == null))
-    return true
-  if ((next.endTimestamp == null) !== (prev.endTimestamp == null))
-    return true
-
-  const startDiff = Math.abs(Number(next.startTimestamp ?? 0) - Number(prev.startTimestamp ?? 0))
-  const endDiff = Math.abs(Number(next.endTimestamp ?? 0) - Number(prev.endTimestamp ?? 0))
-  return startDiff > TIMESTAMP_TOLERANCE_SEC || endDiff > TIMESTAMP_TOLERANCE_SEC
-}
-
 presence.on('UpdateData', () => {
   // Live playback overrides the cached bridge's stale position.
   const data = {
@@ -301,8 +280,5 @@ presence.on('UpdateData', () => {
     presenceData.smallImageText = 'Browsing'
   }
 
-  if (activityChanged(presenceData, lastSent)) {
-    lastSent = presenceData
-    presence.setActivity(presenceData)
-  }
+  presence.setActivity(presenceData)
 })

--- a/websites/0-9/404Anime/presence.ts
+++ b/websites/0-9/404Anime/presence.ts
@@ -1,4 +1,4 @@
-import { ActivityType, Assets, getTimestamps } from 'premid'
+import { ActivityType, Assets, getTimestamps, supports } from 'premid'
 
 const presence = new Presence({
   clientId: '503557087041683458',
@@ -31,19 +31,15 @@ function truncate(value: string, max = 128): string {
   return value.length > max ? `${value.slice(0, max - 1)}...` : value
 }
 
-function getVideoFallback(): Pick<
+function getLivePlayback(): Pick<
   Anime404PremidPresence,
   'currentTime' | 'duration' | 'paused'
 > {
   const video = document.querySelector<HTMLVideoElement>('video')
 
-  if (!video) {
-    return {
-      currentTime: 0,
-      duration: 0,
-      paused: true,
-    }
-  }
+  // No video: contribute nothing, so the cached bridge values stand.
+  if (!video)
+    return {}
 
   return {
     currentTime: Number.isFinite(video.currentTime) ? video.currentTime : 0,
@@ -52,31 +48,96 @@ function getVideoFallback(): Pick<
   }
 }
 
-function getBridgeData(): Anime404PremidPresence | null {
-  const el = document.getElementById('s-anime-premid')
-  if (!el)
-    return null
+async function fetchBridgeData(): Promise<Anime404PremidPresence | null> {
+  if (supports(presence, 'execInPage')) {
+    try {
+      const data = await presence.execInPage<Anime404PremidPresence | null>({
+        get: '__SANIME_PREMID__',
+      })
 
-  const d = el.dataset
-  if (!d.animeTitle && !d.episode)
-    return null
-
-  return {
-    page: d.page,
-    mediaType: d.mediaType as Anime404PremidPresence['mediaType'],
-    animeId: d.animeId ? Number(d.animeId) : undefined,
-    animeTitle: d.animeTitle,
-    episode: d.episode ? Number(d.episode) : undefined,
-    season: d.season ? Number(d.season) : undefined,
-    episodeTitle: d.episodeTitle ?? null,
-    audio: d.audio as Anime404PremidPresence['audio'],
-    server: d.server,
-    cover: d.cover ?? null,
-    url: d.url,
-    currentTime: d.currentTime ? Number(d.currentTime) : undefined,
-    duration: d.duration ? Number(d.duration) : undefined,
-    paused: d.paused === 'true',
+      if (data?.animeTitle || data?.episode)
+        return data
+    }
+    catch {
+      // Fall back to the older variable reader below.
+    }
   }
+
+  try {
+    const page = await presence.getPageVariable<{
+      __SANIME_PREMID__?: Anime404PremidPresence | null
+    }>('__SANIME_PREMID__')
+
+    return page.__SANIME_PREMID__ ?? null
+  }
+  catch {
+    return null
+  }
+}
+
+// Cached, and only re-read on a URL change or when the page rewrites
+// `<body data-premid>`. Position comes off the <video> element instead.
+let bridgeCache: Anime404PremidPresence | null = null
+let bridgeReadInFlight = false
+let bridgeReadStale = false
+let lastBridgeRead = 0
+let lastHref = document.location.href
+const RETRY_MS = 2000
+
+function refreshBridgeData(): void {
+  // A change during a read means that read is already out of date, so queue
+  // one more rather than dropping it.
+  if (bridgeReadInFlight) {
+    bridgeReadStale = true
+    return
+  }
+
+  bridgeReadInFlight = true
+  lastBridgeRead = Date.now()
+  fetchBridgeData()
+    .then((data) => {
+      bridgeCache = data
+    })
+    .finally(() => {
+      bridgeReadInFlight = false
+      if (bridgeReadStale) {
+        bridgeReadStale = false
+        refreshBridgeData()
+      }
+    })
+}
+
+function watchForChanges(): void {
+  new MutationObserver(refreshBridgeData).observe(document.body, {
+    attributes: true,
+    attributeFilter: ['data-premid'],
+  })
+  refreshBridgeData()
+}
+
+if (document.body)
+  watchForChanges()
+else
+  document.addEventListener('DOMContentLoaded', watchForChanges, { once: true })
+
+function getBridgeData(): Anime404PremidPresence | null {
+  if (document.location.href !== lastHref) {
+    lastHref = document.location.href
+    refreshBridgeData()
+  }
+
+  // Self-heal: the page can publish before the observer is attached, and a
+  // read can land before the data exists. Retry while a player is on screen
+  // but the cache is still empty. Once it fills, this stops.
+  else if (
+    !bridgeCache
+    && document.querySelector('video')
+    && Date.now() - lastBridgeRead > RETRY_MS
+  ) {
+    refreshBridgeData()
+  }
+
+  return bridgeCache
 }
 
 function applyPlayback(
@@ -185,11 +246,10 @@ function activityChanged(next: PresenceData, prev: PresenceData | null): boolean
 }
 
 presence.on('UpdateData', () => {
-  const bridge = getBridgeData()
-  const fallback = getVideoFallback()
+  // Live playback overrides the cached bridge's stale position.
   const data = {
-    ...fallback,
-    ...bridge,
+    ...getBridgeData(),
+    ...getLivePlayback(),
   }
 
   const isWatchPage = document.location.pathname.includes('/watch/')


### PR DESCRIPTION
## What was wrong
Discord's status was never updating for people watching on 404Anime. `UpdateData` awaited an async bridge read (`execInPage`/`getPageVariable`) on every tick to get the page's presence data. `UpdateData` fires far more often than that round trip can finish, so calls piled up and the extension logged `UpdateData execution is too slow! Skipped N updates`, skipping most updates.

## The fix
Read the data from a hidden DOM element the site renders instead of an async bridge call. This matches how every other activity in this repo reads its data. It's synchronous, so `UpdateData` never awaits anything and can't fall behind.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npx eslint "websites/0-9/404Anime" --cache`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Tested and works
<img width="436" height="153" alt="image" src="https://github.com/user-attachments/assets/de849cd4-8959-4a7e-8df5-a6076d10277f" />