### PR TITLE
fix(Letterboxd): resolve undefined profile state and expand route detection

### DIFF
--- a/websites/L/Letterboxd/metadata.json
+++ b/websites/L/Letterboxd/metadata.json
@@ -21,7 +21,7 @@
   },
   "url": "letterboxd.com",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*letterboxd[.]com[/]",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/L/Letterboxd/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/L/Letterboxd/assets/thumbnail.png",
   "color": "#202830",

--- a/websites/L/Letterboxd/presence.ts
+++ b/websites/L/Letterboxd/presence.ts
@@ -45,9 +45,9 @@ function getImageURLByAlt(alt: string): string | undefined {
 
 function filterIterable<T extends Element>(
   itr: NodeListOf<T>,
-  fnc: (val: T, ind?: number) => boolean,
+  fn: (val: T, ind?: number) => boolean,
 ) {
-  return Array.from(itr).find((element, ind) => fnc(element, ind))
+  return Array.from(itr).find((element, ind) => fn(element, ind))
 }
 
 interface FilmSchema {
@@ -137,26 +137,57 @@ presence.on('UpdateData', async () => {
         break
 
       case 'actor':
-      case 'director': {
-        const name = document
-          .querySelectorAll('.title-1.prettify')[0]
-          ?.textContent
-          ?.replace(
-            path[0] === 'director' ? /Films directed by\n?/i : /Films starring\n?/i,
-            '',
-          )
-          ?.trim()
+      case 'director':
+      case 'producer':
+      case 'writer':
+      case 'editor':
+      case 'executive-producer':
+      case 'cinematography':
+      case 'story':
+      case 'camera-operator':
+      case 'composer':
+      case 'original-writer':
+      case 'set-decoration':
+      case 'songs':
+      case 'sound':
+      case 'casting':
+      case 'lighting':
+      case 'production-design':
+      case 'art-direction':
+      case 'special-effects':
+      case 'stunts':
+      case 'costume-design':
+      case 'makeup':
+      case 'hairstyling':
+      case 'additional-directing':
+      case 'additional-photopgraphy':
+      case 'visual-effects':
+      case 'title-design':
+      case 'assistant-director': {
+        const rawHeader = document.querySelectorAll('.title-1.prettify')[0]?.textContent ?? ''
+        const cleanHeader = rawHeader.replace(/\s+/g, ' ').trim()
+
         const pfp = (
           document.querySelectorAll('.avatar.person-image.image-loaded')[0]
             ?.firstElementChild as HTMLImageElement
         )?.src
 
-        presenceData.details = `Viewing ${path[0] === 'director' ? 'director' : 'actor'}: ${name}`
+        presenceData.details = cleanHeader ? `Viewing ${cleanHeader}` : 'Viewing person page'
         if (pfp)
           presenceData.largeImageKey = pfp
 
+        const roleName = path[0]
+          .split('-')
+          .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+          .join(' ')
+
         presenceData.smallImageKey = ActivityAssets.Logo
-        presenceData.buttons = generateButtonText(presenceData.details)
+        presenceData.buttons = [
+          {
+            label: `View ${roleName}`,
+            url: document.location.href,
+          },
+        ]
         break
       }
 
@@ -503,16 +534,21 @@ presence.on('UpdateData', async () => {
           }
         }
         else {
-          const name = (document.querySelectorAll('.title-1')[0] as HTMLHeadingElement)?.textContent
-          presenceData.details = `Viewing ${path[0] === user ? 'their own' : `${name ?? path[0]}'s`} profile`
-          presenceData.state = `(${path[0] === user ? `${name}/${path[0]}` : path[0]})`
+          const name = document.querySelectorAll('.title-1')[0]?.textContent?.trim()
+          const displayName = name || path[0]
+
+          presenceData.details = `Viewing ${path[0] === user ? 'their own' : `${displayName}'s`} profile`
+          presenceData.state = path[0] === user && name
+            ? `(${name}/${path[0]})`
+            : `(${path[0]})`
+
           presenceData.largeImageKey = (
             document.querySelector('#avatar-zoom')?.previousElementSibling as HTMLImageElement
           )?.src ?? ActivityAssets.Logo
           presenceData.smallImageKey = ActivityAssets.Logo
           presenceData.buttons = [
             {
-              label: `View ${name ?? path[0]}`,
+              label: `View ${displayName}`,
               url: document.location.href,
             },
           ]


### PR DESCRIPTION
## Description
- Fixed "undefined" profile display when viewing own profile
- Expanded crew & person page support (producer, writer, cinematography...)
- Different, shorter titles for buttons
- Shortened presence detail titles

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

<img width="1854" height="957" alt="Screenshot 2026-08-22 155440" src="https://github.com/user-attachments/assets/0e21d8b0-5f45-41a2-b67b-25aa146890cd" />
<img width="1874" height="959" alt="Screenshot 2026-08-22 155521" src="https://github.com/user-attachments/assets/66b4064f-7c20-48c2-86fc-f7627ecddf36" />
<img width="1860" height="961" alt="Screenshot 2026-08-22 155555" src="https://github.com/user-attachments/assets/0c8eea77-9ea1-41b3-82bc-765eeebed80f" />
<img width="458" height="198" alt="Screenshot 2026-08-22 160528" src="https://github.com/user-attachments/assets/e4caaaea-528f-4f01-93d4-029446037612" />

</details>
