### PR TITLE
feat(SoundScout): add activity

### DIFF
--- a/websites/S/SoundScout/metadata.json
+++ b/websites/S/SoundScout/metadata.json
@@ -13,7 +13,7 @@
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*soundscout[.]com[/]",
   "version": "1.0.0",
   "logo": "https://i.imgur.com/qk0dkl9.png",
-  "thumbnail": "https://i.imgur.com/zURSUfT.jpeg",
+  "thumbnail": "https://i.imgur.com/DruVHwC.jpeg",
   "color": "#F1D383",
   "category": "music",
   "tags": [

--- a/websites/S/SoundScout/metadata.json
+++ b/websites/S/SoundScout/metadata.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.17",
+  "apiVersion": 1,
+  "author": {
+    "id": "239809113125552129",
+    "name": "Snupai"
+  },
+  "service": "SoundScout",
+  "description": {
+    "en": "SoundScout provides claim-free music licensing for creators, streamers, and brands."
+  },
+  "url": "soundscout.com",
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*soundscout[.]com[/]",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/qk0dkl9.png",
+  "thumbnail": "https://i.imgur.com/zURSUfT.jpeg",
+  "color": "#F1D383",
+  "category": "music",
+  "tags": [
+    "streaming",
+    "royalty-free",
+    "creator"
+  ]
+}

