### PR TITLE
feat(HeiwaStream): improve navigation and episode formatting

### DIFF
--- a/websites/H/HeiwaStream/metadata.json
+++ b/websites/H/HeiwaStream/metadata.json
@@ -11,11 +11,10 @@
     "fr": "Parcourez les films, séries et animés disponibles sur HeiwaStream."
   },
   "url": [
-    "heiwastream.fr",
-    "zelyon.xyz"
+    "heiwastream.fr"
   ],
-  "regExp": "^https?[:][/][/](?:www[.])?(?:heiwastream[.]fr|zelyon[.]xyz)(?:[/]|$)",
-  "version": "1.0.2",
+  "regExp": "^https?[:][/][/](?:www[.])?heiwastream[.]fr(?:[/]|$)",
+  "version": "1.0.3",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/H/HeiwaStream/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/H/HeiwaStream/assets/thumbnail.png",
   "color": "#e6a91a",

--- a/websites/H/HeiwaStream/presence.ts
+++ b/websites/H/HeiwaStream/presence.ts
@@ -60,7 +60,6 @@ function mettreAJourActivite(): void {
       presenceData.detailsUrl = pageUrl
       presenceData.stateUrl = pageUrl
       presenceData.largeImageUrl = pageUrl
-      presenceData.buttons = [{ label: 'Open HeiwaStream', url: pageUrl }]
     }
 
     presence.setActivity(presenceData)

--- a/websites/H/HeiwaStream/presence.ts
+++ b/websites/H/HeiwaStream/presence.ts
@@ -13,8 +13,6 @@ enum ActivityAssets {
 const supportedHosts = new Set([
   'heiwastream.fr',
   'www.heiwastream.fr',
-  'zelyon.xyz',
-  'www.zelyon.xyz',
 ])
 
 function lireNombre(value: string | undefined): number | null {
@@ -46,6 +44,7 @@ function mettreAJourActivite(): void {
   const title = data.premidWatching
 
   if (!title) {
+    const pageUrl = lireUrlHeiwa(data.premidPageUrl) ?? lireUrlHeiwa(document.location.href)
     const presenceData: PresenceData = {
       name: 'HeiwaStream',
       type: ActivityType.Playing,
@@ -56,6 +55,14 @@ function mettreAJourActivite(): void {
       smallImageText: 'Navigation',
       startTimestamp: lireNombre(data.premidSince) ?? browsingTimestamp,
     }
+
+    if (pageUrl) {
+      presenceData.detailsUrl = pageUrl
+      presenceData.stateUrl = pageUrl
+      presenceData.largeImageUrl = pageUrl
+      presenceData.buttons = [{ label: 'Open HeiwaStream', url: pageUrl }]
+    }
+
     presence.setActivity(presenceData)
     return
   }
@@ -63,7 +70,10 @@ function mettreAJourActivite(): void {
   const playbackState = data.premidState ?? 'playing'
   const position = lireNombre(data.premidPosition)
   const duration = lireNombre(data.premidDuration)
-  const metadata = [data.premidSeason, data.premidEpisode, data.premidLanguage]
+  const episode = [data.premidSeason, data.premidEpisode]
+    .filter(Boolean)
+    .join('')
+  const metadata = [episode || null, data.premidLanguage]
     .filter(Boolean)
     .join(' · ')
   const stateLabel = playbackState === 'paused'


### PR DESCRIPTION
## What changed

- remove the retired `zelyon.xyz` domain from the activity metadata, URL matcher, and trusted host list
- add an `Open HeiwaStream` button while browsing, linked to the sanitized current page URL exposed by the website
- make the activity details, state, and large image open the current HeiwaStream page
- display season and episode as a compact value such as `S01E01` instead of `S01 · E01`
- bump the activity version to `1.0.3`

## Why

`zelyon.xyz` is no longer served and only redirects to HeiwaStream. Browsing presences had no direct action to return to the page, and season/episode metadata was visually split despite representing one episode coordinate.

## User impact

The Rich Presence now links back to the exact public page being browsed and presents episode coordinates in the familiar compact format.

## Validation

- `npx pmd build "HeiwaStream" --validate`
- verified that no `zelyon` reference remains under `websites/H/HeiwaStream`
