### PR TITLE
fix(SteamDB): Fixed undefined account worth values

### DIFF
--- a/websites/S/SteamDB/metadata.json
+++ b/websites/S/SteamDB/metadata.json
@@ -5,6 +5,12 @@
     "name": "joerkig",
     "id": "205984221859151873"
   },
+  "contributors": [
+    {
+      "name": "entraptaa",
+      "id": "153980822670671872"
+    }
+  ],
   "service": "SteamDB",
   "altnames": [
     "Steam Database"
@@ -18,7 +24,7 @@
     "steamstat.us"
   ],
   "regExp": "^https?[:][/][/](steamdb[.]info|steamstat[.]us)[/]",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/S/SteamDB/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/S/SteamDB/assets/thumbnail.png",
   "color": "#3871C8",

--- a/websites/S/SteamDB/presence.ts
+++ b/websites/S/SteamDB/presence.ts
@@ -108,18 +108,14 @@ presence.on('UpdateData', async () => {
               presenceData.state = `${
                 document.querySelector('.player-name')?.textContent
               } (${
-                Array.from(
-                  document.querySelector('.number-price')?.childNodes ?? [],
-                ).find(node => node.nodeName === '#text')?.textContent
+                document.querySelector('div.prices > span > span:nth-child(2)')?.textContent
               })`
             }
             else if (accountValue === 1) {
               presenceData.state = `${
                 document.querySelector('.player-name')?.textContent
               } (${
-                Array.from(
-                  document.querySelector('.number-price-lowest')?.childNodes ?? [],
-                ).find(node => node.nodeName === '#text')?.textContent
+                document.querySelector('b > span:nth-child(2)')?.textContent
               })`
             }
             presenceData.buttons = [


### PR DESCRIPTION
## Description
Version 1.2.0 would show the Steam Name along with (undefined) as the account value

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<img width="543" height="235" alt="image" src="https://github.com/user-attachments/assets/66d36f4a-f975-4455-8579-a7c294e6ae02" />
<img width="546" height="233" alt="image" src="https://github.com/user-attachments/assets/f0ba0d0f-8184-452b-9093-a349f0ec692a" />
<img width="413" height="485" alt="image" src="https://github.com/user-attachments/assets/8d4b8668-655b-4392-8185-cf0c05ba5a3e" />

</details>
