### PR TITLE
feat(YouTube): add search activity setting

### DIFF
--- a/websites/Y/YouTube/metadata.json
+++ b/websites/Y/YouTube/metadata.json
@@ -74,7 +74,7 @@
     "m.youtube.com"
   ],
   "regExp": "^https?[:][/][/](www|studio|m)[.]youtube[.]com[/]",
-  "version": "6.3.3",
+  "version": "6.4.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Y/YouTube/assets/thumbnail.jpg",
   "color": "#E40813",
@@ -190,6 +190,12 @@
       "title": "Hide Homepage",
       "icon": "fad fa-user-secret",
       "value": false
+    },
+    {
+      "id": "showSearch",
+      "title": "Show Search Activity",
+      "icon": "fas fa-search",
+      "value": true
     },
     {
       "id": "showListening",

--- a/websites/Y/YouTube/presence.ts
+++ b/websites/Y/YouTube/presence.ts
@@ -89,6 +89,19 @@ presence.on('UpdateData', async () => {
   const { pathname, hostname, search, href } = document.location
   const isMobile = hostname === 'm.youtube.com'
   const selectors = getQuerySelectors(isMobile)
+  const isSearchPage = pathname.includes('/results')
+    || (
+      pathname.includes('/search')
+      && (
+        pathname.includes('/@')
+        || pathname.includes('/channel')
+        || pathname.includes('/c')
+        || pathname.includes('/user')
+      )
+    )
+
+  if (isSearchPage && !showSearch)
+    return presence.clearActivity()
 
   // Update strings if user selected another language.
   if (!checkStringLanguage(newLang))
@@ -555,9 +568,6 @@ presence.on('UpdateData', async () => {
         break
       }
     }
-
-    if (searching && !showSearch)
-      return presence.clearActivity()
 
     if (privacy) {
       if (searching) {

--- a/websites/Y/YouTube/presence.ts
+++ b/websites/Y/YouTube/presence.ts
@@ -65,6 +65,7 @@ presence.on('UpdateData', async () => {
     logo,
     buttons,
     hideHome,
+    showSearch,
     hidePaused,
     showListening,
     displayType,
@@ -80,6 +81,7 @@ presence.on('UpdateData', async () => {
     getSetting<number>('largeImage', 0),
     getSetting<boolean>('buttons', true),
     getSetting<boolean>('hideHome', false),
+    getSetting<boolean>('showSearch', true),
     getSetting<boolean>('hidePaused', true),
     getSetting<number>('showListening', 0),
     getSetting<number>('displayType', 2),
@@ -553,6 +555,9 @@ presence.on('UpdateData', async () => {
         break
       }
     }
+
+    if (searching && !showSearch)
+      return presence.clearActivity()
 
     if (privacy) {
       if (searching) {


### PR DESCRIPTION
## Description

Adds an optional Show Search Activity setting to YouTube. When disabled, PreMiD clears the activity on both regular search-result pages and channel search pages instead of publishing the search status or query.

The search-page check runs before video detection because YouTube can retain the previous video element during SPA navigation.

The setting is enabled by default, so existing behavior stays unchanged.

Closes #5884

## Acknowledgements

- [x] I read and understood the [Contributing Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md).
- [x] I linted the code and fixed any linting errors I found.
- [x] The title of this pull request follows the [Commit Convention](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md).

## Validation

- Ran `npx eslint --no-cache --rule 'ts/no-deprecated: off' "websites/Y/YouTube/presence.ts" "websites/Y/YouTube/metadata.json"`
- Ran `npx pmd build "YouTube" --validate`
- Loaded the activity through `pmd dev YouTube` with zero compilation errors
- Confirmed the corrected activity was recompiled and sent to the extension after navigating from a video exposed stale activity
- Confirmed the regular focused lint only reports three unchanged deprecated `setActivity()` calls in the existing YouTube activity

<img width="408" height="45" alt="image" src="https://github.com/user-attachments/assets/b8f4d7ef-0f75-4ed1-ac14-3073a7af4561" />

