### PR TITLE
feat(MagentaTV): add MagentaMusik support

### DIFF
--- a/websites/M/MagentaTV Deutschland/metadata.json
+++ b/websites/M/MagentaTV Deutschland/metadata.json
@@ -14,7 +14,7 @@
     "www.magenta.tv",
     "www.magentamusik.de"
   ],
-  "regExp": "^https?:\\/\\/([a-z0-9-]+\\.)*(magenta\\.tv|magentamusik\\.de)\\/.*",
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*(magenta[.]tv|magentamusik[.]de)[/]",
   "version": "1.1.0",
   "logo": "https://i.ibb.co/JjPZDjqb/Magenta-TV.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/M/MagentaTV%20Deutschland/assets/thumbnail.webp",

--- a/websites/M/MagentaTV Deutschland/metadata.json
+++ b/websites/M/MagentaTV Deutschland/metadata.json
@@ -7,13 +7,16 @@
   },
   "service": "MagentaTV Deutschland",
   "description": {
-    "de": "Schaue Live-TV, Filme und Serien auf MagentaTV Deutschland.",
-    "en": "Watch live TV, movies and series on MagentaTV Germany."
+    "de": "Erlebe Live-TV, Filme und Serien auf MagentaTV Deutschland sowie Konzerte, Livestreams und exklusive Musik-Events mit MagentaMusik.",
+    "en": "Experience live TV, movies and series on MagentaTV Germany alongside concerts, livestreams and exclusive music events with MagentaMusik."
   },
-  "url": "www.magenta.tv",
-  "regExp": "^https?:[/][/]([a-z0-9-]+[.])*magenta[.]tv[/]",
-  "version": "1.0.1",
-  "logo": "https://cdn.rcd.gg/PreMiD/websites/M/MagentaTV%20Deutschland/assets/logo.png",
+  "url": [
+    "www.magenta.tv",
+    "www.magentamusik.de"
+  ],
+  "regExp": "^https?:\\/\\/([a-z0-9-]+\\.)*(magenta\\.tv|magentamusik\\.de)\\/.*",
+  "version": "1.1.0",
+  "logo": "https://i.ibb.co/JjPZDjqb/Magenta-TV.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/M/MagentaTV%20Deutschland/assets/thumbnail.webp",
   "color": "#E20074",
   "category": "videos",

--- a/websites/M/MagentaTV Deutschland/presence.ts
+++ b/websites/M/MagentaTV Deutschland/presence.ts
@@ -5,7 +5,7 @@ const presence = new Presence({
 })
 
 presence.on('UpdateData', async () => {
-  const isMagentaMusik = location.hostname.includes('magentamusik.de')
+  const isMagentaMusik = document.location.hostname.includes('magentamusik.de')
 
   const video = document.querySelector<HTMLVideoElement>('video')
 

--- a/websites/M/MagentaTV Deutschland/presence.ts
+++ b/websites/M/MagentaTV Deutschland/presence.ts
@@ -5,10 +5,13 @@ const presence = new Presence({
 })
 
 presence.on('UpdateData', async () => {
+  const isMagentaMusik = location.hostname.includes('magentamusik.de')
+
   const video = document.querySelector<HTMLVideoElement>('video')
 
-  const title
-    = document.querySelector('#PARAGRAPH-TITLE')
+  const title = isMagentaMusik
+    ? document.title.trim()
+    : document.querySelector('#PARAGRAPH-TITLE')
       ?.textContent
       ?.trim()
       || document.title.replace('MagentaTV - ', '').trim()
@@ -18,19 +21,22 @@ presence.on('UpdateData', async () => {
 
   const logoImage = document.querySelector<HTMLImageElement>('[id^="PARAGRAPH-LOGO"]')
 
-  const logoUrl = logoImage?.src
-    ?.replace(/x=\d+/, 'x=250')
-    ?.replace(/y=\d+/, 'y=250')
-    ?.replace('ar=keep', 'ar=ignore')
+  const logoUrl = isMagentaMusik
+    ? 'https://i.ibb.co/Gf51vGdb/Magenta-Musik.png'
+    : logoImage?.src
+      ?.replace(/x=\d+/, 'x=250')
+      ?.replace(/y=\d+/, 'y=250')
+      ?.replace('ar=keep', 'ar=ignore')
+      ?? 'https://i.ibb.co/JjPZDjqb/Magenta-TV.png'
 
   const isLive
-    = document.querySelector('#PLAYER-PREVIOUS-CHANNEL') !== null
+    = !isMagentaMusik
+      && document.querySelector('#PLAYER-PREVIOUS-CHANNEL') !== null
 
   const presenceData: PresenceData = {
     type: ActivityType.Watching,
     largeImageKey:
-      logoUrl
-      ?? 'https://cdn.rcd.gg/PreMiD/websites/M/MagentaTV%20Deutschland/assets/logo.png',
+      logoUrl,
   }
 
   const parts = title.split(' - ')
@@ -49,11 +55,15 @@ presence.on('UpdateData', async () => {
 
     if (isLive)
       presenceData.state = 'Live TV'
+
+    if (isMagentaMusik) {
+      presenceData.name = 'MagentaMusik'
+    }
   }
 
-  const detailsLink = document.querySelector<HTMLAnchorElement>(
-    '#PLAYER-INFO-DETAILS',
-  )
+  const detailsLink = isMagentaMusik
+    ? document.querySelector<HTMLLinkElement>('link[rel="canonical"]')
+    : document.querySelector<HTMLAnchorElement>('#PLAYER-INFO-DETAILS')
 
   if (detailsLink?.href) {
     presenceData.buttons = [
@@ -74,8 +84,7 @@ presence.on('UpdateData', async () => {
         : Assets.Play
 
     if (!paused) {
-      const [startTimestamp, endTimestamp]
-        = getTimestampsFromMedia(video)
+      const [startTimestamp, endTimestamp] = getTimestampsFromMedia(video)
 
       presenceData.startTimestamp = startTimestamp
       presenceData.endTimestamp = endTimestamp


### PR DESCRIPTION
## Description
- Extend **MagentaTV Deutschland** activity support to also include **[MagentaMusik.de](https://magentamusik.de)**
- Detect playback on MagentaMusik and display corresponding activity information
- Add MagentaMusik branding and service logo support

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots

**MagentaMusik Playback**
<img width="293" height="120" alt="image" src="https://github.com/user-attachments/assets/e2c5f59f-a3bd-4f01-8360-d3d5b98b81d5" />

**MagentaTV Playback**
<img width="283" height="116" alt="image" src="https://github.com/user-attachments/assets/84f688dd-ad39-4735-8741-1ace295a17ba" />