### PR TITLE
feat(Netbattle): add presence

### DIFF
--- a/websites/N/Netbattle/metadata.json
+++ b/websites/N/Netbattle/metadata.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.17",
+  "apiVersion": 1,
+  "author": {
+    "id": "840739493622841377",
+    "name": "hmksenpai"
+  },
+  "service": "Netbattle",
+  "description": {
+    "en": "A competitive multiplayer network engineering game. Battle opponents in network troubleshooting, syntax sprint and DDoS defense challenges."
+  },
+  "url": "netbattle.vercel.app",
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*netbattle[.]vercel[.]app[/]",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/hLiMa6j.png",
+  "thumbnail": "https://i.imgur.com/vIEnmNt.png",
+  "color": "#FF6B35",
+  "category": "games",
+  "tags": [
+    "game",
+    "multiplayer",
+    "networking"
+  ]
+}

--- a/websites/N/Netbattle/presence.ts
+++ b/websites/N/Netbattle/presence.ts
@@ -1,0 +1,76 @@
+const presence = new Presence({
+  clientId: '1537532267759538186',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://i.imgur.com/hLiMa6j.png',
+}
+
+const MODE_NAMES: Record<string, string> = {
+  ranked: 'Ranked',
+  casual: 'Casual',
+}
+
+const GAME_NAMES: Record<string, string> = {
+  speedrun: 'Speed-Run Troubleshooting',
+  syntax: 'Syntax Sprint',
+  ddos: 'DDoS Defense',
+  crimp: 'Opération Câble',
+  blackout: 'Blackout',
+}
+
+presence.on('UpdateData', async () => {
+  const { pathname } = document.location
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+  }
+
+  const beacon = document.querySelector('[data-nb-state]')
+
+  if (pathname === '/' || pathname === '') {
+    const nbState = beacon?.getAttribute('data-nb-state')
+    const mode = beacon?.getAttribute('data-nb-mode') ?? ''
+    const game = beacon?.getAttribute('data-nb-game') ?? ''
+
+    if (nbState === 'matchmaking') {
+      presenceData.details = 'Recherche d\u2019adversaire'
+      presenceData.state = `${MODE_NAMES[mode] ?? mode} - ${GAME_NAMES[game] ?? game}`
+    }
+    else if (nbState === 'match') {
+      presenceData.details = GAME_NAMES[game] ?? 'Partie en cours'
+      const opponent = document.querySelector('[data-nb-opponent]')?.getAttribute('data-nb-opponent')
+      presenceData.state = opponent ? `Adversaire : ${opponent}` : (MODE_NAMES[mode] ?? 'En match')
+    }
+    else {
+      presenceData.details = 'Browsing the main hub'
+    }
+  }
+  else if (pathname === '/practice') {
+    presenceData.details = 'Browsing training modes'
+  }
+  else if (pathname === '/practice/sprint') {
+    presenceData.details = 'Practicing Syntax Sprint'
+  }
+  else if (pathname === '/practice/vlsm') {
+    presenceData.details = 'Practicing VLSM addressing'
+  }
+  else if (pathname.startsWith('/auth/login')) {
+    presenceData.details = 'Logging in'
+  }
+  else if (pathname.startsWith('/auth/register')) {
+    presenceData.details = 'Creating an account'
+  }
+  else if (pathname.startsWith('/auth/reset-password')) {
+    presenceData.details = 'Resetting password'
+  }
+  else if (pathname.startsWith('/auth/update-password')) {
+    presenceData.details = 'Updating password'
+  }
+  else {
+    presenceData.details = 'Exploring Netbattle'
+  }
+
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Adds a PreMiD presence for Netbattle (`netbattle.vercel.app`), a competitive
network game (Next.js 16 / React 19 / TypeScript).

The presence shows the player's current state on the main hub:
- **Matchmaking** : "Recherche d'adversaire" + selected mode/game (Ranked/Casual,
  Speed-Run Troubleshooting, Syntax Sprint, DDoS Defense, Operation Cable, Blackout)
- **In match** : current game details + "Adversaire : X" (opponent pseudonym)
- **Practice** routes : `/practice`, `/practice/sprint`, `/practice/vlsm`
- Elsewhere : "Browsing the main hub"

The activity is read from a DOM beacon (`data-nb-state`, `data-nb-mode`,
`data-nb-game`, `data-nb-opponent`) exposed by the app.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="1851" height="744" alt="Capture d&#39;écran 2026-08-13 213614" src="https://github.com/user-attachments/assets/52b531f3-5d27-4c1e-aab4-eaf91f3f5f09" />
<img width="379" height="157" alt="Capture d&#39;écran 2026-08-13 213602" src="https://github.com/user-attachments/assets/89f2badf-9aa4-4b52-8ee7-356468a7d842" /><br>

<img width="706" height="514" alt="Capture d&#39;écran 2026-08-13 213625" src="https://github.com/user-attachments/assets/c36619d0-750f-485e-b1de-49eb0b2dfb49" />
<img width="357" height="168" alt="Capture d&#39;écran 2026-08-13 213633" src="https://github.com/user-attachments/assets/ed0cf2fd-bf7a-4f46-bd66-56cb0b11f9a6" /><br>

<img width="1041" height="690" alt="Capture d&#39;écran 2026-08-13 213654" src="https://github.com/user-attachments/assets/00b28344-f2a0-4336-942c-5a3b7835c51c" />
<img width="350" height="151" alt="Capture d&#39;écran 2026-08-13 213649" src="https://github.com/user-attachments/assets/69af02bd-660d-4a0b-b107-795dd4445844" />



</details>
