### PR TITLE
fix(Twitch): fix moderator privacy setting

### DIFF
--- a/websites/T/Twitch/Twitch.json
+++ b/websites/T/Twitch/Twitch.json
@@ -181,7 +181,7 @@
   },
   "twitch.modStreamer": {
     "description": "",
-    "message": "Moderating streamer:"
+    "message": "Moderating streamer"
   },
   "twitch.moderationSettings": {
     "description": "Part 2 of the string: \"Viewing their\"",

--- a/websites/T/Twitch/metadata.json
+++ b/websites/T/Twitch/metadata.json
@@ -55,7 +55,7 @@
     "status.twitch.tv"
   ],
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*twitch[.]tv[/]",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/T/Twitch/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/T/Twitch/assets/thumbnail.png",
   "color": "#9146FF",

--- a/websites/T/Twitch/presence.ts
+++ b/websites/T/Twitch/presence.ts
@@ -474,7 +474,8 @@ presence.on('UpdateData', async () => {
           streamerinfo = getElement('.stream-info-card p > a')
         }
 
-        presenceData.state = streamerinfo
+        if (!privacy)
+          presenceData.state = streamerinfo
 
         if (getElement('.modview-dock-widget p') !== 'Offline') {
           presenceData.smallImageKey = Assets.Live


### PR DESCRIPTION
## Description
Fixes the issue where despite the privacy setting being enabled, it would still show the streamers name that the user is moderating for.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

Without Privacy
<img width="2445" height="1345" alt="2026-08-03_22-52" src="https://github.com/user-attachments/assets/6d9e653f-3d34-4988-a3d1-c07a2e603576" />

With Privacy
<img width="2445" height="1345" alt="2026-08-03_22-52_1" src="https://github.com/user-attachments/assets/e590ef37-2c3e-4a7e-be0d-2bf7ee9f3e20" />

</details>
