### PR TITLE
feat(Kiite): add activity

### DIFF
--- a/websites/K/Kiite/metadata.json
+++ b/websites/K/Kiite/metadata.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "id": "751341509068193840",
+    "name": "mitac_"
+  },
+  "service": "Kiite",
+  "description": {
+    "en": "Discover Vocaloid and UTAU music from Niconico with playlists, Radar, Cafe, World, and Check.",
+    "ja": "ニコニコ動画のボカロ・UTAU楽曲をプレイリスト、Radar、Cafe、World、Check で発掘・共有できる音楽サービスです。"
+  },
+  "url": [
+    "kiite.jp",
+    "cafe.kiite.jp",
+    "check.kiite.jp",
+    "world.kiite.jp",
+    "radar.kiite.jp",
+    "mobile.kiite.jp"
+  ],
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*kiite[.]jp[/]",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/Xs7h5Ix.png",
+  "thumbnail": "https://i.imgur.com/U1wfM6B.png",
+  "color": "#FF33AA",
+  "category": "music",
+  "tags": [
+    "audio",
+    "cafe",
+    "music",
+    "niconico",
+    "player",
+    "vocaloid"
+  ],
+  "settings": [
+    {
+      "id": "lang",
+      "multiLanguage": true
+    }
+  ]
+}

