### PR TITLE
feat(Anime3rb): add activity

### DIFF
--- a/websites/A/Anime3rb/metadata.json
+++ b/websites/A/Anime3rb/metadata.json
@@ -2,8 +2,8 @@
   "$schema": "https://schemas.premid.app/metadata/1.17",
   "apiVersion": 1,
   "author": {
-    "name": "nando",
-    "id": "1530277199087931392"
+    "name": "Bassam",
+    "id": "1206658241006932040"
   },
   "service": "Anime3rb",
   "description": {
@@ -12,8 +12,8 @@
   "url": "anime3rb.com",
   "regExp": "^https?:\\/\\/(?:www\\.)?anime3rb\\.com\\/",
   "version": "1.0.0",
-  "logo": "https://cdn.rcd.gg/PreMiD/resources/question.png",
-  "thumbnail": "https://placehold.co/1280x720/151515/FFFFFF.png",
+  "logo": "https://imgur.com/Cm2uVbf",
+  "thumbnail": "https://imgur.com/A19xn84",
   "color": "#151515",
   "category": "anime",
   "tags": ["anime", "arabic", "streaming"]

--- a/websites/A/Anime3rb/metadata.json
+++ b/websites/A/Anime3rb/metadata.json
@@ -10,7 +10,7 @@
     "en": "Watch anime on Anime3rb."
   },
   "url": "anime3rb.com",
-  "regExp": "^https?:\\/\\/(?:www\\.)?anime3rb\\.com\\/",
+  "regExp": "^https?[:][/][/](?:www[.])?anime3rb[.]com[/]",
   "version": "1.0.0",
   "logo": "https://i.imgur.com/Cm2uVbf.png",
   "thumbnail": "https://i.imgur.com/A19xn84.png",

--- a/websites/A/Anime3rb/metadata.json
+++ b/websites/A/Anime3rb/metadata.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.17",
+  "apiVersion": 1,
+  "author": {
+    "name": "nando",
+    "id": "1530277199087931392"
+  },
+  "service": "Anime3rb",
+  "description": {
+    "en": "Watch anime on Anime3rb."
+  },
+  "url": "anime3rb.com",
+  "regExp": "^https?:\\/\\/(?:www\\.)?anime3rb\\.com\\/",
+  "version": "1.0.0",
+  "logo": "https://cdn.rcd.gg/PreMiD/resources/question.png",
+  "thumbnail": "https://placehold.co/1280x720/151515/FFFFFF.png",
+  "color": "#151515",
+  "category": "anime",
+  "tags": ["anime", "arabic", "streaming"]
+}

--- a/websites/A/Anime3rb/metadata.json
+++ b/websites/A/Anime3rb/metadata.json
@@ -12,8 +12,8 @@
   "url": "anime3rb.com",
   "regExp": "^https?:\\/\\/(?:www\\.)?anime3rb\\.com\\/",
   "version": "1.0.0",
-  "logo": "https://imgur.com/Cm2uVbf",
-  "thumbnail": "https://imgur.com/A19xn84",
+  "logo": "https://i.imgur.com/Cm2uVbf.png",
+  "thumbnail": "https://i.imgur.com/A19xn84.png",
   "color": "#151515",
   "category": "anime",
   "tags": ["anime", "arabic", "streaming"]

--- a/websites/A/Anime3rb/presence.ts
+++ b/websites/A/Anime3rb/presence.ts
@@ -1,0 +1,69 @@
+import { Assets, getTimestampsFromMedia } from 'premid'
+
+const presence = new Presence({
+  clientId: '1530277199087931392',
+})
+
+let browsingTimestamp = Date.now()
+let wasWatching = false
+
+presence.on('UpdateData', () => {
+  const { pathname } = document.location
+  const presenceData: PresenceData = {
+    largeImageKey: document.querySelector<HTMLMetaElement>('meta[property="og:image"]')?.content
+      ?? Assets.Question,
+  }
+
+  if (!pathname.startsWith('/episode/')) {
+    if (wasWatching) {
+      browsingTimestamp = Date.now()
+      wasWatching = false
+    }
+
+    presenceData.details = 'Browsing Anime3rb'
+    presenceData.smallImageKey = Assets.Search
+    presenceData.smallImageText = 'Browsing'
+    presenceData.startTimestamp = browsingTimestamp
+    presence.setActivity(presenceData)
+    return
+  }
+
+  const pathParts = pathname.split('/').filter(Boolean)
+  const episode = pathParts.at(-1)
+  const slug = pathParts.at(-2)
+  const heading = document.querySelector('h1')?.textContent?.trim()
+  const pageTitle = document.querySelector<HTMLMetaElement>('meta[property="og:title"]')?.content
+  const animeTitle = slug?.replaceAll('-', ' ').replace(/\b\w/g, character => character.toUpperCase())
+    ?? pageTitle?.replace(/\s*[-|]\s*Anime3rb.*$/i, '')
+    ?? heading
+    ?? 'Anime'
+  const videos = [...document.querySelectorAll('video')]
+  const video = videos
+    .filter(video => !video.paused && Number.isFinite(video.duration) && video.duration > 0)
+    .sort((first, second) => second.currentTime - first.currentTime)[0]
+    ?? videos[0]
+
+  presenceData.details = animeTitle
+  presenceData.state = episode ? `Episode ${episode}` : 'Watching an episode'
+  presenceData.buttons = [{
+    label: 'Watch Episode',
+    url: document.location.href,
+  }]
+
+  if (video && Number.isFinite(video.duration) && video.duration > 0) {
+    wasWatching = true
+    presenceData.smallImageKey = video.paused ? Assets.Pause : Assets.Play
+    presenceData.smallImageText = video.paused ? 'Paused' : 'Watching'
+
+    if (!video.paused) {
+      [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestampsFromMedia(video)
+    }
+  }
+  else {
+    wasWatching = true
+    presenceData.smallImageKey = Assets.Viewing
+    presenceData.smallImageText = 'Watching'
+  }
+
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description

Added a new Activity for Anime3rb that displays the currently playing anime and episode information.

This activity allows users to easily view anime details and the current episode directly through PreMiD.

### Changes Made

- Added Anime3rb activity support.
- Added detection for anime titles and episode numbers.
- Added support for displaying the current anime page information.
- Improved user experience by showing relevant anime data while watching.

### Acknowledgements

- [x] I read the Activity Guidelines
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's commit conventions

## Screenshots

<details>
<summary>Proof showing the activity is working as expected</summary>

<img width="294" height="687" alt="image" src="https://github.com/user-attachments/assets/004bd39b-a0b3-42ff-98da-d3e42cce8d73" />


</details>