### PR TITLE
fix(HeiwaStream): fix URL metadata

### DIFF
--- a/websites/H/HeiwaStream/metadata.json
+++ b/websites/H/HeiwaStream/metadata.json
@@ -10,9 +10,7 @@
     "en": "Browse movies, series and anime available on HeiwaStream.",
     "fr": "Parcourez les films, séries et animés disponibles sur HeiwaStream."
   },
-  "url": [
-    "heiwastream.fr"
-  ],
+  "url": "heiwastream.fr",
   "regExp": "^https?[:][/][/](?:www[.])?heiwastream[.]fr(?:[/]|$)",
   "version": "1.0.3",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/H/HeiwaStream/assets/logo.png",


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Fixes the `url` field in the metadata. Version not bumped because the Activity failed to be pushed

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)