### PR TITLE
feat(Brawl Stars Championship): add activity

### DIFF
--- a/websites/B/Brawl Stars Championship/metadata.json
+++ b/websites/B/Brawl Stars Championship/metadata.json
@@ -35,6 +35,15 @@
       "title": "Privacy Mode",
       "icon": "fad fa-user-secret",
       "value": false
+    },
+    {
+      "id": "showButtons",
+      "title": "Show Buttons",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "privacy": false
+      }
     }
   ]
 }

--- a/websites/B/Brawl Stars Championship/metadata.json
+++ b/websites/B/Brawl Stars Championship/metadata.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.17",
+  "apiVersion": 1,
+  "author": {
+    "name": "gamerjagdish",
+    "id": "525148562842189825"
+  },
+  "service": "Brawl Stars Championship",
+  "altnames": [
+    "BSC",
+    "Brawl Stars Esports",
+    "Brawl Stars Event",
+    "Brawl Stars Live"
+  ],
+  "description": {
+    "en": "Official platform for Brawl Stars Championship and esports events. Watch live streams, interact, and earn in-game rewards."
+  },
+  "url": "event.supercell.com",
+  "regExp": "^https?[:][/][/]event[.]supercell[.]com[/](brawlstars)?",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/ByIrt2V.png",
+  "thumbnail": "https://i.imgur.com/Z0qBOIl.jpeg",
+  "color": "#FFC414",
+  "category": "games",
+  "tags": [
+    "brawl-stars",
+    "bsc",
+    "esports",
+    "livestream",
+    "supercell"
+  ],
+  "settings": [
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "icon": "fad fa-user-secret",
+      "value": false
+    }
+  ]
+}

--- a/websites/B/Brawl Stars Championship/presence.ts
+++ b/websites/B/Brawl Stars Championship/presence.ts
@@ -10,6 +10,12 @@ enum ActivityAssets {
   Logo = 'https://i.imgur.com/ByIrt2V.png',
 }
 
