### PR TITLE
feat(HeiwaStream): add activity

### DIFF
--- a/websites/H/HeiwaStream/metadata.json
+++ b/websites/H/HeiwaStream/metadata.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "name": "heiwafr",
+    "id": "1086606341990256650"
+  },
+  "service": "HeiwaStream",
+  "description": {
+    "en": "Browse movies, series and anime available on HeiwaStream.",
+    "fr": "Parcourez les films, séries et animés disponibles sur HeiwaStream."
+  },
+  "url": [
+    "heiwastream.fr",
+    "zelyon.xyz"
+  ],
+  "regExp": "^https?[:][/][/](?:www[.])?(?:heiwastream[.]fr|zelyon[.]xyz)(?:[/]|$)",
+  "version": "1.0.0",
+  "logo": "https://zelyon.xyz/icon-512.png",
+  "thumbnail": "https://zelyon.xyz/icon-512.png",
+  "color": "#e6a91a",
+  "category": "videos",
+  "tags": [
+    "zelyon",
+    "movies",
+    "series",
+    "anime"
+  ]
+}

--- a/websites/H/HeiwaStream/metadata.json
+++ b/websites/H/HeiwaStream/metadata.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "$schema": "https://schemas.premid.app/metadata/1.17",
   "apiVersion": 1,
   "author": {
     "name": "heiwafr",

--- a/websites/H/HeiwaStream/metadata.json
+++ b/websites/H/HeiwaStream/metadata.json
@@ -21,7 +21,6 @@
   "color": "#e6a91a",
   "category": "videos",
   "tags": [
-    "zelyon",
     "movies",
     "series",
     "anime"

--- a/websites/H/HeiwaStream/metadata.json
+++ b/websites/H/HeiwaStream/metadata.json
@@ -16,8 +16,8 @@
   ],
   "regExp": "^https?[:][/][/](?:www[.])?(?:heiwastream[.]fr|zelyon[.]xyz)(?:[/]|$)",
   "version": "1.0.0",
-  "logo": "https://zelyon.xyz/icon-512.png",
-  "thumbnail": "https://zelyon.xyz/icon-512.png",
+  "logo": "https://i.imgur.com/RWdxBEH.png",
+  "thumbnail": "https://i.imgur.com/VRtNGUH.png",
   "color": "#e6a91a",
   "category": "videos",
   "tags": [

--- a/websites/H/HeiwaStream/presence.ts
+++ b/websites/H/HeiwaStream/presence.ts
@@ -4,6 +4,7 @@ const presence = new Presence({
   clientId: '1142417275966738503',
 })
 const browsingTimestamp = Math.floor(Date.now() / 1_000)
+const heartbeatAttribute = 'data-premid-extension-heartbeat'
 
 enum ActivityAssets {
   Logo = 'https://i.imgur.com/RWdxBEH.png',
@@ -24,6 +25,10 @@ function lireNombre(value: string | undefined): number | null {
 }
 
 function mettreAJourActivite(): void {
+  // Le site utilise ce signal local pour ne plus proposer PreMiD lorsque
+  // l'activité HeiwaStream est déjà réellement chargée par l'extension.
+  document.documentElement.setAttribute(heartbeatAttribute, String(Date.now()))
+
   const data = document.documentElement.dataset
   const title = data.premidWatching
 

--- a/websites/H/HeiwaStream/presence.ts
+++ b/websites/H/HeiwaStream/presence.ts
@@ -24,6 +24,19 @@ function lireNombre(value: string | undefined): number | null {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : null
 }
 
+function lireUrlHeiwa(value: string | undefined): string | null {
+  if (!value)
+    return null
+
+  try {
+    const url = new URL(value)
+    return url.protocol === 'https:' && supportedHosts.has(url.hostname) ? url.href : null
+  }
+  catch {
+    return null
+  }
+}
+
 function mettreAJourActivite(): void {
   // Le site utilise ce signal local pour ne plus proposer PreMiD lorsque
   // l'activité HeiwaStream est déjà réellement chargée par l'extension.
@@ -70,14 +83,25 @@ function mettreAJourActivite(): void {
     smallImageText: stateLabel,
   }
 
-  if (data.premidMediaUrl) {
-    try {
-      const mediaUrl = new URL(data.premidMediaUrl)
-      if (mediaUrl.protocol === 'https:' && supportedHosts.has(mediaUrl.hostname))
-        presenceData.detailsUrl = mediaUrl.href
-    }
-    catch {
-      // Une URL invalide est simplement ignorée.
+  const mediaUrl = lireUrlHeiwa(data.premidMediaUrl)
+  const pageUrl = lireUrlHeiwa(data.premidPageUrl)
+  const contentType = data.premidContentType
+  const isMovie = contentType === 'movie' || data.premidMediaType === 'movie'
+  const detailsUrl = pageUrl ?? mediaUrl
+
+  if (detailsUrl)
+    presenceData.detailsUrl = detailsUrl
+
+  if (isMovie && mediaUrl) {
+    presenceData.buttons = [{ label: 'Watch Movie', url: mediaUrl }]
+  }
+  else if (data.premidEpisode && mediaUrl) {
+    presenceData.buttons = [{ label: 'Watch Episode', url: mediaUrl }]
+    if (pageUrl && pageUrl !== mediaUrl) {
+      presenceData.buttons.push({
+        label: contentType === 'anime' ? 'View Anime' : 'View Series',
+        url: pageUrl,
+      })
     }
   }
 
@@ -112,6 +136,7 @@ new MutationObserver(planifierMiseAJour).observe(document.documentElement, {
     'data-premid-watching',
     'data-premid-episode',
     'data-premid-media-type',
+    'data-premid-content-type',
     'data-premid-provider',
     'data-premid-language',
     'data-premid-quality',

--- a/websites/H/HeiwaStream/presence.ts
+++ b/websites/H/HeiwaStream/presence.ts
@@ -6,7 +6,7 @@ const presence = new Presence({
 const browsingTimestamp = Math.floor(Date.now() / 1_000)
 
 enum ActivityAssets {
-  Logo = 'https://zelyon.xyz/icon-512.png',
+  Logo = 'https://i.imgur.com/RWdxBEH.png',
 }
 
 const supportedHosts = new Set([

--- a/websites/H/HeiwaStream/presence.ts
+++ b/websites/H/HeiwaStream/presence.ts
@@ -1,0 +1,84 @@
+import { ActivityType, Assets, getTimestamps } from 'premid'
+
+const presence = new Presence({
+  clientId: '1142417275966738503',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1_000)
+
+enum ActivityAssets {
+  Logo = 'https://zelyon.xyz/icon-512.png',
+}
+
+const supportedHosts = new Set([
+  'heiwastream.fr',
+  'www.heiwastream.fr',
+  'zelyon.xyz',
+  'www.zelyon.xyz',
+])
+
+function lireNombre(value: string | undefined): number | null {
+  if (!value)
+    return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null
+}
+
+presence.on('UpdateData', async () => {
+  const data = document.documentElement.dataset
+  const title = data.premidWatching
+
+  if (!title) {
+    const presenceData: PresenceData = {
+      name: 'HeiwaStream',
+      type: ActivityType.Playing,
+      details: 'Parcourt HeiwaStream',
+      state: data.premidPage ?? 'Accueil',
+      largeImageKey: ActivityAssets.Logo,
+      smallImageKey: Assets.Search,
+      smallImageText: 'Navigation',
+      startTimestamp: lireNombre(data.premidSince) ?? browsingTimestamp,
+    }
+    presence.setActivity(presenceData)
+    return
+  }
+
+  const playbackState = data.premidState ?? 'playing'
+  const position = lireNombre(data.premidPosition)
+  const duration = lireNombre(data.premidDuration)
+  const metadata = [data.premidEpisode, data.premidProvider, data.premidLanguage, data.premidQuality]
+    .filter(Boolean)
+    .join(' · ')
+  const stateLabel = playbackState === 'paused'
+    ? 'En pause'
+    : playbackState === 'loading'
+      ? 'Chargement'
+      : 'En lecture'
+
+  const presenceData: PresenceData = {
+    name: 'HeiwaStream',
+    type: ActivityType.Watching,
+    details: title,
+    state: metadata ? `${stateLabel} · ${metadata}`.slice(0, 128) : stateLabel,
+    largeImageKey: data.premidPoster ?? ActivityAssets.Logo,
+    largeImageText: 'HeiwaStream',
+    smallImageKey: playbackState === 'paused' ? Assets.Pause : Assets.Play,
+    smallImageText: stateLabel,
+  }
+
+  if (data.premidMediaUrl) {
+    try {
+      const mediaUrl = new URL(data.premidMediaUrl)
+      if (mediaUrl.protocol === 'https:' && supportedHosts.has(mediaUrl.hostname))
+        presenceData.detailsUrl = mediaUrl.href
+    }
+    catch {
+      // Une URL invalide est simplement ignorée.
+    }
+  }
+
+  if (playbackState === 'playing' && position !== null && duration !== null && duration > position) {
+    [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestamps(position, duration)
+  }
+
+  presence.setActivity(presenceData)
+})

--- a/websites/H/HeiwaStream/presence.ts
+++ b/websites/H/HeiwaStream/presence.ts
@@ -23,7 +23,7 @@ function lireNombre(value: string | undefined): number | null {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : null
 }
 
-presence.on('UpdateData', async () => {
+function mettreAJourActivite(): void {
   const data = document.documentElement.dataset
   const title = data.premidWatching
 
@@ -81,4 +81,42 @@ presence.on('UpdateData', async () => {
   }
 
   presence.setActivity(presenceData)
+}
+
+let miseAJourPlanifiee = false
+
+function planifierMiseAJour(): void {
+  if (miseAJourPlanifiee)
+    return
+
+  miseAJourPlanifiee = true
+  queueMicrotask(() => {
+    miseAJourPlanifiee = false
+    mettreAJourActivite()
+  })
+}
+
+presence.on('UpdateData', mettreAJourActivite)
+
+// Le lecteur est une modale React : l'URL ne change pas lorsqu'il s'ouvre.
+// On observe donc directement le pont DOM afin que Discord reflète aussitôt
+// le contenu, la lecture/pause et le timecode, sans attendre le cycle PreMiD.
+new MutationObserver(planifierMiseAJour).observe(document.documentElement, {
+  attributes: true,
+  attributeFilter: [
+    'data-premid-watching',
+    'data-premid-episode',
+    'data-premid-media-type',
+    'data-premid-provider',
+    'data-premid-language',
+    'data-premid-quality',
+    'data-premid-poster',
+    'data-premid-media-url',
+    'data-premid-position',
+    'data-premid-duration',
+    'data-premid-state',
+    'data-premid-page',
+    'data-premid-page-url',
+    'data-premid-since',
+  ],
 })


### PR DESCRIPTION
## Description

Adds Rich Presence support for HeiwaStream.

The activity supports:

- Browsing the HeiwaStream catalogue
- Displaying the selected movie, series or anime
- Displaying episode, language, quality and player information
- Play, pause, loading and timecode states
- Contextual `Watch Movie`, `Watch Episode`, `View Series` and `View Anime` buttons
- Both `heiwastream.fr`, the production domain, and `zelyon.xyz`, the development domain

HeiwaStream is a React single-page application whose media player opens in a modal without changing the current URL. The website exposes stable, non-sensitive `data-premid-*` attributes on `document.documentElement`. The activity only reads these attributes and observes their changes; it does not inject, remove or modify any website element.

Content buttons point to public HeiwaStream pages. They never expose or redirect directly to a video stream.

Validation completed with:

- `npx eslint "websites/H/HeiwaStream"`
- `npx pmd build "HeiwaStream" --validate`

## Acknowledgements

- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code
- [x] The PR title follows the repository's commit conventions

## Screenshots

<details>
<summary>Proof showing the activity working as expected</summary>

### HeiwaStream homepage

![HeiwaStream homepage](https://i.imgur.com/BspJHOE.png)

### Browsing a movie

![Browsing a movie](https://i.imgur.com/YDJB5KH.png)

### Loading content

![Loading content](https://i.imgur.com/bHiltKb.png)

### Watching content

![Watching content](https://i.imgur.com/kdzOeZK.png)

### Activity viewed from another Discord profile

![HeiwaStream Watch Episode button viewed from another Discord profile](https://zelyon.xyz/preuves/premid-activite-profil.png)

</details>