### PR TITLE
feat(NotebookLM): add activity

### DIFF
--- a/websites/N/NotebookLM/metadata.json
+++ b/websites/N/NotebookLM/metadata.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.17",
+  "apiVersion": 1,
+  "author": {
+    "id": "389892856451432449",
+    "name": "ineligibility."
+  },
+  "service": "NotebookLM",
+  "description": {
+    "en": "NotebookLM is a Google AI-powered research and study assistant for working with your sources and notes."
+  },
+  "url": [
+    "notebook.google.com",
+    "notebooklm.google.com",
+    "notebooklm.google"
+  ],
+  "regExp": "^https?://(notebook\\.google\\.com|notebooklm\\.google\\.com|notebooklm\\.google)/",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/C1Nq0Zf.jpeg",
+  "thumbnail": "https://i.imgur.com/C1Nq0Zf.jpeg",
+  "color": "#F9AB00",
+  "category": "other",
+  "tags": [
+    "google",
+    "education",
+    "study",
+    "research",
+    "ai"
+  ]
+}

--- a/websites/N/NotebookLM/presence.ts
+++ b/websites/N/NotebookLM/presence.ts
@@ -1,0 +1,89 @@
+const presence = new Presence({
+  clientId: "1541863227976060999",
+})
+
+const NOTEBOOK_LM_ICON = "https://i.imgur.com/C1Nq0Zf.jpeg"
+
+let studyStartedAt: number | undefined
+let activeNotebookKey: string | undefined
+
+function cleanText(value?: string | null): string | undefined {
+  const text = value?.replace(/\s+/g, " ").trim()
+  return text || undefined
+}
+
+function getNotebookTitle(): string | undefined {
+  const selectors = [
+    '[data-testid="notebook-title"]',
+    '[data-test-id="notebook-title"]',
+    '[aria-label*="Notebook title" i]',
+    'input[aria-label*="Notebook" i]',
+    'textarea[aria-label*="Notebook" i]',
+    "h1",
+  ]
+
+  for (const selector of selectors) {
+    const element = document.querySelector<HTMLElement>(selector)
+    const title = cleanText(
+      element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement
+        ? element.value
+        : element?.textContent,
+    )
+
+    if (title && !/^(notebooklm|google notebooklm)$/i.test(title)) return title
+  }
+
+  const pageTitle = cleanText(document.title)
+  if (!pageTitle) return undefined
+
+  return cleanText(
+    pageTitle
+      .replace(/\s*[|·–—-]\s*(google\s*)?notebooklm\s*$/i, "")
+      .replace(/^(google\s*)?notebooklm\s*[|·–—-]\s*/i, ""),
+  )
+}
+
+function isNotebookOpen(): boolean {
+  const path = location.pathname
+  return /\/notebook\//i.test(path) || /\/notebooks?\//i.test(path)
+}
+
+presence.on("UpdateData", () => {
+  const presenceData: PresenceData = {
+    type: 0,
+    largeImageKey: NOTEBOOK_LM_ICON,
+    details: "Studying in NotebookLM",
+  }
+
+  if (isNotebookOpen()) {
+    const notebookKey = location.pathname
+    if (activeNotebookKey !== notebookKey) {
+      activeNotebookKey = notebookKey
+      studyStartedAt = Date.now()
+    }
+
+    const notebookTitle = getNotebookTitle()
+    presenceData.state = notebookTitle
+      ? `Notebook: ${notebookTitle}`
+      : "Notebook open"
+    presenceData.startTimestamp = studyStartedAt
+    presenceData.buttons = [
+      {
+        label: "Open NotebookLM",
+        url: location.href,
+      },
+    ]
+  } else {
+    activeNotebookKey = undefined
+    studyStartedAt = undefined
+    presenceData.state = "Browsing notebooks"
+    presenceData.buttons = [
+      {
+        label: "Open NotebookLM",
+        url: "https://notebook.google.com/",
+      },
+    ]
+  }
+
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description
Adds a PreMiD activity for NotebookLM.

## Features
- Shows when the user is studying in NotebookLM
- Shows the currently open notebook title
- Shows an elapsed study-session timer
- Includes a button to open the current notebook
- Uses a NotebookLM icon in the Discord activity

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repository's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Testing
- Tested on the NotebookLM home page
- Tested while a notebook was open
- Ran `npx pmd build "NotebookLM" --validate` successfully

## Screenshots
<details>
<summary>Activity preview</summary>

![NotebookLM Discord activity](https://i.imgur.com/C1Nq0Zf.jpeg)

</details>
<img width="1916" height="1028" alt="dt2" src="https://github.com/user-attachments/assets/dfb9eae7-0dc9-4de3-9f24-956c7ad70555" />