--- a/websites/K/Kiite/presence.ts
+++ b/websites/K/Kiite/presence.ts
@@ -1,0 +1,488 @@
+import { ActivityType, Assets, getTimestampsFromMedia } from 'premid'
+
+const presence = new Presence({
+  clientId: '1490262611995000872',
+})
+
+enum ActivityAssets {
+  Logo = 'https://i.imgur.com/Xs7h5Ix.png',
+}
+
+const SELECTORS = {
+  // kiite.jp player
+  nowPlayingRow: 'li.media-info.nowplaying',
+  playPauseIcon: '#player .pl-fn-cont .pl-btn-play .material-icons',
+  playerBarCreator: '#player .pl-now-creator',
+  playerThumb: '#player .pl-thum',
+  playerTitle: '.pl-now-title .jp-title',
+  video: '#jp_video_container video',
+  // cafe.kiite.jp
+  cafeTitle: '#now_playing_info .title',
+  cafeArtist: '#now_playing_info .artist',
+  cafeThumbIcon: '#now_playing_info .thumbnail .icon',
+  cafePlayer: '#cafe_player',
+  cafeBgBlur: '#cafe .bg_blur',
+  // check.kiite.jp
+  checkTitle: '[class*="[grid-area:title]"] p',
+  checkArtist: '[class*="[grid-area:artist]"] p',
+  checkThumb: '[class*="[grid-area:thumbnail]"] img',
+} as const
+
+const NICO_CDN_THUMB_RE
+  = /https:\/\/nicovideo\.cdn\.nimg\.jp\/thumbnails\/[^"');}\s]+/g
+
+function normalizeText(s: string | null | undefined): string {
+  return s?.replaceAll('\u00A0', ' ').trim() ?? ''
+}
+
+function dataAttr(
+  el: Element | null | undefined,
+  name: string,
+): string | undefined {
+  const v = el?.getAttribute(name)?.trim()
+  return v || undefined
+}
+
+function nowPlayingRow(): Element | null {
+  return document.querySelector(SELECTORS.nowPlayingRow)
+}
+
+function isPlaceholderThumbnail(url: string): boolean {
+  return url.includes('no_thumbnail')
+}
+
+function urlFromCssBackground(bg: string): string | undefined {
+  if (!bg || bg === 'none')
+    return undefined
+  const m = bg.match(/url\(["']?([^"')]+)["']?\)/)
+  const url = m?.[1]
+  if (!url || isPlaceholderThumbnail(url))
+    return undefined
+  return url
+}
+
+function backgroundImageFromElement(el: HTMLElement | null): string | undefined {
+  if (!el)
+    return undefined
+  return (
+    urlFromCssBackground(el.style.backgroundImage)
+    ?? urlFromCssBackground(getComputedStyle(el).backgroundImage)
+  )
+}
+
+function nicoThumbnailUrlsInCssText(css: string): string[] {
+  return Array.from(css.matchAll(NICO_CDN_THUMB_RE))
+    .map(m => m[0])
+    .filter(url => !isPlaceholderThumbnail(url))
+}
+
+function pickBestNicoThumbnailUrl(urls: string[]): string | undefined {
+  if (urls.length === 0)
+    return undefined
+  const rank = (u: string) => (u.endsWith('.L') ? 3 : u.endsWith('.M') ? 2 : 1)
+  return urls.reduce((best, curr) => (rank(curr) > rank(best) ? curr : best))
+}
+
+function thumbnailFromNicoHeadStyles(): string | undefined {
+  const { head } = document
+  if (!head)
+    return undefined
+  const urls: string[] = []
+  for (const style of head.querySelectorAll('style')) {
+    const text = style.textContent
+    if (text)
+      urls.push(...nicoThumbnailUrlsInCssText(text))
+  }
+  return pickBestNicoThumbnailUrl(urls)
+}
+
+function playerVideo(): HTMLVideoElement | null {
+  return document.querySelector(SELECTORS.video)
+}
+
+function playerTitle(): string | null {
+  const text = normalizeText(
+    document.querySelector(SELECTORS.playerTitle)?.textContent,
+  )
+  if (!text || text === '-')
+    return null
+  return text
+}
+
+function playerCreator(): string | undefined {
+  const bar = document.querySelector(SELECTORS.playerBarCreator)
+  const fromArtist = normalizeText(
+    bar?.querySelector('.jp-artist')?.textContent,
+  )
+  if (fromArtist)
+    return fromArtist
+  const fromLink = normalizeText(bar?.querySelector('a')?.textContent)
+  if (fromLink)
+    return fromLink
+  return dataAttr(nowPlayingRow(), 'data-creator-name')
+}
+
+function playerThumbnail(): string | undefined {
+  const video = playerVideo()
+  const fromThumb = backgroundImageFromElement(
+    document.querySelector<HTMLElement>(SELECTORS.playerThumb),
+  )
+  const fromRow = dataAttr(nowPlayingRow(), 'data-thumbnail')
+  const fromPoster = (() => {
+    if (!video)
+      return undefined
+    const poster = video.getAttribute('poster') || video.poster
+    return poster && !isPlaceholderThumbnail(poster) ? poster : undefined
+  })()
+
+  return (
+    fromThumb
+    ?? (fromRow && !isPlaceholderThumbnail(fromRow) ? fromRow : undefined)
+    ?? fromPoster
+    ?? thumbnailFromNicoHeadStyles()
+  )
+}
+
+function isTrackPlaying(video: HTMLVideoElement | null): boolean {
+  const icon = document
+    .querySelector(SELECTORS.playPauseIcon)
+    ?.textContent
+    ?.trim()
+  if (icon === 'pause')
+    return true
+  return !!(video && !video.paused && video.readyState > 0)
+}
+
+function applyMediaTimestamps(
+  data: PresenceData,
+  playing: boolean,
+  video: HTMLVideoElement | null,
+): void {
+  if (!playing || !video)
+    return
+  const [start, end] = getTimestampsFromMedia(video)
+  if (start && end) {
+    data.startTimestamp = start
+    data.endTimestamp = end
+  }
+}
+
+async function fetchStrings() {
+  return presence.getStrings({
+    browsing: 'general.browsing',
+    searchSomething: 'general.searchSomething',
+    searchFor: 'general.searchFor',
+    buttonViewPage: 'general.buttonViewPage',
+    viewHome: 'general.viewHome',
+    viewPlaylist: 'general.viewPlaylist',
+    viewAPlaylist: 'general.viewAPlaylist',
+    viewUser: 'general.viewUser',
+    viewProfile: 'general.viewProfile',
+    viewAccount: 'general.viewAccount',
+    viewAHelpPage: 'general.viewAHelpPage',
+    readingAbout: 'general.readingAbout',
+    playing: 'general.playing',
+    paused: 'general.paused',
+  })
+}
+
+type PresenceStrings = Awaited<ReturnType<typeof fetchStrings>>
+
+function listeningPresence(
+  strings: PresenceStrings,
+  href: string,
+  title: string,
+  artist: string | undefined,
+  thumbnail: string | undefined,
+  playing: boolean,
+  video: HTMLVideoElement | null = null,
+): PresenceData {
+  const presenceData: PresenceData = {
+    type: ActivityType.Listening,
+    largeImageKey: thumbnail ?? ActivityAssets.Logo,
+    details: title,
+    smallImageKey: playing ? Assets.Play : Assets.Pause,
+    smallImageText: playing ? strings.playing : strings.paused,
+    buttons: [{ label: strings.buttonViewPage, url: href }],
+  }
+  if (artist)
+    presenceData.state = artist
+  applyMediaTimestamps(presenceData, playing, video)
+  return presenceData
+}
+
+function applyMainBrowsingState(
+  pathname: string,
+  search: string,
+  strings: PresenceStrings,
+  data: PresenceData,
+): void {
+  delete data.state
+  data.smallImageKey = Assets.Reading
+
+  if (pathname === '/' || pathname === '') {
+    data.details = strings.viewHome
+  }
+  else if (pathname.startsWith('/playlist/')) {
+    const title = document
+      .querySelector('h1.playlist-dtl-title')
+      ?.textContent
+      ?.trim()
+    data.details = title ? strings.viewPlaylist : strings.viewAPlaylist
+    if (title)
+      data.state = title
+  }
+  else if (pathname.startsWith('/user/')) {
+    const name
+      = document.querySelector('h1.user-dtl-name')?.textContent?.trim()
+        ?? document.querySelector('#user-info')?.getAttribute('data-nickname')
+    data.details = strings.viewUser
+    if (name)
+      data.state = name
+  }
+  else if (pathname.startsWith('/creator/')) {
+    const name = document
+      .querySelector('h1.playlist-dtl-title')
+      ?.textContent
+      ?.trim()
+    data.details = strings.viewProfile
+    if (name)
+      data.state = name
+  }
+  else if (pathname.startsWith('/search')) {
+    const keyword = new URLSearchParams(search).get('keyword')?.trim()
+    data.details = keyword ? strings.searchFor : strings.searchSomething
+    if (keyword)
+      data.state = keyword
+    data.smallImageKey = Assets.Search
+  }
+  else if (pathname.startsWith('/about')) {
+    data.details = strings.readingAbout
+    data.state = 'Kiite'
+  }
+  else if (pathname.startsWith('/my/')) {
+    data.details = strings.viewAccount
+  }
+  else if (pathname.startsWith('/faq')) {
+    data.details = strings.viewAHelpPage
+  }
+  else {
+    data.details = strings.browsing
+  }
+}
+
+function handleMainSite(
+  strings: PresenceStrings,
+  href: string,
+  pathname: string,
+  search: string,
+): PresenceData {
+  const title = playerTitle()
+  const video = playerVideo()
+  const playing = isTrackPlaying(video)
+
+  if (title) {
+    return listeningPresence(
+      strings,
+      href,
+      title,
+      playerCreator(),
+      playerThumbnail(),
+      playing,
+      video,
+    )
+  }
+
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    details: strings.browsing,
+    buttons: [{ label: strings.buttonViewPage, url: href }],
+  }
+  applyMainBrowsingState(pathname, search, strings, presenceData)
+  return presenceData
+}
+
+function cafeThumbnail(): string | undefined {
+  return (
+    backgroundImageFromElement(
+      document.querySelector<HTMLElement>(SELECTORS.cafeThumbIcon),
+    )
+    ?? backgroundImageFromElement(
+      document.querySelector<HTMLElement>(SELECTORS.cafeBgBlur),
+    )
+    ?? backgroundImageFromElement(
+      document.querySelector<HTMLElement>('#cafe_player .videos'),
+    )
+  )
+}
+
+function handleCafe(strings: PresenceStrings, href: string): PresenceData {
+  const title = normalizeText(
+    document.querySelector(SELECTORS.cafeTitle)?.textContent,
+  )
+  const artist = normalizeText(
+    document.querySelector(SELECTORS.cafeArtist)?.textContent,
+  )
+  const playing = !!document.querySelector(`${SELECTORS.cafePlayer}.playing`)
+
+  if (title) {
+    return listeningPresence(
+      strings,
+      href,
+      title,
+      artist || undefined,
+      cafeThumbnail(),
+      playing || !!title,
+    )
+  }
+
+  return {
+    largeImageKey: ActivityAssets.Logo,
+    details: strings.browsing,
+    state: 'Kiite Cafe',
+    smallImageKey: Assets.Reading,
+    buttons: [{ label: strings.buttonViewPage, url: href }],
+  }
+}
+
+function handleCheck(strings: PresenceStrings, href: string): PresenceData {
+  const title = normalizeText(
+    document.querySelector(SELECTORS.checkTitle)?.textContent,
+  )
+  const artist = normalizeText(
+    document.querySelector(SELECTORS.checkArtist)?.textContent,
+  )
+  const thumbEl = document.querySelector<HTMLImageElement>(SELECTORS.checkThumb)
+  const thumbnail = thumbEl?.currentSrc || thumbEl?.src || undefined
+
+  if (title) {
+    return listeningPresence(
+      strings,
+      href,
+      title,
+      artist || undefined,
+      thumbnail && !isPlaceholderThumbnail(thumbnail) ? thumbnail : undefined,
+      true,
+    )
+  }
+
+  return {
+    largeImageKey: ActivityAssets.Logo,
+    details: strings.browsing,
+    state: 'Kiite Check',
+    smallImageKey: Assets.Reading,
+    buttons: [{ label: strings.buttonViewPage, url: href }],
+  }
+}
+
+function handleWorld(strings: PresenceStrings, href: string): PresenceData {
+  // World map / visit UI — prefer NP song text when the mini player is visible.
+  const playerRoot
+    = document.querySelector('.safe_player')
+      ?? document.querySelector('[class*="player"]')
+  const title = normalizeText(
+    playerRoot?.querySelector('.title')?.textContent
+    ?? document.querySelector('.video_info .title')?.textContent,
+  )
+  const artist = normalizeText(
+    playerRoot?.querySelector('.artist')?.textContent
+    ?? document.querySelector('.video_info .artist')?.textContent,
+  )
+  const thumb
+    = backgroundImageFromElement(
+      playerRoot?.querySelector<HTMLElement>('.thumbnail') ?? null,
+    )
+    ?? backgroundImageFromElement(
+      document.querySelector<HTMLElement>('.video_info .thumbnail'),
+    )
+
+  if (title) {
+    return listeningPresence(
+      strings,
+      href,
+      title,
+      artist || undefined,
+      thumb,
+      true,
+    )
+  }
+
+  return {
+    largeImageKey: ActivityAssets.Logo,
+    details: strings.browsing,
+    state: 'Kiite World',
+    smallImageKey: Assets.Reading,
+    buttons: [{ label: strings.buttonViewPage, url: href }],
+  }
+}
+
+function handleRadar(strings: PresenceStrings, href: string): PresenceData {
+  const selected = document.querySelector('.selected .title, .active .title, li.active')
+  const title = normalizeText(selected?.textContent)
+
+  return {
+    largeImageKey: ActivityAssets.Logo,
+    details: strings.browsing,
+    state: title || 'Kiite Radar',
+    smallImageKey: Assets.Reading,
+    buttons: [{ label: strings.buttonViewPage, url: href }],
+  }
+}
+
+function handleGenericHost(
+  strings: PresenceStrings,
+  href: string,
+  hostname: string,
+): PresenceData {
+  const label = hostname.replace(/\.kiite\.jp$/, '') || 'Kiite'
+  return {
+    largeImageKey: ActivityAssets.Logo,
+    details: strings.browsing,
+    state: label === 'kiite' ? 'Kiite' : `Kiite ${label.charAt(0).toUpperCase()}${label.slice(1)}`,
+    smallImageKey: Assets.Reading,
+    buttons: [{ label: strings.buttonViewPage, url: href }],
+  }
+}
+
+let strings: PresenceStrings | null = null
+let oldLang: string | null = null
+
+presence.on('UpdateData', async () => {
+  const { pathname, href, search, hostname } = document.location
+  const lang = await presence.getSetting<string>('lang').catch(() => 'en')
+  if (oldLang !== lang || !strings) {
+    oldLang = lang
+    strings = await fetchStrings()
+  }
+
+  let presenceData: PresenceData
+
+  switch (hostname) {
+    case 'cafe.kiite.jp':
+      presenceData = handleCafe(strings, href)
+      break
+    case 'check.kiite.jp':
+      presenceData = handleCheck(strings, href)
+      break
+    case 'world.kiite.jp':
+    case 'mobile.kiite.jp':
+      presenceData = handleWorld(strings, href)
+      break
+    case 'radar.kiite.jp':
+      presenceData = handleRadar(strings, href)
+      break
+    case 'kiite.jp':
+    case 'www.kiite.jp':
+      presenceData = handleMainSite(strings, href, pathname, search)
+      break
+    default:
+      // Other *.kiite.jp hosts (doc, report, …) — generic browsing,
+      // unless the main Kiite player markup is present on the page.
+      presenceData = playerTitle()
+        ? handleMainSite(strings, href, pathname, search)
+        : handleGenericHost(strings, href, hostname)
+      break
+  }
+
+  presence.setActivity(presenceData)
+})

