### PR TITLE
feat(HeiwaStream): show season, episode and language only

### DIFF
--- a/websites/H/HeiwaStream/metadata.json
+++ b/websites/H/HeiwaStream/metadata.json
@@ -15,7 +15,7 @@
     "zelyon.xyz"
   ],
   "regExp": "^https?[:][/][/](?:www[.])?(?:heiwastream[.]fr|zelyon[.]xyz)(?:[/]|$)",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/H/HeiwaStream/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/H/HeiwaStream/assets/thumbnail.png",
   "color": "#e6a91a",

--- a/websites/H/HeiwaStream/presence.ts
+++ b/websites/H/HeiwaStream/presence.ts
@@ -63,7 +63,7 @@ function mettreAJourActivite(): void {
   const playbackState = data.premidState ?? 'playing'
   const position = lireNombre(data.premidPosition)
   const duration = lireNombre(data.premidDuration)
-  const metadata = [data.premidEpisode, data.premidProvider, data.premidLanguage, data.premidQuality]
+  const metadata = [data.premidSeason, data.premidEpisode, data.premidLanguage]
     .filter(Boolean)
     .join(' · ')
   const stateLabel = playbackState === 'paused'
@@ -135,6 +135,7 @@ new MutationObserver(planifierMiseAJour).observe(document.documentElement, {
   attributeFilter: [
     'data-premid-watching',
     'data-premid-episode',
+    'data-premid-season',
     'data-premid-media-type',
     'data-premid-content-type',
     'data-premid-provider',


### PR DESCRIPTION
## Changes
- The playback **state** line now shows `Season · Episode · Language` (e.g. `S01 · E01 · VF`) instead of `Episode · Provider · Language · Quality`. The streaming-provider name and the quality tag were noise for viewers, so they're dropped. Movies are unchanged (language only).
- New `data-premid-season` DOM-bridge attribute (exposed by the website, also added to the `MutationObserver` filter) so the season shows up for series and anime.
- No image / clientId change. Version bump `1.0.1` → `1.0.2`.

Follow-up to #11036.

## Testing
- `pmd build "HeiwaStream" --validate` passes (type check + compile).
- Verified live on the website.

## Before / After
_Before:_ `En lecture · E01 · Zelyon Player · VF · standard`
_After:_ `En lecture · S01 · E01 · VF`

<!-- screenshots -->
