### PR TITLE
feat(CodiQuest): add activity

### DIFF
--- a/websites/C/CodiQuest/metadata.json
+++ b/websites/C/CodiQuest/metadata.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "$schema": "https://schemas.premid.app/metadata/1.17",
   "apiVersion": 1,
   "author": {
     "name": "Codima Studios",

--- a/websites/C/CodiQuest/metadata.json
+++ b/websites/C/CodiQuest/metadata.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "name": "Codima Studios",
+    "id": "268870067465355268"
+  },
+  "service": "CodiQuest",
+  "description": {
+    "en": "A text-forward fantasy RPG built around deliberate combat and a complete crafter and gatherer career."
+  },
+  "url": "codiquest.online",
+  "regExp": "^https?[:][/][/](www[.])?codiquest[.]online[/]",
+  "version": "1.0.0",
+  "logo": "https://www.codiquest.online/icon-512.png",
+  "thumbnail": "https://www.codiquest.online/social-card.png",
+  "color": "#E2B95C",
+  "category": "games",
+  "tags": [
+    "fantasy",
+    "rpg",
+    "mmorpg"
+  ],
+  "settings": [
+    {
+      "id": "showLocation",
+      "title": "Show location",
+      "icon": "fas fa-map-marker-alt",
+      "value": true,
+      "description": "Show the current room or destination"
+    },
+    {
+      "id": "showCharacter",
+      "title": "Show class and level",
+      "icon": "fas fa-user-shield",
+      "value": false,
+      "description": "Show class and level without revealing the character name"
+    },
+    {
+      "id": "showTimestamp",
+      "title": "Show activity time",
+      "icon": "fas fa-stopwatch",
+      "value": true,
+      "description": "Show time spent on the current kind of activity"
+    },
+    {
+      "id": "showParty",
+      "title": "Show party size",
+      "icon": "fas fa-users",
+      "value": true,
+      "description": "Show party size while grouped"
+    }
+  ]
+}

--- a/websites/C/CodiQuest/presence.ts
+++ b/websites/C/CodiQuest/presence.ts
@@ -1,8 +1,6 @@
 import { ActivityType } from 'premid'
 
 const presence = new Presence({
-  // Public Discord application/client ID for CodiQuest. Never place its client
-  // secret or a bot token in this activity.
   clientId: '1532069734961647827',
 })
 

--- a/websites/C/CodiQuest/presence.ts
+++ b/websites/C/CodiQuest/presence.ts
@@ -1,0 +1,63 @@
+import { ActivityType } from 'premid'
+
+const presence = new Presence({
+  // Public Discord application/client ID for CodiQuest. Never place its client
+  // secret or a bot token in this activity.
+  clientId: '1532069734961647827',
+})
+
+const LOGO_URL = 'https://www.codiquest.online/icon-512.png'
+
+let activeKind: string | undefined
+let activityStartedAt = Date.now()
+
+presence.on('UpdateData', async () => {
+  const { pathname } = document.location
+  const bridge = document.documentElement.dataset
+
+  // Public, authentication, and legal surfaces never publish an activity. The
+  // game removes the bridge on sign-out as a second layer of protection.
+  if (pathname !== '/play' || bridge.cqPresence !== 'ready') {
+    presence.clearActivity()
+    return
+  }
+
+  const [showLocation, showCharacter, showTimestamp, showParty] = await Promise.all([
+    presence.getSetting<boolean>('showLocation'),
+    presence.getSetting<boolean>('showCharacter'),
+    presence.getSetting<boolean>('showTimestamp'),
+    presence.getSetting<boolean>('showParty'),
+  ])
+
+  if (activeKind !== bridge.cqActivity) {
+    activeKind = bridge.cqActivity
+    activityStartedAt = Date.now()
+  }
+
+  const presenceData: PresenceData = {
+    type: ActivityType.Playing,
+    details: bridge.cqDetails || 'Adventuring in Hollowreach',
+    largeImageKey: LOGO_URL,
+  }
+
+  const state: string[] = []
+  if (showLocation && bridge.cqLocation)
+    state.push(bridge.cqLocation)
+  if (showCharacter && bridge.cqClass && bridge.cqLevel) {
+    state.push(`Level ${bridge.cqLevel} ${bridge.cqClass}`)
+  }
+  if (state.length)
+    presenceData.state = state.join(' · ')
+  if (showTimestamp)
+    presenceData.startTimestamp = activityStartedAt
+
+  if (showParty) {
+    const partySize = Number.parseInt(bridge.cqPartySize ?? '', 10)
+    const partyMax = Number.parseInt(bridge.cqPartyMax ?? '', 10)
+    if (Number.isInteger(partySize) && Number.isInteger(partyMax) && partySize > 0 && partyMax >= partySize) {
+      presenceData.party = { partySize, maxPartySize: partyMax }
+    }
+  }
+
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description

Adds a PreMiD activity for [CodiQuest](https://www.codiquest.online), a text-forward fantasy RPG.

The activity reports broad gameplay states such as exploring, fighting, gathering, crafting, and trading. Optional settings control location, class and level, elapsed activity time, and party size. The game exposes a deliberately sanitized DOM contract; the activity does not read character names, account identifiers, inventory, currency, chat, guild membership, or exact vitals.

## Validation

- PreMiD CLI 2.3.1 typecheck and compile
- `npx pmd build "CodiQuest" --validate`
- Repository ESLint for `websites/C/CodiQuest`
- Live Activity Developer Mode verification against signed-in CodiQuest
- All upstream pull-request checks passing

## Acknowledgements

- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the activity with the repository ESLint configuration
- [x] The PR title follows the repository's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots

### Exploring Hollowreach

![CodiQuest Hollowreach City alongside its matching Discord Rich Presence](https://raw.githubusercontent.com/Cody229/Activities/pr-assets/codiquest-11067/.github/pr-assets/CodiQuest-11067/exploring.png)

### Crafting at The Forge

![CodiQuest Forge screen alongside its matching Discord Rich Presence](https://raw.githubusercontent.com/Cody229/Activities/pr-assets/codiquest-11067/.github/pr-assets/CodiQuest-11067/crafting.png)

### Activity settings

![CodiQuest activity settings in PreMiD](https://raw.githubusercontent.com/Cody229/Activities/pr-assets/codiquest-11067/.github/pr-assets/CodiQuest-11067/settings.png)