--- a/websites/S/SoundScout/presence.ts
+++ b/websites/S/SoundScout/presence.ts
@@ -25,6 +25,9 @@ presence.on('UpdateData', async () => {
     type: ActivityType.Listening,
   }
   const { href, pathname } = document.location
+
+  // SoundScout exposes metadata through Media Session, while playback timing
+  // can fall back to the controls in its persistent player bar.
   const playerBar = document.querySelector<HTMLElement>('[data-testid="player-bar"]')
   const audio = playerBar?.querySelector<HTMLAudioElement>('audio')
     ?? document.querySelector<HTMLAudioElement>('audio')
@@ -37,6 +40,7 @@ presence.on('UpdateData', async () => {
     const isPlaying = navigator.mediaSession.playbackState === 'playing'
       || Boolean(audio && !audio.paused)
 
+    // Clear paused tracks so an abandoned tab does not leave a stale activity.
     if (!isPlaying) {
       presence.clearActivity()
       return
@@ -56,6 +60,7 @@ presence.on('UpdateData', async () => {
     presenceData.smallImageKey = Assets.Play
     presenceData.smallImageText = 'Playing'
 
+    // Replace the browsing timer with synchronized progress for active media.
     delete presenceData.startTimestamp
 
     const currentTime = audio?.currentTime
@@ -106,6 +111,7 @@ presence.on('UpdateData', async () => {
         break
       }
       case pathname.startsWith('/player/explore/'): {
+        // Detail routes can contain UUIDs, so prefer the rendered page heading.
         const pathParts = pathname.split('/').filter(Boolean)
         const category = pathParts[2] ?? 'music'
         const selection = pathParts[3]
@@ -136,6 +142,8 @@ presence.on('UpdateData', async () => {
           '[data-testid="artist-hero"]',
         )
         const artistName = artistHero?.querySelector('h1')?.textContent?.trim()
+
+        // Artist portraits are CSS backgrounds rather than image elements.
         const artistImage = getBackgroundImageUrl(
           artistHero?.querySelector<HTMLElement>(
             '[aria-hidden="true"] [style*="background-image"]',

--- a/websites/S/SoundScout/presence.ts
+++ b/websites/S/SoundScout/presence.ts
@@ -1,0 +1,118 @@
+import { ActivityType, Assets, getTimestamps } from 'premid'
+
+const presence = new Presence({
+  clientId: '1535996328230780938',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://i.imgur.com/qk0dkl9.png',
+}
+
+presence.on('UpdateData', async () => {
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+    type: ActivityType.Listening,
+  }
+  const { href, pathname } = document.location
+  const playerBar = document.querySelector<HTMLElement>('[data-testid="player-bar"]')
+  const audio = playerBar?.querySelector<HTMLAudioElement>('audio')
+    ?? document.querySelector<HTMLAudioElement>('audio')
+  const seekSlider = playerBar?.querySelector<HTMLInputElement>(
+    'input[aria-label="Seek"]',
+  )
+  const metadata = navigator.mediaSession.metadata
+
+  if (metadata?.title) {
+    const isPlaying = navigator.mediaSession.playbackState === 'playing'
+      || Boolean(audio && !audio.paused)
+    const trackUrl = document.querySelector<HTMLAnchorElement>(
+      '[data-testid="player-bar"] a[href^="/player/music/"]',
+    )?.href
+    const artistUrl = document.querySelector<HTMLAnchorElement>(
+      '[data-testid="player-bar"] a[href^="/player/artists/"]',
+    )?.href
+
+    presenceData.details = metadata.title
+    presenceData.state = metadata.artist || 'Unknown artist'
+    presenceData.largeImageKey = metadata.artwork[0]?.src
+      || ActivityAssets.Logo
+    presenceData.smallImageKey = isPlaying ? Assets.Play : Assets.Pause
+    presenceData.smallImageText = isPlaying ? 'Playing' : 'Paused'
+
+    delete presenceData.startTimestamp
+
+    const currentTime = audio?.currentTime
+      ?? seekSlider?.valueAsNumber
+      ?? Number.NaN
+    const audioDuration = audio?.duration
+    const duration = audioDuration !== undefined
+      && Number.isFinite(audioDuration)
+      ? audioDuration
+      : Number(seekSlider?.max)
+
+    if (
+      isPlaying
+      && Number.isFinite(currentTime)
+      && Number.isFinite(duration)
+      && duration > 0
+    ) {
+      [presenceData.startTimestamp, presenceData.endTimestamp]
+        = getTimestamps(currentTime, duration)
+    }
+
+    if (trackUrl) {
+      presenceData.detailsUrl = trackUrl
+      presenceData.largeImageUrl = trackUrl
+    }
+    if (artistUrl)
+      presenceData.stateUrl = artistUrl
+  }
+  else {
+    presenceData.details = 'Browsing SoundScout'
+
+    switch (true) {
+      case pathname === '/player': {
+        presenceData.state = 'Exploring music'
+        break
+      }
+      case pathname.includes('/search'): {
+        presenceData.state = 'Searching for music'
+        break
+      }
+      case pathname.includes('/explore/genres/'):
+      case pathname.includes('/explore/moods/'):
+      case pathname.includes('/explore/activities/'):
+      case pathname.includes('/explore/instruments/'): {
+        presenceData.state = `Exploring ${pathname.split('/').at(-1)?.replaceAll('-', ' ')}`
+        break
+      }
+      case pathname.includes('/music/'): {
+        presenceData.state = 'Viewing a track'
+        break
+      }
+      case pathname.includes('/artists/'): {
+        presenceData.state = 'Viewing an artist'
+        break
+      }
+      case pathname.includes('/releases/'): {
+        presenceData.state = 'Viewing a release'
+        break
+      }
+      case pathname.includes('/playlists/'): {
+        presenceData.state = 'Viewing a playlist'
+        break
+      }
+      default: {
+        presenceData.state = 'Exploring music'
+      }
+    }
+
+    presenceData.detailsUrl = href
+  }
+
+  if (presenceData.details)
+    presence.setActivity(presenceData)
+  else presence.clearActivity()
+})

--- a/websites/S/SoundScout/presence.ts
+++ b/websites/S/SoundScout/presence.ts
@@ -101,6 +101,10 @@ presence.on('UpdateData', async () => {
         presenceData.state = 'Searching for music'
         break
       }
+      case pathname === '/player/my-library': {
+        presenceData.state = 'Browsing favorites'
+        break
+      }
       case pathname.startsWith('/player/explore/'): {
         const pathParts = pathname.split('/').filter(Boolean)
         const category = pathParts[2] ?? 'music'

--- a/websites/S/SoundScout/presence.ts
+++ b/websites/S/SoundScout/presence.ts
@@ -13,6 +13,11 @@ function getBackgroundImageUrl(element: HTMLElement | null) {
   return element?.style.backgroundImage.match(/^url\(["']?(.*?)["']?\)$/)?.[1]
 }
 
+function getPageName() {
+  return document.querySelector('main h1')?.textContent?.trim()
+    || document.title.split('·')[0]?.trim()
+}
+
 presence.on('UpdateData', async () => {
   const presenceData: PresenceData = {
     largeImageKey: ActivityAssets.Logo,
@@ -96,11 +101,26 @@ presence.on('UpdateData', async () => {
         presenceData.state = 'Searching for music'
         break
       }
-      case pathname.includes('/explore/genres/'):
-      case pathname.includes('/explore/moods/'):
-      case pathname.includes('/explore/activities/'):
-      case pathname.includes('/explore/instruments/'): {
-        presenceData.state = `Exploring ${pathname.split('/').at(-1)?.replaceAll('-', ' ')}`
+      case pathname.startsWith('/player/explore/'): {
+        const pathParts = pathname.split('/').filter(Boolean)
+        const category = pathParts[2] ?? 'music'
+        const selection = pathParts[3]
+        const collectionTypes: Record<string, string> = {
+          activities: 'activity',
+          genres: 'genre',
+          instruments: 'instrument',
+          keys: 'key',
+          moods: 'mood',
+          themes: 'theme',
+        }
+        const pathLabel = selection
+          ? decodeURIComponent(selection).replaceAll('-', ' ')
+          : undefined
+        const collectionName = getPageName() || pathLabel
+
+        presenceData.state = selection && collectionName
+          ? `Browsing ${collectionTypes[category] ?? category}: ${collectionName}`
+          : `Browsing ${category}`
         break
       }
       case pathname.includes('/music/'): {
@@ -132,8 +152,18 @@ presence.on('UpdateData', async () => {
         presenceData.state = 'Viewing a release'
         break
       }
-      case pathname.includes('/playlists/'): {
-        presenceData.state = 'Viewing a playlist'
+      case pathname === '/player/playlists':
+      case pathname === '/player/my-playlists': {
+        presenceData.state = 'Browsing playlists'
+        break
+      }
+      case pathname.startsWith('/player/playlists/'):
+      case pathname.startsWith('/player/my-playlists/'): {
+        const playlistName = getPageName()
+
+        presenceData.state = playlistName
+          ? `Browsing playlist: ${playlistName}`
+          : 'Browsing a playlist'
         break
       }
       default: {

--- a/websites/S/SoundScout/presence.ts
+++ b/websites/S/SoundScout/presence.ts
@@ -124,7 +124,6 @@ presence.on('UpdateData', async () => {
 
         if (artistImage) {
           presenceData.largeImageKey = artistImage
-          presenceData.largeImageText = artistName
           presenceData.largeImageUrl = href
         }
         break

--- a/websites/S/SoundScout/presence.ts
+++ b/websites/S/SoundScout/presence.ts
@@ -27,6 +27,12 @@ presence.on('UpdateData', async () => {
   if (metadata?.title) {
     const isPlaying = navigator.mediaSession.playbackState === 'playing'
       || Boolean(audio && !audio.paused)
+
+    if (!isPlaying) {
+      presence.clearActivity()
+      return
+    }
+
     const trackUrl = document.querySelector<HTMLAnchorElement>(
       '[data-testid="player-bar"] a[href^="/player/music/"]',
     )?.href
@@ -38,8 +44,8 @@ presence.on('UpdateData', async () => {
     presenceData.state = metadata.artist || 'Unknown artist'
     presenceData.largeImageKey = metadata.artwork[0]?.src
       || ActivityAssets.Logo
-    presenceData.smallImageKey = isPlaying ? Assets.Play : Assets.Pause
-    presenceData.smallImageText = isPlaying ? 'Playing' : 'Paused'
+    presenceData.smallImageKey = Assets.Play
+    presenceData.smallImageText = 'Playing'
 
     delete presenceData.startTimestamp
 
@@ -53,8 +59,7 @@ presence.on('UpdateData', async () => {
       : Number(seekSlider?.max)
 
     if (
-      isPlaying
-      && Number.isFinite(currentTime)
+      Number.isFinite(currentTime)
       && Number.isFinite(duration)
       && duration > 0
     ) {
@@ -65,6 +70,12 @@ presence.on('UpdateData', async () => {
     if (trackUrl) {
       presenceData.detailsUrl = trackUrl
       presenceData.largeImageUrl = trackUrl
+      presenceData.buttons = [
+        {
+          label: 'Listen on SoundScout',
+          url: trackUrl,
+        },
+      ]
     }
     if (artistUrl)
       presenceData.stateUrl = artistUrl

--- a/websites/S/SoundScout/presence.ts
+++ b/websites/S/SoundScout/presence.ts
@@ -9,6 +9,10 @@ enum ActivityAssets {
   Logo = 'https://i.imgur.com/qk0dkl9.png',
 }
 
+function getBackgroundImageUrl(element: HTMLElement | null) {
+  return element?.style.backgroundImage.match(/^url\(["']?(.*?)["']?\)$/)?.[1]
+}
+
 presence.on('UpdateData', async () => {
   const presenceData: PresenceData = {
     largeImageKey: ActivityAssets.Logo,
@@ -104,7 +108,25 @@ presence.on('UpdateData', async () => {
         break
       }
       case pathname.includes('/artists/'): {
-        presenceData.state = 'Viewing an artist'
+        const artistHero = document.querySelector<HTMLElement>(
+          '[data-testid="artist-hero"]',
+        )
+        const artistName = artistHero?.querySelector('h1')?.textContent?.trim()
+        const artistImage = getBackgroundImageUrl(
+          artistHero?.querySelector<HTMLElement>(
+            '[aria-hidden="true"] [style*="background-image"]',
+          ) ?? null,
+        )
+
+        presenceData.state = artistName
+          ? `Viewing ${artistName}`
+          : 'Viewing an artist'
+
+        if (artistImage) {
+          presenceData.largeImageKey = artistImage
+          presenceData.largeImageText = artistName
+          presenceData.largeImageUrl = href
+        }
         break
       }
       case pathname.includes('/releases/'): {


### PR DESCRIPTION
## Description

Adds a new SoundScout activity that displays the currently playing track, artist, artwork, and synchronized playback progress on Discord. It also provides a direct "Listen on SoundScout" button and contextual browsing states for artists, explore, themes, genres, moods, playlists, and favorites.

The activity reads SoundScout's Media Session metadata and falls back to the player's seek slider for current position and duration because the site does not expose a persistent page-level audio element. It clears the activity when playback is paused so a stale listening status is not left on Discord.

## Acknowledgements

- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Validation

- `npx pmd build SoundScout --validate`
- `npx pmd check-dns SoundScout`
- `npx eslint websites/S/SoundScout --no-cache`

The repository-wide `npm run lint` command was also executed. It currently reports pre-existing errors outside SoundScout; targeted linting for SoundScout passes.

## Screenshots

<details>
<summary>Proof showing the activity working as expected</summary>

### Playing — Waiting for the Dream to End

![SoundScout playing — Waiting for the Dream to End](https://i.imgur.com/ZtpAxCo.jpeg)

### Playing — FEAR

![SoundScout playing — FEAR](https://i.imgur.com/6eezvsp.jpeg)

</details>

<details>
<summary>Proof of contextual browsing states (11 screenshots)</summary>

[View the complete proof album on Imgur](https://imgur.com/a/RELiYw9)

### Artist detail — Viewing Cozi Zuehlsdorff

![SoundScout artist browsing state — Viewing Cozi Zuehlsdorff](https://i.imgur.com/XQcQdb4.jpeg)

### Explore — Exploring music

![SoundScout explore browsing state — Exploring music](https://i.imgur.com/z1lDsUv.jpeg)

### Themes index — Browsing themes

![SoundScout themes index browsing state](https://i.imgur.com/XWKoHNk.jpeg)

### Theme detail — Browsing theme: Science

![SoundScout theme detail browsing state — Science](https://i.imgur.com/2zcQ6Ww.jpeg)

### Genres index — Browsing genres

![SoundScout genres index browsing state](https://i.imgur.com/4WtTSB9.jpeg)

### Genre detail — Browsing genre: LoFi

![SoundScout genre detail browsing state — LoFi](https://i.imgur.com/CyxiHvH.jpeg)

### Moods index — Browsing moods

![SoundScout moods index browsing state](https://i.imgur.com/6R72Atv.jpeg)

### Mood detail — Browsing mood: Exciting

![SoundScout mood detail browsing state — Exciting](https://i.imgur.com/aL4X2w6.jpeg)

### Playlists index — Browsing playlists

![SoundScout playlists index browsing state](https://i.imgur.com/kYJ8JGa.jpeg)

### Favorites — Browsing favorites

![SoundScout favorites browsing state](https://i.imgur.com/TzO62pV.jpeg)

### Playlist detail — Browsing playlist: Rhythm Games

![SoundScout playlist detail browsing state — Rhythm Games](https://i.imgur.com/xCS7kI5.jpeg)

</details>
