### PR TITLE
feat(Udemy): add privacy mode

### DIFF
--- a/websites/U/Udemy/metadata.json
+++ b/websites/U/Udemy/metadata.json
@@ -19,7 +19,7 @@
   },
   "url": "www.udemy.com",
   "regExp": "^https?[:][/][/](www[.])?udemy[.]com[/]",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/U/Udemy/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/U/Udemy/assets/thumbnail.png",
   "color": "#a435f0",
@@ -27,5 +27,13 @@
   "tags": [
     "course",
     "learning"
+  ],
+  "settings": [
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "icon": "fad fa-user-secret",
+      "value": false
+    }
   ]
 }

--- a/websites/U/Udemy/presence.ts
+++ b/websites/U/Udemy/presence.ts
@@ -15,6 +15,7 @@ presence.on('UpdateData', async () => {
     pause: 'general.paused',
     browse: 'general.browsing',
   })
+  const privacy = await presence.getSetting<boolean>('privacy')
 
   const presenceData: PresenceData = {
     largeImageKey: ActivityAssets.Logo,
@@ -71,6 +72,23 @@ presence.on('UpdateData', async () => {
     presenceData.startTimestamp = BROWSING_TIMESTAMP
     presenceData.smallImageKey = Assets.Search
     presenceData.smallImageText = (await strings).browse
+  }
+
+  if (privacy) {
+    if (videoInfo)
+      presenceData.details = 'Watching a course'
+    else if (pathname.includes('/course/'))
+      presenceData.details = 'Viewing a course'
+    else if (pathname.includes('/courses/search/'))
+      presenceData.details = 'Searching Udemy'
+    else
+      presenceData.details = (await strings).browse
+
+    presenceData.startTimestamp = BROWSING_TIMESTAMP
+    delete presenceData.state
+    delete presenceData.endTimestamp
+    delete presenceData.smallImageKey
+    delete presenceData.smallImageText
   }
 
   if (presenceData.details) {


### PR DESCRIPTION
## Description

Adds an optional Privacy Mode setting to Udemy. When enabled, the activity keeps generic learning context while hiding course titles, lecture names, search queries, playback progress, and play/pause details.

Privacy Mode is disabled by default, so existing behavior stays unchanged.

Closes #10719

## Acknowledgements

- [x] I read and understood the [Contributing Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md).
- [x] I linted the code and fixed any linting errors I found.
- [x] The title of this pull request follows the [Commit Convention](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md).

## Validation

- Ran `npm run lint` (currently stops on 578 existing `ts/no-deprecated` findings in other activities; no Udemy files are reported)
- Ran `npx eslint --no-cache "websites/U/Udemy/presence.ts" "websites/U/Udemy/metadata.json"`
- Ran `npx pmd build "Udemy" --validate`
- Loaded the activity through `pmd dev Udemy` with zero compilation errors
- Verified the developer activity loads as Udemy v1.5.0 and the Privacy Mode setting can be toggled

## Screenshots

<details>
<summary>Privacy Mode setting</summary>

![Udemy Privacy Mode setting](https://raw.githubusercontent.com/iDavi/Activities/refs/heads/codex/pr-assets-11054/11054/privacy-mode-setting.jpeg)

</details>