--- a/websites/K/Kiite/presence.ts
+++ b/websites/K/Kiite/presence.ts
@@ -1,4 +1,4 @@
-import { ActivityType, Assets, getTimestampsFromMedia } from 'premid'
+import { ActivityType, Assets, getTimestampsFromMedia, StatusDisplayType } from 'premid'
 
 const presence = new Presence({
   clientId: '1490262611995000872',
@@ -199,6 +199,7 @@ function listeningPresence(
 ): PresenceData {
   const presenceData: PresenceData = {
     type: ActivityType.Listening,
+    statusDisplayType: StatusDisplayType.Details,
     largeImageKey: thumbnail ?? ActivityAssets.Logo,
     details: title,
     smallImageKey: playing ? Assets.Play : Assets.Pause,


### PR DESCRIPTION
## Description
Adds a new PreMiD activity for [Kiite](https://kiite.jp), a Niconico Vocaloid / UTAU music discovery service.

Supported hosts:
- `kiite.jp` / `www.kiite.jp` — main player (Listening presence with title, creator, thumbnail, play/pause, media timestamps) and browsing states for home, playlists, users, creators, search, account, FAQ, etc.
- `cafe.kiite.jp` — Cafe now-playing
- `check.kiite.jp` — Check
- `world.kiite.jp` / `mobile.kiite.jp` — World / mobile player
- `radar.kiite.jp` — Radar browsing
- other `*.kiite.jp` hosts via `regExp`, with Listening when the main player markup is present

While a track is playing, Discord status uses `StatusDisplayType.Details` so the status line shows the song title (not just “Listening to Kiite”).

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary>Proof showing the creation/modification is working as expected</summary>

![image.png](https://github.com/user-attachments/assets/d70e18ab-a3b3-4910-8007-ea58a9fd812a)
![image.png](https://github.com/user-attachments/assets/bda10cbd-ab92-440b-8594-f49c4d3e110f)

</details>