### PR TITLE
feat(AMLL TTML Tool): add supported domains

### DIFF
--- a/websites/A/AMLL TTML Tool/metadata.json
+++ b/websites/A/AMLL TTML Tool/metadata.json
@@ -16,10 +16,12 @@
     "tool.amll.dev",
     "verycool-ttml-tool-trust.vercel.app",
     "ttml.tx24.dev",
-    "tool.knightryry.xyz"
+    "tool.knightryry.xyz",
+    "tool.community.spicylyrics.org",
+    "ttmltool.community.reel.peak.reelcertified.meow.spicylyrics.org"
   ],
-  "regExp": "^https?[:][/][/](?:briangriff[.]in|amll-ttml-tool(?:-test[.]vercel[.]app|[.]stevexmh[.]net)|tool[.]amll[.]dev|verycool-ttml-tool-trust[.]vercel[.]app|ttml[.]tx24[.]dev|tool[.]knightryry[.]xyz)(?:[/]|$)",
-  "version": "1.1.0",
+  "regExp": "^https?[:][/][/](?:briangriff[.]in|amll-ttml-tool(?:-test[.]vercel[.]app|[.]stevexmh[.]net)|tool[.]amll[.]dev|verycool-ttml-tool-trust[.]vercel[.]app|ttml[.]tx24[.]dev|tool[.]knightryry[.]xyz|tool[.]community[.]spicylyrics[.]org|ttmltool[.]community[.]reel[.]peak[.]reelcertified[.]meow[.]spicylyrics[.]org)(?:[/]|$)",
+  "version": "1.1.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/A/AMLL%20TTML%20Tool/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AMLL%20TTML%20Tool/assets/thumbnail.png",
   "color": "#18a058",


### PR DESCRIPTION
## What changed

- add `tool.community.spicylyrics.org` to the AMLL TTML Tool supported URLs and activation regex
- add `ttmltool.community.reel.peak.reelcertified.meow.spicylyrics.org` to the same allowlist
- bump the activity metadata version from `1.1.0` to `1.1.1`

## Why

These AMLL TTML Tool deployments should activate the existing PreMiD activity.

## Validation

- parsed `metadata.json` successfully
- confirmed both hosts match at the root and on nested paths
- confirmed suffix lookalike domains do not match
- `pnpm exec eslint "websites/A/AMLL TTML Tool/metadata.json"`
- `git diff --check`