### PR TITLE
feat(Scribble Hub): add activity

### DIFF
--- a/websites/S/Scribble Hub/metadata.json
+++ b/websites/S/Scribble Hub/metadata.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.17",
+  "apiVersion": 1,
+  "author": {
+    "id": "990316096244572204",
+    "name": "iRedX"
+  },
+  "service": "Scribble Hub",
+  "description": {
+    "en": "Scribble Hub is a popular online self-publishing platform dedicated to original web stories, serialized novels, and fanfiction."
+  },
+  "url": [
+    "www.scribblehub.com",
+    "www.scribblehubforum.com"
+  ],
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*(scribblehub|scribblehubforum)[.]com[/]",
+  "version": "1.0.0",
+  "logo": "https://i.ibb.co/S7M6V6kV/SH.png",
+  "thumbnail": "https://i.ibb.co/Y77FYtDD/image.png",
+  "color": "#3399CC",
+  "category": "other",
+  "tags": [
+    "novels",
+    "books",
+    "reading",
+    "writing"
+  ]
+}

--- a/websites/S/Scribble Hub/presence.ts
+++ b/websites/S/Scribble Hub/presence.ts
@@ -1,0 +1,167 @@
+import { Assets } from 'premid'
+
+const presence = new Presence({
+  clientId: '503557087041683458',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://i.ibb.co/S7M6V6kV/SH.png',
+}
+
+function truncate(text: string, maxLength = 128): string {
+  return text.length > maxLength
+    ? `${text.slice(0, maxLength - 3)}...`
+    : text
+}
+
+function getText(selector: string): string {
+  return document.querySelector(selector)?.textContent?.trim() ?? ''
+}
+
+function getImage(selector: string): string {
+  return document.querySelector<HTMLImageElement>(selector)?.src ?? ''
+}
+
+function getNovelTitle(): string {
+  return getText('.chp_byauthor a:first-child')
+    || getText('.fic_title')
+    || document.querySelector<HTMLMetaElement>('meta[property="og:title"]')?.content.trim()
+    || ''
+}
+
+function getNovelCover(): string {
+  return getImage('.novel-cover .fic_image img, .s_novel_img img')
+    || document.querySelector<HTMLMetaElement>('meta[property="og:image"]')?.content.trim()
+    || ''
+}
+
+function setLargeImage(
+  presenceData: PresenceData,
+  image: string,
+  smallImageText: string,
+): void {
+  if (!image)
+    return
+
+  presenceData.largeImageKey = image
+  presenceData.smallImageKey = ActivityAssets.Logo
+  presenceData.smallImageText = smallImageText
+}
+
+function updateForumActivity(
+  presenceData: PresenceData,
+  pathname: string,
+): void {
+  const pageTitle = getText('.p-title-value')
+
+  if (pathname.startsWith('/threads/')) {
+    presenceData.details = 'Reading a Thread'
+    if (pageTitle)
+      presenceData.state = truncate(pageTitle)
+    presenceData.smallImageKey = Assets.Reading
+    presenceData.smallImageText = 'Reading'
+  }
+  else if (pathname.startsWith('/forums/')) {
+    presenceData.details = 'Viewing a Forum'
+    if (pageTitle)
+      presenceData.state = truncate(pageTitle)
+  }
+  else if (pathname.startsWith('/members/')) {
+    const profileName = getText('.memberHeader-name .username')
+
+    presenceData.details = 'Viewing a Forum Profile'
+    if (profileName)
+      presenceData.state = truncate(profileName)
+    setLargeImage(
+      presenceData,
+      getImage('.memberHeader-avatar img'),
+      'Viewing',
+    )
+  }
+  else if (pathname.startsWith('/search/')) {
+    const searchInput = document.querySelector<HTMLInputElement>(
+      'input[name="keywords"], input[name="q"]',
+    )
+    const searchQuery = searchInput?.value.trim()
+
+    presenceData.details = searchQuery
+      ? 'Searching the Forum for:'
+      : 'Searching the Forum'
+    if (searchQuery)
+      presenceData.state = truncate(searchQuery)
+    presenceData.smallImageKey = Assets.Search
+    presenceData.smallImageText = 'Searching'
+  }
+  else if (pathname.startsWith('/whats-new/')) {
+    presenceData.details = 'Viewing What\'s New'
+  }
+  else if (pathname.startsWith('/conversations/')) {
+    presenceData.details = 'Viewing Conversations'
+  }
+  else if (pathname.startsWith('/account/')) {
+    presenceData.details = 'Managing Their Account'
+  }
+}
+
+function updateMainSiteActivity(
+  presenceData: PresenceData,
+  pathname: string,
+): void {
+  if (/^\/read\/[^/]+\/chapter\/\d+\/?$/.test(pathname)) {
+    const novelTitle = getNovelTitle()
+    const chapterTitle = getText('.chapter-title')
+
+    presenceData.details = truncate(`Reading: ${novelTitle || 'a Novel'}`)
+    presenceData.state = truncate(chapterTitle || 'Reading a Chapter')
+    presenceData.smallImageKey = Assets.Reading
+    presenceData.smallImageText = 'Reading'
+    setLargeImage(presenceData, getNovelCover(), 'Reading')
+  }
+  else if (pathname.startsWith('/series/')) {
+    const novelTitle = getNovelTitle()
+
+    presenceData.details = 'Viewing a Novel'
+    if (novelTitle)
+      presenceData.state = truncate(novelTitle)
+    setLargeImage(presenceData, getNovelCover(), 'Browsing')
+  }
+  else if (pathname.startsWith('/series-finder') || pathname.startsWith('/genre/')) {
+    presenceData.details = 'Searching Novels'
+    presenceData.smallImageKey = Assets.Search
+    presenceData.smallImageText = 'Searching'
+  }
+  else if (pathname.startsWith('/profile/')) {
+    const profileName = getText('.auth_name_fic') || getText('h1')
+
+    presenceData.details = 'Viewing a Profile'
+    if (profileName)
+      presenceData.state = truncate(profileName)
+    setLargeImage(
+      presenceData,
+      getImage('.fic_useravatar_profile img'),
+      'Viewing',
+    )
+  }
+}
+
+presence.on('UpdateData', () => {
+  const { hostname, pathname } = document.location
+  const isForum = hostname === 'scribblehubforum.com'
+    || hostname === 'www.scribblehubforum.com'
+  const presenceData: PresenceData = {
+    name: 'Scribble Hub',
+    details: isForum ? 'Browsing the Forum' : 'Browsing Scribble Hub',
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+    smallImageKey: Assets.Viewing,
+    smallImageText: 'Browsing',
+  }
+
+  if (isForum)
+    updateForumActivity(presenceData, pathname)
+  else
+    updateMainSiteActivity(presenceData, pathname)
+
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description

Adds Rich Presence support for Scribble Hub and Scribble Hub Forum.

The activity supports:

- Browsing Scribble Hub
- Searching for novels
- Viewing novels with their title and cover artwork
- Reading chapters with the novel title, chapter title, cover artwork, and elapsed time
- Viewing author profiles with profile photos
- Browsing Scribble Hub Forum
- Viewing forum sections and member profiles
- Reading forum threads
- Searching the forum
- Forum pages such as What's New, conversations, and account management
- Supports both `scribblehub.com` and `scribblehubforum.com`

Validation completed with:

- `npx eslint "websites/S/Scribble Hub"`
- `npx pmd build "Scribble Hub"`

## Acknowledgements

- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code
- [x] The PR title follows the repository's commit conventions

## Screenshots

<details>
<summary>Proof showing the activity working as expected</summary>

### Viewing homepage

<img width="366" height="147" alt="image" src="https://github.com/user-attachments/assets/d5aef976-b6fe-4b1d-b9d3-3a2ebac7a907" />


### Viewing a novel

<img width="373" height="162" alt="image" src="https://github.com/user-attachments/assets/df5c1bb2-a93b-412c-8757-5ffd48bad04e" />

### Reading a chapter

<img width="369" height="153" alt="image" src="https://github.com/user-attachments/assets/3c8cd910-b0cc-40a1-a59b-d636a8cf3dc4" />

### Viewing a profile

<img width="370" height="185" alt="image" src="https://github.com/user-attachments/assets/53f02e9f-bc61-4a32-bad0-9593598a212c" />

### Reading a forum thread

<img width="366" height="155" alt="image" src="https://github.com/user-attachments/assets/bed038e2-5791-4aa4-8aac-def9a7ee4b69" />

</details>