### PR TITLE
feat(AnimeVietSub): add a privacy button and change "Chế Độ Riêng Tư" to "Privacy Overwrite Button"

### DIFF
--- a/websites/A/AnimeVietSub/iframe.ts
+++ b/websites/A/AnimeVietSub/iframe.ts
@@ -1,8 +1,60 @@
+import type { PrivacyCommandMessage } from './privacy.js'
+import {
+  isPrivacyStateMessage,
+  PRIVACY_MESSAGE_SOURCE,
+} from './privacy.js'
+import {
+  ensurePrivacyButton,
+  removePrivacyButton,
+} from './privacyUi.js'
+
 const iframe = new iFrame()
+let privateMode = false
+let privacyButtonShown = false
+let hasPrivacyState = false
+let lastStateRequest = 0
+
+function sendPrivacyCommand(type: PrivacyCommandMessage['type']): void {
+  window.top?.postMessage({ source: PRIVACY_MESSAGE_SOURCE, type }, '*')
+}
+
+function togglePrivacy(): void {
+  if (!privacyButtonShown)
+    return
+
+  privateMode = !privateMode
+  ensurePrivacyButton(document, privateMode, togglePrivacy)
+  sendPrivacyCommand('toggle')
+}
+
+function syncPrivacyButton(): void {
+  if (privacyButtonShown)
+    ensurePrivacyButton(document, privateMode, togglePrivacy)
+  else
+    removePrivacyButton(document)
+}
+
+window.addEventListener('message', (event) => {
+  if (event.source !== window.top || !isPrivacyStateMessage(event.data))
+    return
+
+  privateMode = event.data.privateMode
+  privacyButtonShown = event.data.privacyButtonShown
+  hasPrivacyState = true
+  syncPrivacyButton()
+})
 
 iframe.on('UpdateData', async () => {
   const video = document.querySelector<HTMLVideoElement>('video')
   if (video && !Number.isNaN(video.duration)) {
+    if (hasPrivacyState) {
+      syncPrivacyButton()
+    }
+    else if (Date.now() - lastStateRequest > 2000) {
+      lastStateRequest = Date.now()
+      sendPrivacyCommand('request-state')
+    }
+
     iframe.send({
       duration: video.duration,
       currTime: video.currentTime,

--- a/websites/A/AnimeVietSub/metadata.json
+++ b/websites/A/AnimeVietSub/metadata.json
@@ -32,10 +32,10 @@
       "value": true
     },
     {
-      "id": "privateMode",
-      "title": "Chế Độ Riêng Tư",
-      "icon": "fas fa-user-secret",
-      "value": false
+      "id": "privacy-shown",
+      "title": "Privacy Overwrite Button",
+      "icon": "fad fa-eye-low-vision",
+      "value": true
     }
   ]
 }

--- a/websites/A/AnimeVietSub/presence.ts
+++ b/websites/A/AnimeVietSub/presence.ts
@@ -1,7 +1,126 @@
 import { ActivityType, Assets, getTimestamps } from 'premid'
+import {
+  getEpisodeKey,
+  getEpisodePrivacy,
+  isPrivacyCommandMessage,
+  parsePrivacyOverrides,
+  PRIVACY_MESSAGE_SOURCE,
+  toggleEpisodePrivacy,
+} from './privacy.js'
+import { ensurePrivacyButton, removePrivacyButton } from './privacyUi.js'
 
 const presence = new Presence({
   clientId: '1264754447276310599',
+})
+
+const privacyStorageKey = 'pmdAnimeVietSubPrivacyOverrides'
+const privacyFrames = new Set<Window>()
+let currentEpisodeKey = ''
+let currentEpisodePrivacy = false
+let currentPrivacyButtonShown = true
+let lastBroadcastEpisodeKey = ''
+let lastBroadcastPrivacy: boolean | null = null
+let lastBroadcastPrivacyButtonShown: boolean | null = null
+
+function readPrivacyOverrides() {
+  return parsePrivacyOverrides(localStorage.getItem(privacyStorageKey))
+}
+
+function sendPrivacyState(
+  target: Window,
+  privateMode: boolean,
+  privacyButtonShown: boolean,
+): void {
+  target.postMessage({
+    source: PRIVACY_MESSAGE_SOURCE,
+    type: 'state',
+    privateMode,
+    privacyButtonShown,
+  }, '*')
+}
+
+function broadcastPrivacyState(
+  privateMode: boolean,
+  privacyButtonShown: boolean,
+  force = false,
+): void {
+  if (!force
+    && lastBroadcastEpisodeKey === currentEpisodeKey
+    && lastBroadcastPrivacy === privateMode
+    && lastBroadcastPrivacyButtonShown === privacyButtonShown) {
+    return
+  }
+
+  lastBroadcastEpisodeKey = currentEpisodeKey
+  lastBroadcastPrivacy = privateMode
+  lastBroadcastPrivacyButtonShown = privacyButtonShown
+  for (const frame of privacyFrames) {
+    try {
+      sendPrivacyState(frame, privateMode, privacyButtonShown)
+    }
+    catch {
+      privacyFrames.delete(frame)
+    }
+  }
+}
+
+function toggleCurrentEpisodePrivacy(): void {
+  const overrides = toggleEpisodePrivacy(
+    false,
+    currentEpisodeKey,
+    readPrivacyOverrides(),
+  )
+  localStorage.setItem(privacyStorageKey, JSON.stringify(overrides))
+  currentEpisodePrivacy = getEpisodePrivacy(
+    false,
+    currentEpisodeKey,
+    overrides,
+  )
+  if (currentPrivacyButtonShown)
+    ensurePrivacyButton(document, currentEpisodePrivacy, toggleCurrentEpisodePrivacy)
+  broadcastPrivacyState(currentEpisodePrivacy, currentPrivacyButtonShown, true)
+}
+
+async function sendInitialPrivacyState(target: Window): Promise<void> {
+  currentPrivacyButtonShown = await presence.getSetting<boolean>('privacy-shown')
+  currentEpisodeKey = getEpisodeKey(document.location.pathname, document.location.search)
+  currentEpisodePrivacy = getEpisodePrivacy(
+    false,
+    currentEpisodeKey,
+    readPrivacyOverrides(),
+  )
+  sendPrivacyState(target, currentEpisodePrivacy, currentPrivacyButtonShown)
+}
+
+window.addEventListener('message', (event) => {
+  if (!isPrivacyCommandMessage(event.data) || !event.source || !isWatchPage())
+    return
+
+  const target = event.source as Window
+  privacyFrames.add(target)
+
+  if (event.data.type === 'request-state') {
+    void sendInitialPrivacyState(target)
+    return
+  }
+
+  currentEpisodeKey = getEpisodeKey(document.location.pathname, document.location.search)
+
+  if (currentPrivacyButtonShown) {
+    const overrides = toggleEpisodePrivacy(
+      false,
+      currentEpisodeKey,
+      readPrivacyOverrides(),
+    )
+    localStorage.setItem(privacyStorageKey, JSON.stringify(overrides))
+  }
+
+  currentEpisodePrivacy = getEpisodePrivacy(
+    false,
+    currentEpisodeKey,
+    readPrivacyOverrides(),
+  )
+  sendPrivacyState(target, currentEpisodePrivacy, currentPrivacyButtonShown)
 })
 
 let browsingTimestamp = Number.parseInt(sessionStorage.getItem('PMD_browsing_time') || '0', 10)
@@ -153,9 +272,23 @@ presence.on('UpdateData', async () => {
 
   const { pathname, href } = document.location
   const buttons = await presence.getSetting<boolean>('buttons')
-  const privateMode = await presence.getSetting<boolean>('privateMode')
+  const privacyButtonShown = await presence.getSetting<boolean>('privacy-shown')
+  const watchPage = isWatchPage()
+  const detailPage = isDetailPage()
 
-  if (isWatchPage()) {
+  currentPrivacyButtonShown = privacyButtonShown
+  currentEpisodeKey = getEpisodeKey(pathname, document.location.search)
+  currentEpisodePrivacy = watchPage
+    ? getEpisodePrivacy(false, currentEpisodeKey, readPrivacyOverrides())
+    : false
+
+  if (watchPage) {
+    if (privacyButtonShown)
+      ensurePrivacyButton(document, currentEpisodePrivacy, toggleCurrentEpisodePrivacy)
+    else
+      removePrivacyButton(document)
+    broadcastPrivacyState(currentEpisodePrivacy, privacyButtonShown)
+
     const title = getAnimeTitle()
     const episode = getEpisodeName()
     const poster = getAnimePoster()
@@ -246,7 +379,7 @@ presence.on('UpdateData', async () => {
       ]
     }
   }
-  else if (isDetailPage()) {
+  else if (detailPage) {
     const title = getAnimeTitle()
     const poster = getAnimePoster()
 
@@ -302,7 +435,7 @@ presence.on('UpdateData', async () => {
     }
   }
 
-  if (privateMode && (isWatchPage() || isDetailPage())) {
+  if (currentEpisodePrivacy && (watchPage || detailPage)) {
     presenceData.details = 'Đang xem Anime'
     delete presenceData.state
     presenceData.largeImageKey = ActivityAssets.Logo

--- a/websites/A/AnimeVietSub/privacy.ts
+++ b/websites/A/AnimeVietSub/privacy.ts
@@ -1,0 +1,84 @@
+export type PrivacyOverrides = Record<string, boolean>
+
+export const PRIVACY_MESSAGE_SOURCE = 'premid-animevietsub-privacy'
+
+export interface PrivacyCommandMessage {
+  source: typeof PRIVACY_MESSAGE_SOURCE
+  type: 'request-state' | 'toggle'
+}
+
+export interface PrivacyStateMessage {
+  source: typeof PRIVACY_MESSAGE_SOURCE
+  type: 'state'
+  privateMode: boolean
+  privacyButtonShown: boolean
+}
+
+const unsafeKeys = new Set(['__proto__', 'constructor', 'prototype'])
+
+export function isPrivacyCommandMessage(value: unknown): value is PrivacyCommandMessage {
+  if (!value || typeof value !== 'object')
+    return false
+
+  const message = value as Partial<PrivacyCommandMessage>
+  return message.source === PRIVACY_MESSAGE_SOURCE
+    && (message.type === 'request-state' || message.type === 'toggle')
+}
+
+export function isPrivacyStateMessage(value: unknown): value is PrivacyStateMessage {
+  if (!value || typeof value !== 'object')
+    return false
+
+  const message = value as Partial<PrivacyStateMessage>
+  return message.source === PRIVACY_MESSAGE_SOURCE
+    && message.type === 'state'
+    && typeof message.privateMode === 'boolean'
+    && typeof message.privacyButtonShown === 'boolean'
+}
+
+export function parsePrivacyOverrides(raw: string | null): PrivacyOverrides {
+  try {
+    const parsed: unknown = JSON.parse(raw ?? '{}')
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))
+      return {}
+
+    const overrides: PrivacyOverrides = {}
+    for (const [key, value] of Object.entries(parsed)) {
+      if (unsafeKeys.has(key) || typeof value !== 'boolean')
+        return {}
+      overrides[key] = value
+    }
+    return overrides
+  }
+  catch {
+    return {}
+  }
+}
+
+export function getEpisodeKey(pathname: string, search: string): string {
+  const normalizedPath = pathname.replace(/\/+$/, '') || '/'
+  const episode = new URLSearchParams(search).get('tap')
+
+  return episode
+    ? `${normalizedPath}?tap=${encodeURIComponent(episode)}`
+    : normalizedPath
+}
+
+export function getEpisodePrivacy(
+  globalPrivacy: boolean,
+  episodeKey: string,
+  overrides: PrivacyOverrides,
+): boolean {
+  return overrides[episodeKey] ?? globalPrivacy
+}
+
+export function toggleEpisodePrivacy(
+  globalPrivacy: boolean,
+  episodeKey: string,
+  overrides: PrivacyOverrides,
+): PrivacyOverrides {
+  return {
+    ...overrides,
+    [episodeKey]: !getEpisodePrivacy(globalPrivacy, episodeKey, overrides),
+  }
+}

--- a/websites/A/AnimeVietSub/privacyUi.ts
+++ b/websites/A/AnimeVietSub/privacyUi.ts
@@ -1,0 +1,218 @@
+const buttonId = 'pmd-animevietsub-privacy'
+const styleId = 'pmd-animevietsub-privacy-style'
+
+const controlBarSelectors = [
+  '.vjs-control-bar',
+  '.jw-controlbar .jw-button-container',
+  '.plyr__controls',
+  '.dplayer-icons-right',
+  '.art-control-right',
+  '.media-control-right-panel',
+  '.mejs__controls',
+  '.shaka-controls-button-panel',
+]
+
+const settingsControlSelectors = [
+  '.vjs-settings-button',
+  '.jw-icon-settings',
+  '[data-plyr="settings"]',
+  '.dplayer-setting',
+  '.art-control-setting',
+  '.media-control-button[data-settings]',
+  '.mejs__settings-button',
+  '.shaka-overflow-menu-button',
+  '[aria-label*="Settings"]',
+  '[title*="Settings"]',
+  '[aria-label*="Cài đặt"]',
+  '[title*="Cài đặt"]',
+]
+
+const pictureInPictureControlSelectors = [
+  '.vjs-picture-in-picture-control',
+  '.jw-icon-pip',
+  '[data-plyr="pip"]',
+  '.dplayer-pip-icon',
+  '.art-control-pip',
+  '.media-control-button[data-pip]',
+  '.mejs__picture-in-picture-button',
+  '.shaka-pip-button',
+  '[aria-label*="Picture in Picture"]',
+  '[aria-label*="Picture-in-Picture"]',
+  '[title*="Picture in Picture"]',
+  '[title*="Picture-in-Picture"]',
+]
+
+const actionControlClass = /(?:^|[-_])(?:settings?|picture|pip|fullscreen|quality|captions?|subtitles?|overflow|menu)(?:$|[-_])/i
+
+const eyeIcon = `
+  <svg data-private="false" aria-hidden="true" viewBox="0 0 576 512">
+    <path fill="currentColor" d="M288 32c-80.8 0-145.5 36.8-192.6 80.6C48.6 156 17.3 208 2.5 243.7a32 32 0 0 0 0 24.6C17.3 304 48.6 356 95.4 399.4 142.5 443.2 207.2 480 288 480s145.5-36.8 192.6-80.6c46.8-43.5 78.1-95.4 93-131.1a32 32 0 0 0 0-24.6C558.7 208 527.4 156 480.6 112.6 433.5 68.8 368.8 32 288 32Zm0 336a112 112 0 1 1 0-224 112 112 0 0 1 0 224Z"/>
+  </svg>
+  <svg data-private="true" aria-hidden="true" viewBox="0 0 640 512">
+    <path fill="currentColor" d="M38.8 5.1A24 24 0 0 0 9.2 42.9l592 464a24 24 0 1 0 29.6-37.8L525.6 386.7c39.6-40.6 66.4-86.1 79.9-118.4a32 32 0 0 0 0-24.6c-14.9-35.7-46.2-87.7-93-131.1C465.5 68.8 400.8 32 320 32c-68.2 0-125 26.3-169.3 60.8L38.8 5.1Zm184.3 144.4A143.4 143.4 0 0 1 320 112a144 144 0 0 1 126.6 212.7L408 294.5a96 96 0 0 0-84-134.4c-5.8-.2-9.2 6.1-7.4 11.7a64 64 0 0 1-3.3 48.6l-90.2-70.9ZM373 389.9A144 144 0 0 1 176 256c0-6.9.5-13.6 1.4-20.2l-94.3-74.3C60.3 191.2 44 220.8 34.5 243.7a32 32 0 0 0 0 24.6c14.9 35.7 46.2 87.7 93 131.1C174.5 443.2 239.2 480 320 480c47.8 0 89.9-12.9 126.2-32.5L373 389.9Z"/>
+  </svg>`
+
+function ensureStyles(document: Document): void {
+  if (document.getElementById(styleId))
+    return
+
+  const style = document.createElement('style')
+  style.id = styleId
+  style.textContent = `
+    .pmd-avs-privacy-host { position: relative !important; }
+    .pmd-avs-privacy-button {
+      align-items: center; box-sizing: border-box; color: inherit; cursor: pointer;
+      display: inline-flex; justify-content: center; position: relative;
+    }
+    .pmd-avs-privacy-button:focus-visible { outline: 2px solid #fff; outline-offset: -3px; }
+    .pmd-avs-privacy-button svg {
+      display: none; height: 100%; pointer-events: none; transform: scale(.6); width: 100%;
+    }
+    .pmd-avs-privacy-button[aria-pressed="false"] svg[data-private="false"],
+    .pmd-avs-privacy-button[aria-pressed="true"] svg[data-private="true"] { display: block; }
+    .pmd-avs-privacy-button--fallback {
+      background: rgba(0, 0, 0, .58); border: 0; border-radius: 3px; bottom: 8px;
+      color: #fff; height: 36px; padding: 7px; position: absolute; right: 48px;
+      width: 40px; z-index: 2147483646;
+    }
+    .pmd-avs-privacy-button--fallback svg { height: 22px; transform: none; width: 22px; }
+  `
+  document.head?.append(style)
+}
+
+function getPlayerHost(video: HTMLVideoElement): HTMLElement | null {
+  return video.closest<HTMLElement>(
+    '.video-js, .jwplayer, .plyr, .dplayer, .artplayer-app, .media-player, .mejs__container, .shaka-video-container, [class*="player"], [id*="player"]',
+  ) ?? video.parentElement
+}
+
+function getControlBar(document: Document, host: HTMLElement | null): HTMLElement | null {
+  for (const selector of controlBarSelectors) {
+    const controls = host?.querySelector<HTMLElement>(selector)
+      ?? document.querySelector<HTMLElement>(selector)
+    if (controls)
+      return controls
+  }
+  return null
+}
+
+function findControl(
+  controls: HTMLElement,
+  selectors: string[],
+): HTMLElement | null {
+  for (const selector of selectors) {
+    const control = controls.querySelector<HTMLElement>(selector)
+    if (control)
+      return control
+  }
+  return null
+}
+
+function getDirectControl(
+  controls: HTMLElement,
+  control: HTMLElement | null,
+): HTMLElement | null {
+  while (control?.parentElement && control.parentElement !== controls)
+    control = control.parentElement
+  return control?.parentElement === controls ? control : null
+}
+
+function mountPrivacyButton(
+  controls: HTMLElement | null,
+  mount: HTMLElement,
+  button: HTMLButtonElement,
+): HTMLElement | null {
+  if (!controls) {
+    if (button.parentElement !== mount)
+      mount.append(button)
+    return null
+  }
+
+  const settingsControl = findControl(controls, settingsControlSelectors)
+  const pictureInPictureControl = findControl(
+    controls,
+    pictureInPictureControlSelectors,
+  )
+  const settings = getDirectControl(controls, settingsControl)
+  const pictureInPicture = getDirectControl(controls, pictureInPictureControl)
+  const nativeControl = settingsControl ?? pictureInPictureControl
+
+  if (pictureInPicture) {
+    if (button.parentElement !== controls
+      || button.nextElementSibling !== pictureInPicture) {
+      controls.insertBefore(button, pictureInPicture)
+    }
+    return nativeControl
+  }
+
+  const nextControl = settings?.nextElementSibling
+  if (nextControl && nextControl !== button)
+    controls.insertBefore(button, nextControl)
+  else if (button.parentElement !== controls)
+    controls.append(button)
+  return nativeControl
+}
+
+function syncPrivacyButtonAppearance(
+  button: HTMLButtonElement,
+  nativeControl: HTMLElement | null,
+): void {
+  const nativeClasses = nativeControl?.className
+    .split(/\s+/)
+    .filter(className => className && !actionControlClass.test(className))
+    ?? []
+
+  button.className = [...new Set([
+    ...nativeClasses,
+    'pmd-avs-privacy-button',
+  ])].join(' ')
+}
+
+export function setPrivacyButtonState(button: HTMLButtonElement, privateMode: boolean): void {
+  const label = 'Chế độ riêng tư'
+
+  button.ariaPressed = String(privateMode)
+  button.ariaLabel = label
+  button.title = label
+}
+
+export function removePrivacyButton(document: Document): void {
+  document.getElementById(buttonId)?.remove()
+}
+
+export function ensurePrivacyButton(
+  document: Document,
+  privateMode: boolean,
+  onToggle: () => void,
+): HTMLButtonElement | null {
+  const video = document.querySelector<HTMLVideoElement>('video')
+  if (!video)
+    return null
+
+  ensureStyles(document)
+  const host = getPlayerHost(video)
+  const controls = getControlBar(document, host)
+  const mount = controls ?? host
+  if (!mount)
+    return null
+
+  host?.classList.add('pmd-avs-privacy-host')
+  let button = document.getElementById(buttonId) as HTMLButtonElement | null
+  if (!button) {
+    button = document.createElement('button')
+    button.id = buttonId
+    button.type = 'button'
+    button.innerHTML = eyeIcon
+    button.addEventListener('click', (event) => {
+      event.preventDefault()
+      event.stopPropagation()
+      onToggle()
+    })
+  }
+
+  const nativeControl = mountPrivacyButton(controls, mount, button)
+  syncPrivacyButtonAppearance(button, nativeControl)
+  button.classList.toggle('pmd-avs-privacy-button--fallback', !nativeControl)
+  setPrivacyButtonState(button, privateMode)
+  return button
+}


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

### 1. Updated Privacy Settings

<img width="418" height="601" alt="Updated AnimeVietSub privacy settings" src="https://github.com/user-attachments/assets/b87b4f81-8f25-4c38-95aa-f0485a0becd7" />

### 2. Added Privacy Button

<img width="793" height="109" alt="AnimeVietSub privacy button displayed in the activity presence" src="https://github.com/user-attachments/assets/22f3cd3f-8bb5-4f36-b6e4-0d5e3da1f83a" />



</details>