+function getText(selector: string): string | undefined {
+  const el = document.querySelector(selector)
+  const text = el?.textContent?.trim()
+  return text && text.length > 0 ? text : undefined
+}
+
 presence.on('UpdateData', async () => {
   const { pathname } = document.location
 
@@ -18,7 +24,10 @@ presence.on('UpdateData', async () => {
     return
   }
 
-  const privacy = await presence.getSetting<boolean>('privacy')
+  const [privacy, showButtons] = await Promise.all([
+    presence.getSetting<boolean>('privacy'),
+    presence.getSetting<boolean>('showButtons'),
+  ])
 
   const presenceData: PresenceData = {
     type: ActivityType.Watching,
@@ -34,17 +43,113 @@ presence.on('UpdateData', async () => {
     return
   }
 
-  if (pathname.includes('/live')) {
-    presenceData.details = 'Watching Live Stream'
-    presenceData.state = 'Brawl Stars Championship'
+  const isLiveRewards = pathname.includes('/live/rewards') || (pathname.includes('/live') && !!document.querySelector('.baseModal .pointsBar__label, .videoControls__rewardsButton--active'))
+
+  if (isLiveRewards) {
+    const points = getText('.pointsBar__label')
+    const match = getText('.eventIndicator__text')
+
+    presenceData.details = 'Viewing Live Rewards'
+    presenceData.state = points ? `Points: ${points}` : (match || 'Brawl Stars Championship')
+    presenceData.smallImageKey = Assets.Viewing
+    presenceData.smallImageText = 'Rewards'
+
+    if (showButtons) {
+      presenceData.buttons = [
+        {
+          label: 'Watch Live',
+          url: 'https://event.supercell.com/brawlstars/en/live/',
+        },
+      ]
+    }
+  }
+  else if (pathname.includes('/rewards')) {
+    const points = getText('.pointsBar__label')
+    presenceData.details = 'Viewing Rewards Track'
+    presenceData.state = points ? `Points: ${points}` : 'Brawl Stars Championship'
+    presenceData.smallImageKey = Assets.Viewing
+    presenceData.smallImageText = 'Rewards'
+
+    if (showButtons) {
+      presenceData.buttons = [
+        {
+          label: 'Event Hub',
+          url: 'https://event.supercell.com/brawlstars/en/',
+        },
+      ]
+    }
+  }
+  else if (pathname.includes('/live')) {
+    const streamer = getText('.streamerInfo__title')
+    const match = getText('.eventIndicator__text')
+
+    presenceData.details = match || streamer || 'Watching Live Stream'
     presenceData.smallImageKey = Assets.Live
     presenceData.smallImageText = 'Live'
+
+    if (match && streamer && match !== streamer) {
+      presenceData.state = streamer
+    }
+    else {
+      presenceData.state = 'Brawl Stars Championship'
+    }
+
+    if (showButtons) {
+      presenceData.buttons = [
+        {
+          label: 'Watch Live',
+          url: document.location.href,
+        },
+      ]
+    }
+  }
+  else if (pathname.includes('/schedule')) {
+    const stageHeader = getText('.leaderboardSection__header h2') || getText('h1') || getText('h2')
+    presenceData.details = 'Viewing Event Schedule'
+    presenceData.state = stageHeader || 'Brawl Stars Championship'
+    presenceData.smallImageKey = Assets.Viewing
+    presenceData.smallImageText = 'Schedule'
+
+    if (showButtons) {
+      presenceData.buttons = [
+        {
+          label: 'View Schedule',
+          url: document.location.href,
+        },
+      ]
+    }
+  }
+  else if (pathname.includes('/leaderboard')) {
+    const leaderboardRegion = getText('.select--leaderboard .select__label') || getText('.leaderboardSection__header h2')
+    presenceData.details = 'Viewing Leaderboard'
+    presenceData.state = leaderboardRegion || 'Brawl Stars Championship'
+    presenceData.smallImageKey = Assets.Viewing
+    presenceData.smallImageText = 'Leaderboard'
+
+    if (showButtons) {
+      presenceData.buttons = [
+        {
+          label: 'Leaderboards',
+          url: document.location.href,
+        },
+      ]
+    }
   }
   else {
+    const heroTitle = getText('h1') || getText('.events__title')
     presenceData.details = 'Browsing Event Hub'
-    presenceData.state = 'Brawl Stars Championship'
+    presenceData.state = heroTitle || 'Brawl Stars Championship'
     presenceData.smallImageKey = Assets.Viewing
     presenceData.smallImageText = 'Browsing'
+
+    if (showButtons) {
+      presenceData.buttons = [
+        {
+          label: 'Watch Live',
+          url: 'https://event.supercell.com/brawlstars/en/live/',
+        },
+      ]
+    }
   }
 
   presence.setActivity(presenceData)

--- a/websites/B/Brawl Stars Championship/presence.ts
+++ b/websites/B/Brawl Stars Championship/presence.ts
@@ -1,0 +1,51 @@
+import { ActivityType, Assets } from 'premid'
+
+const presence = new Presence({
+  clientId: '503557087041683458',
+})
+
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://i.imgur.com/ByIrt2V.png',
+}
+
+presence.on('UpdateData', async () => {
+  const { pathname } = document.location
+
+  if (!pathname.includes('/brawlstars')) {
+    presence.clearActivity()
+    return
+  }
+
+  const privacy = await presence.getSetting<boolean>('privacy')
+
+  const presenceData: PresenceData = {
+    type: ActivityType.Watching,
+    largeImageKey: ActivityAssets.Logo,
+    largeImageText: 'Brawl Stars Championship',
+    startTimestamp: browsingTimestamp,
+  }
+
+  if (privacy) {
+    presenceData.details = 'Browsing...'
+    presenceData.state = 'Brawl Stars Championship'
+    presence.setActivity(presenceData)
+    return
+  }
+
+  if (pathname.includes('/live')) {
+    presenceData.details = 'Watching Live Stream'
+    presenceData.state = 'Brawl Stars Championship'
+    presenceData.smallImageKey = Assets.Live
+    presenceData.smallImageText = 'Live'
+  }
+  else {
+    presenceData.details = 'Browsing Event Hub'
+    presenceData.state = 'Brawl Stars Championship'
+    presenceData.smallImageKey = Assets.Viewing
+    presenceData.smallImageText = 'Browsing'
+  }
+
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Adds Rich Presence support for Brawl Stars Championship, the official interactive live event and esports broadcast platform by Supercell (`event.supercell.com/brawlstars`).
### Features
- **Live Stream (`/live`)**:
  - Dynamically extracts active match title, teams, and tournament stage.
  - Detects stream broadcaster / language feed.
  - Live status badge indicator.
- **Live Rewards (`/live/rewards`)**:
  - Detects when viewing the in-stream rewards modal or dedicated rewards popup with live points progress.
- **Rewards Track (`/rewards`)**:
  - Displays user points and rewards track progress.
- **Schedule Page (`/schedule`)**:
  - Displays event schedule and current tournament stage header.
- **Leaderboards Page (`/leaderboard`)**:
  - Displays leaderboard rankings and selected region bracket.
- **General**:
  - Multi-language URL routing support (`/brawlstars/<lang>/...`).
  - Presence action buttons (*Watch Live*, *View Schedule*, *Leaderboards*, *Event Hub*).
  - Customizable settings (*Privacy Mode*, *Show Buttons*).
## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img width="1564" height="660" alt="chrome_uf7lR3p7KG" src="https://github.com/user-attachments/assets/6c75d91f-b5a4-401d-9621-5b695dc4181b" />

<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
